### PR TITLE
Feature: Bus Staff role support and JS i18n (free plugin side)

### DIFF
--- a/admin/WBTM_Analytics_Dashboard.php
+++ b/admin/WBTM_Analytics_Dashboard.php
@@ -13,7 +13,7 @@
 					'edit.php?post_type=wbtm_bus',
 					__('Analytics Dashboard', 'bus-ticket-booking-with-seat-reservation'),
 					__('Analytics', 'bus-ticket-booking-with-seat-reservation'),
-					'manage_options',
+					'wbtm_staff_access',
 					'wbtm-analytics',
 					array($this, 'analytics_dashboard_page')
 				);

--- a/assets/admin/wbtm_admin.js
+++ b/assets/admin/wbtm_admin.js
@@ -131,7 +131,7 @@
                     },
                 });
             } else {
-                alert("Number  of row & column must be greater than 0");
+                alert(typeof wbtm_admin_var !== 'undefined' && wbtm_admin_var.seat_row_col_error ? wbtm_admin_var.seat_row_col_error : 'Number of rows & columns must be greater than 0');
             }
         }
     );
@@ -196,7 +196,7 @@
                     },
                 });
             } else {
-                alert("Number  of row & column must be greater than 0");
+                alert(typeof wbtm_admin_var !== 'undefined' && wbtm_admin_var.seat_row_col_error ? wbtm_admin_var.seat_row_col_error : 'Number of rows & columns must be greater than 0');
             }
         }
     );

--- a/assets/global/wbtm_global.js
+++ b/assets/global/wbtm_global.js
@@ -7,7 +7,7 @@
 		parent.find('.wbtm_search_action_button:visible').each(function () {
 			let button = $(this);
 			let default_html = button.data('default-html');
-			let loading_text = button.data('loading-text') || 'Searching...';
+			let loading_text = button.data('loading-text') || (typeof wbtm_strings !== 'undefined' ? wbtm_strings.searching : 'Searching...');
 
 			if (!default_html) {
 				default_html = button.html();
@@ -345,7 +345,7 @@
 	"use strict";
 	function wbtm_set_loading_button_state(button, is_loading) {
 		let default_html = button.data('default-html');
-		let loading_text = button.data('loading-text') || 'Loading...';
+		let loading_text = button.data('loading-text') || (typeof wbtm_strings !== 'undefined' ? wbtm_strings.loading : 'Loading...');
 
 		if (!default_html) {
 			default_html = button.html();
@@ -779,7 +779,7 @@
 			e.preventDefault();
 			// Fixed by Shahnur - 2026-04-23 03:00 PM (Asia/Dhaka)
 			// Do not allow return-tab browsing before the outbound bus is placed.
-			wbtm_toast($(this).data('alert') || 'Please place departure bus first.');
+			wbtm_toast($(this).data('alert') || (typeof wbtm_strings !== 'undefined' ? wbtm_strings.place_departure_first : 'Please place departure bus first.'));
 			return false;
 		}
 		wtbm_active_return_bus_tab_data();
@@ -891,7 +891,7 @@
 			}
 		});
 		if (!isValid) {
-			alert('Please fill all required fields ❗');
+			alert(typeof wbtm_strings !== 'undefined' ? wbtm_strings.fill_required_fields : 'Please fill all required fields');
 			return;
 		}
 		wbtm_set_loading_button_state(this_btn, true);
@@ -1011,7 +1011,7 @@
 					wbtm_filter_return_buses_by_outbound_time();
 				} else {
 					wbtm_set_loading_button_state(this_btn, false);
-					alert('Failed to add ticket ❌');
+					alert(typeof wbtm_strings !== 'undefined' ? wbtm_strings.failed_add_ticket : 'Failed to add ticket');
 				}
 			},
 			error: function () {

--- a/inc/WBTM_Dependencies.php
+++ b/inc/WBTM_Dependencies.php
@@ -79,7 +79,11 @@
 				wp_enqueue_script('wtbm_bus_taxonomy', WBTM_PLUGIN_URL . '/assets/admin/wtbm_bus_taxonomy.js', array('jquery'), time(), true);
 				wp_enqueue_style('wbtm_admin', WBTM_PLUGIN_URL . '/assets/admin/wbtm_admin.css', array(), time());
 				wp_enqueue_style('wtbm_bus_taxonomy', WBTM_PLUGIN_URL . '/assets/admin/wtbm_bus_taxonomy.css', array(), time());
-				wp_localize_script( 'wbtm_admin', 'wbtm_admin_var', array( 'url' => admin_url( 'admin-ajax.php' ), 'nonce' => wp_create_nonce( 'wbtm_admin_nonce' ) ) );
+				wp_localize_script( 'wbtm_admin', 'wbtm_admin_var', array(
+					'url'               => admin_url( 'admin-ajax.php' ),
+					'nonce'             => wp_create_nonce( 'wbtm_admin_nonce' ),
+					'seat_row_col_error' => esc_html__( 'Number of rows & columns must be greater than 0', 'bus-ticket-booking-with-seat-reservation' ),
+				) );
 				do_action('wbtm_add_admin_script');
 			}
 			public function appsero_init_tracker() {
@@ -99,6 +103,13 @@
 				wp_localize_script('jquery', 'wbtm_wc_vars', array(
 					'checkout_url' => wc_get_checkout_url()
 				));
+				wp_localize_script( 'wbtm_global', 'wbtm_strings', array(
+					'searching'             => esc_html__( 'Searching...', 'bus-ticket-booking-with-seat-reservation' ),
+					'loading'               => esc_html__( 'Loading...', 'bus-ticket-booking-with-seat-reservation' ),
+					'place_departure_first' => esc_html__( 'Please place departure bus first.', 'bus-ticket-booking-with-seat-reservation' ),
+					'fill_required_fields'  => esc_html__( 'Please fill all required fields', 'bus-ticket-booking-with-seat-reservation' ),
+					'failed_add_ticket'     => esc_html__( 'Failed to add ticket', 'bus-ticket-booking-with-seat-reservation' ),
+				) );
 				do_action('wbtm_add_frontend_script');
 			}
 			public function load_single_template($template) {


### PR DESCRIPTION
This commit contains the free-plugin-side changes that work together with the WBTM_Staff_Role class added in the PRO plugin. The PRO plugin creates the 'bus_staff' role and 'wbtm_staff_access' capability; this plugin exposes its admin pages to that capability and localises its JS strings.

=== 1. Analytics Dashboard staff access ===

admin/WBTM_Analytics_Dashboard.php
  Changed the add_submenu_page() capability from 'manage_options' to
  'wbtm_staff_access' so bus_staff users can view the Analytics Dashboard.
  The administrator role is automatically granted 'wbtm_staff_access' by
  the PRO plugin's WBTM_Staff_Role class, so admins see no change.

=== 2. JavaScript string localisation (JS i18n) ===

inc/WBTM_Dependencies.php
  a) Extended the existing wbtm_admin_var wp_localize_script() call to
     include 'seat_row_col_error', the alert message shown when a user
     submits a seat plan with zero rows or columns.

  b) Added a new wp_localize_script() call for the 'wbtm_global' frontend
     script, exposing a 'wbtm_strings' object containing:
       - searching:             button loading text during bus search
       - loading:               button loading text for general actions
       - place_departure_first: toast shown when return tab is clicked
                                before an outbound bus is selected
       - fill_required_fields:  alert shown when required fields are empty
       - failed_add_ticket:     alert shown when adding a ticket fails

  All strings are wrapped in esc_html__() with the plugin text domain so
  they are picked up by the .pot file and translatable via .po files.

assets/global/wbtm_global.js
  Replaced 5 hardcoded English strings with wbtm_strings.key references:
    line 10:  'Searching...'              → wbtm_strings.searching
    line 348: 'Loading...'               → wbtm_strings.loading
    line 782: 'Please place departure…'  → wbtm_strings.place_departure_first
    line 894: 'Please fill all required…'→ wbtm_strings.fill_required_fields
    line 1014:'Failed to add ticket ❌'   → wbtm_strings.failed_add_ticket

assets/admin/wbtm_admin.js
  Replaced hardcoded alert (appears on 2 lines) for the seat-plan row/column
  validation with wbtm_admin_var.seat_row_col_error reference so it is
  translatable. English fallback retained for safety.