### PR TITLE
Fix by Shahnur —  Multiple fatal errors when WooCommerce is missing/deleted but plugin remains active (ghost-active state)---2026-05-04 14:30 (Asia/Dhaka)

### DIFF
--- a/admin/WBTM_Hidden_Product.php
+++ b/admin/WBTM_Hidden_Product.php
@@ -24,6 +24,12 @@
 				}
 			}
 			public function run_link_product_on_save( $post_id ) {
+				// Fixed by Shahnur — 2026-05-04 02:35 PM (Asia/Dhaka)
+				// Guard against WooCommerce being listed as active but not actually loaded
+				// (e.g. plugin folder deleted). Avoids fatal "Call to undefined function is_product()".
+				if ( ! function_exists( 'is_product' ) ) {
+					return;
+				}
 				if ( get_post_type( $post_id ) == WBTM_Functions::get_cpt() ) {
 					if ( ! isset( $_POST['wbtm_type_nonce'] ) || ! wp_verify_nonce( sanitize_text_field(wp_unslash($_POST['wbtm_type_nonce'])), 'wbtm_type_nonce' ) ) {
 						return;
@@ -75,6 +81,11 @@
 				}
 			}
 			public function hide_hidden_wc_product_from_frontend() {
+				// Fixed by Shahnur — 2026-05-04 02:35 PM (Asia/Dhaka)
+				// is_product() is a WooCommerce conditional; bail if WC isn't actually loaded.
+				if ( ! function_exists( 'is_product' ) ) {
+					return;
+				}
 				global $post, $wp_query;
 				if ( is_product() ) {
 					$post_id    = $post->ID;
@@ -130,6 +141,11 @@
 			}
 			//**************Google search url hidden*********************//
 			public function url_exclude_search_engine() {
+				// Fixed by Shahnur — 2026-05-04 02:35 PM (Asia/Dhaka)
+				// is_product() is a WooCommerce conditional; bail if WC isn't actually loaded.
+				if ( ! function_exists( 'is_product' ) ) {
+					return;
+				}
 				global $post;
 				if (is_single() && is_product()) {
 					$post_id = $post->ID;

--- a/inc/WBTM_Woo_Installer.php
+++ b/inc/WBTM_Woo_Installer.php
@@ -42,13 +42,16 @@ if ( ! class_exists( 'WBTM_Woo_Installer' ) ) {
 		}
 
 		/**
-		 * Check if WooCommerce is active.
+		 * Check if WooCommerce is truly active (listed as active AND files exist).
 		 *
 		 * @return bool
 		 */
+		// Fixed by Shahnur — 2026-05-04 03:15 PM (Asia/Dhaka)
+		// is_plugin_active can return true even if WC folder was deleted manually.
+		// Verify the file actually exists to avoid ghost-active state.
 		private function is_woo_active() {
 			include_once ABSPATH . 'wp-admin/includes/plugin.php';
-			return is_plugin_active( 'woocommerce/woocommerce.php' );
+			return is_plugin_active( 'woocommerce/woocommerce.php' ) && $this->is_woo_installed();
 		}
 
 		/**
@@ -79,13 +82,13 @@ if ( ! class_exists( 'WBTM_Woo_Installer' ) ) {
 
 		/**
 		 * Should we show the popup on this page load?
-		 * Always show when WooCommerce is not active and our plugin is active.
+		 * Show when WooCommerce is not active OR when its files are missing.
 		 *
 		 * @return bool
 		 */
 		private function should_show_popup() {
-			// Always show the popup when WooCommerce is not active
-			return ! $this->is_woo_active();
+			// Show the popup if WooCommerce is not active or files are missing (e.g. deleted manually)
+			return ! $this->is_woo_active() || ! $this->is_woo_installed();
 		}
 
 		/**

--- a/mp_global/WBTM_Global_File_Load.php
+++ b/mp_global/WBTM_Global_File_Load.php
@@ -94,7 +94,13 @@
 					let wbtm_date_format_without_year = "<?php echo esc_attr(WBTM_Global_Function::get_settings('wbtm_global_settings', 'date_format_without_year', 'D d M')); ?>";
 				</script>
 				<?php
-				if (WBTM_Global_Function::check_woocommerce() == 1) {
+				// Fixed by Shahnur — 2026-05-04 01:35 PM (Asia/Dhaka)
+				// check_woocommerce() only checks the active-plugins option, not whether WooCommerce
+				// actually loaded its functions. Verify the functions exist to avoid a fatal at admin_head.
+				if ( WBTM_Global_Function::check_woocommerce() == 1
+					&& function_exists( 'get_woocommerce_currency_symbol' )
+					&& function_exists( 'wc_get_price_decimal_separator' )
+					&& function_exists( 'wc_get_price_thousand_separator' ) ) {
 					?>
 					<script type="text/javascript">
 						wbtm_currency_symbol = "<?php echo esc_html( get_woocommerce_currency_symbol() ); ?>";

--- a/woocommerce-bus.php
+++ b/woocommerce-bus.php
@@ -45,7 +45,10 @@
 		require_once WBTM_PLUGIN_DIR . '/inc/WBTM_Woo_Installer.php';
 	}
 
-	if (is_plugin_active('woocommerce/woocommerce.php')) {
+	// Fixed by Shahnur — 2026-05-04 03:15 PM (Asia/Dhaka)
+	// Also verify WooCommerce files exist to handle ghost-active state
+	// (plugin marked active in DB but folder deleted manually).
+	if ( is_plugin_active('woocommerce/woocommerce.php') && file_exists( WP_PLUGIN_DIR . '/woocommerce/woocommerce.php' ) ) {
 
 		if (!class_exists('Wbtm_Woocommerce_bus')) {
 			class Wbtm_Woocommerce_bus {


### PR DESCRIPTION
Issue: Multiple fatal errors when WooCommerce is missing/deleted but plugin remains active (ghost-active state)

Resolution:
1. woocommerce-bus.php — Added file_exists() check alongside is_plugin_active() to detect ghost-active WooCommerce. Prevents loading WBTM_Dependencies when WC files are missing.
2. inc/WBTM_Woo_Installer.php — Fixed is_woo_active() to verify WC files exist on disk. Ensures WooCommerce installer popup shows when WC is ghost-active.
3. mp_global/WBTM_Global_File_Load.php — Added function_exists() guards around WC currency functions in js_constant(). Prevents fatal on admin_head.
4. admin/WBTM_Hidden_Product.php — Added function_exists('is_product') guards in 3 methods. Prevents fatal on wp and wp_head hooks.