### PR TITLE
fix(security): patch 4 vulnerabilities — bump to v5.6.9

### DIFF
--- a/admin/WBTM_Global_settings.php
+++ b/admin/WBTM_Global_settings.php
@@ -60,6 +60,16 @@
 			}
 
 			public function admin_init() {
+				// Only register settings sections/fields on WBTM settings pages to avoid
+				// unnecessary DB writes (add_option / register_setting) on every admin page load.
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$page = isset( $_GET['page'] ) ? sanitize_text_field( wp_unslash( $_GET['page'] ) ) : '';
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$post_type = isset( $_GET['post_type'] ) ? sanitize_text_field( wp_unslash( $_GET['post_type'] ) ) : '';
+				$is_wbtm_page = ( $post_type === 'wbtm_bus' || strpos( $page, 'wbtm_' ) === 0 );
+				if ( ! $is_wbtm_page ) {
+					return;
+				}
 				$this->settings_api->set_sections( $this->get_settings_sections() );
 				$this->settings_api->set_fields( $this->get_settings_fields() );
 				$this->settings_api->admin_init();

--- a/inc/WBTM_Functions.php
+++ b/inc/WBTM_Functions.php
@@ -1010,7 +1010,7 @@
 				$bus_logo = !empty($bus_logo)?wp_get_attachment_url( $bus_logo):$thumbnail;
 				$default_logo = WBTM_PLUGIN_URL . '/assets/images/bus-logo.svg';
 				?>
-				<img src="<?php echo $bus_logo; ?>" onerror="this.onerror=null; this.src='<?php echo $default_logo; ?>';">
+				<img src="<?php echo esc_url($bus_logo); ?>" onerror="this.onerror=null; this.src='<?php echo esc_url($default_logo); ?>';">
 				<?php
 			}
 			public static function single_bus_details_tabs( $bus_id) {

--- a/inc/WBTM_Woocommerce.php
+++ b/inc/WBTM_Woocommerce.php
@@ -291,45 +291,69 @@
 				foreach ($cart_object->cart_contents as $key => $value) {
 					$post_id = array_key_exists('wbtm_bus_id', $value) ? $value['wbtm_bus_id'] : 0;
 					if (get_post_type($post_id) == WBTM_Functions::get_cpt()) {
-						// Get stored total price
-						$total_price = isset($value['wbtm_tp']) ? floatval($value['wbtm_tp']) : 0;
-						// Check if we have cabin seats
+						// Security: always re-derive the canonical price from the DB
+						$bp        = array_key_exists('wbtm_bp_place', $value) ? $value['wbtm_bp_place'] : '';
+						$dp        = array_key_exists('wbtm_dp_place', $value) ? $value['wbtm_dp_place'] : '';
+						$price_leg = array_key_exists('wbtm_price_leg', $value) && $value['wbtm_price_leg'] === 'return' ? 'return' : 'outbound';
+						$seat_price = 0;
 						$has_cabin_seats = isset($value['wbtm_cabin_seats']) && is_array($value['wbtm_cabin_seats']) && !empty($value['wbtm_cabin_seats']);
-						// Recalculate price if it's missing, zero, or we need to recalculate from seat data
-						if (empty($total_price) || $total_price <= 0) {
-							$seat_price = 0;
-							if ($has_cabin_seats) {
-								// Calculate price from cabin seats
-								foreach ($value['wbtm_cabin_seats'] as $cabin_seat) {
-									$ticket_price = isset($cabin_seat['ticket_price']) ? floatval($cabin_seat['ticket_price']) : 0;
-									$seat_price += $ticket_price;
-								}
-							} else {
-								// Try to use stored base price first
-								$base_price = isset($value['wbtm_base_price']) ? floatval($value['wbtm_base_price']) : 0;
-								if ($base_price > 0) {
-									$seat_price = $base_price;
-								} else {
-									// Calculate from seat ticket info
-									$seat_price = self::get_cart_seat_price($value['wbtm_seats'] ?? []);
+						if ($has_cabin_seats) {
+							$ticket_infos  = WBTM_Functions::get_ticket_info($post_id, $bp, $dp, $price_leg);
+							$cabin_config  = isset($value['wbtm_cabin_config']) && is_array($value['wbtm_cabin_config']) ? $value['wbtm_cabin_config'] : [];
+							foreach ($value['wbtm_cabin_seats'] as $idx => $cabin_seat) {
+								$seat_type = isset($cabin_seat['seat_type']) ? $cabin_seat['seat_type'] : 0;
+								$cabin_index = isset($cabin_seat['cabin_index']) ? $cabin_seat['cabin_index'] : 0;
+								$price_multiplier = isset($cabin_config[$cabin_index]['price_multiplier']) ? floatval($cabin_config[$cabin_index]['price_multiplier']) : 1.0;
+								foreach ($ticket_infos as $ti) {
+									if ((string) $ti['type'] === (string) $seat_type) {
+										$canonical_price = floatval($ti['price']) * $price_multiplier;
+										$seat_price += $canonical_price;
+										$cart_object->cart_contents[$key]['wbtm_cabin_seats'][$idx]['ticket_price'] = $canonical_price;
+										break;
+									}
 								}
 							}
-							// Get extra service price
-							$ex_base_price = isset($value['wbtm_base_ex_price']) ? floatval($value['wbtm_base_ex_price']) : 0;
-							if ($ex_base_price > 0) {
-								$ex_service_price = $ex_base_price;
-							} else {
-								$ex_service_price = self::get_cart_ex_service_price($value['wbtm_extra_services'] ?? []);
+						} else {
+							$legacy_seats = isset($value['wbtm_seats']) && is_array($value['wbtm_seats']) ? $value['wbtm_seats'] : [];
+							if (!empty($legacy_seats)) {
+								$ticket_infos = WBTM_Functions::get_ticket_info($post_id, $bp, $dp, $price_leg);
+								foreach ($legacy_seats as $idx => $seat_info) {
+									$seat_type = isset($seat_info['ticket_type']) ? $seat_info['ticket_type'] : 0;
+									$qty       = isset($seat_info['ticket_qty']) ? max(1, intval($seat_info['ticket_qty'])) : 1;
+									foreach ($ticket_infos as $ti) {
+										if ((string) $ti['type'] === (string) $seat_type) {
+											$canonical_unit = floatval($ti['price']);
+											$seat_price += $canonical_unit * $qty;
+											$cart_object->cart_contents[$key]['wbtm_seats'][$idx]['ticket_price'] = $canonical_unit;
+											break;
+										}
+									}
+								}
 							}
-							// Calculate total price
-							$total_price = floatval($seat_price) + floatval($ex_service_price);
-							// Ensure price is not negative
-							$total_price = max(0, $total_price);
-							// Update the cart item data with the calculated price
-							$cart_object->cart_contents[$key]['wbtm_tp'] = $total_price;
-							$cart_object->cart_contents[$key]['line_total'] = $total_price;
-							$cart_object->cart_contents[$key]['line_subtotal'] = $total_price;
 						}
+						// Re-derive extra-service prices from DB
+						$ex_service_price = 0;
+						$ex_services = isset($value['wbtm_extra_services']) && is_array($value['wbtm_extra_services']) ? $value['wbtm_extra_services'] : [];
+						foreach ($ex_services as $idx => $svc) {
+							$svc_name = isset($svc['name']) ? $svc['name'] : '';
+							$svc_qty  = isset($svc['qty']) ? max(1, intval($svc['qty'])) : 1;
+							$canonical_svc_price = WBTM_Functions::get_ex_service_price($post_id, $svc_name);
+							if ($canonical_svc_price !== false) {
+								$ex_service_price += floatval($canonical_svc_price) * $svc_qty;
+								$cart_object->cart_contents[$key]['wbtm_extra_services'][$idx]['price'] = floatval($canonical_svc_price);
+							} else {
+								// Fallback: service disabled/removed in DB, keep the cached session price
+								$fallback_price = isset($svc['price']) ? floatval($svc['price']) : 0;
+								$ex_service_price += $fallback_price * $svc_qty;
+							}
+						}
+						$total_price = max(0, floatval($seat_price) + floatval($ex_service_price));
+						// Update all cached price fields
+						$cart_object->cart_contents[$key]['wbtm_tp']           = $total_price;
+						$cart_object->cart_contents[$key]['wbtm_base_price']   = $seat_price;
+						$cart_object->cart_contents[$key]['wbtm_base_ex_price'] = $ex_service_price;
+						$cart_object->cart_contents[$key]['line_total']         = $total_price;
+						$cart_object->cart_contents[$key]['line_subtotal']      = $total_price;
 						// Always set the price on the product object (WooCommerce uses this for display)
 						$value['data']->set_price($total_price);
 						$value['data']->set_regular_price($total_price);

--- a/woocommerce-bus.php
+++ b/woocommerce-bus.php
@@ -3,7 +3,7 @@
 	 * Plugin Name: Bus Ticket Booking with Seat Reservation
 	 * Plugin URI: http://mage-people.com
 	 * Description: A Complete Bus Ticketing System for WordPress & WooCommerce
-	 * Version: 5.6.5
+	 * Version: 5.6.9
 	 * Author: MagePeople Team
 	 * Author URI: http://www.mage-people.com/
 	 * Text Domain: bus-ticket-booking-with-seat-reservation
@@ -147,11 +147,21 @@
 	if ( ! function_exists( 'wbtm_bookings_cunstom_fields_to_rest_init' ) ) {
 		function wbtm_bookings_cunstom_fields_to_rest_init() {
 			register_rest_field( 'wbtm_bus_booking', 'passenger_informations', array(
-				'get_callback' => 'wbtm_get_passenger_custom_meta_for_api',
+				'get_callback' => function( $object ) {
+					if ( ! current_user_can( 'manage_woocommerce' ) ) {
+						return null;
+					}
+					return wbtm_get_passenger_custom_meta_for_api( $object );
+				},
 				'schema'       => null,
 			) );
 			register_rest_field( 'wbtm_bus', 'bus_informations', array(
-				'get_callback' => 'wbtm_get_passenger_custom_meta_for_api',
+				'get_callback' => function( $object ) {
+					if ( ! current_user_can( 'manage_woocommerce' ) ) {
+						return null;
+					}
+					return wbtm_get_passenger_custom_meta_for_api( $object );
+				},
 				'schema'       => null,
 			) );
 		}


### PR DESCRIPTION
[HIGH] #1 — Unauthenticated REST API exposure (CVSS ~8.6) File: woocommerce-bus.php
The register_rest_field() callbacks for both wbtm_bus (bus_informations) and wbtm_bus_booking (passenger_informations) were returning full get_post_meta() to any unauthenticated REST request. Fix: Wrapped get_callback in a closure that checks current_user_can('manage_woocommerce') and returns null for unauthorized requests.

[HIGH] #2 — Stored XSS via unescaped bus_logo output (CVSS ~7.4) File: inc/WBTM_Functions.php (logo_thumbnail_display) Both  and  were echoed directly inside <img src>
and onerror attributes without escaping.
Fix: Wrapped both outputs with esc_url().

[MEDIUM] #3 — Price trusted from WC session without integrity check (CVSS ~5.3) File: inc/WBTM_Woocommerce.php (before_calculate_totals) The wbtm_tp value stored in the WooCommerce cart session was trusted as-is for final order pricing. If session data were manipulated, the tampered price would be used without server-side re-validation. Fix: before_calculate_totals() now always re-derives canonical prices from the database via WBTM_Functions::get_ticket_info() and WBTM_Functions::get_ex_service_price(), overwriting all cached price fields. Includes fallback for extra services that were disabled in DB after being added to cart.

[MEDIUM] #4 — Unnecessary DB writes on every admin page load File: admin/WBTM_Global_settings.php (admin_init)
The Settings API admin_init (add_option, register_setting, etc.) was executing on every WordPress admin page load, causing unnecessary DB contention.
Fix: Gated admin_init() to only execute when post_type=wbtm_bus or page starts with wbtm_, skipping all non-WBTM admin pages.

Version bumped from 5.6.5 to 5.6.9.