### PR TITLE
feat(seat-plan): non-seat fixtures, drag-drop admin, and booking/count alignment

### DIFF
--- a/admin/WBTM_Settings.php
+++ b/admin/WBTM_Settings.php
@@ -631,6 +631,38 @@
 						$total_seat = $seat_type == 'wbtm_seat_plan' ? $total_seat : $current_seat;
 						update_post_meta($post_id, 'wbtm_get_total_seat', $total_seat);
 					}
+					// Per-seat ticket price overrides (modal in seat plan admin; JSON object of scope key => [ type_id => raw price ]).
+					if (array_key_exists('wbtm_seat_price_overrides', $_POST)) {
+						$raw = wp_unslash((string) $_POST['wbtm_seat_price_overrides']);
+						if ($raw !== '') {
+							$decoded = json_decode($raw, true);
+							if (JSON_ERROR_NONE === json_last_error() && is_array($decoded)) {
+								$clean = [];
+								foreach ($decoded as $scope => $rows) {
+									$scope_s = (string) $scope;
+									// Keys are generated in JS/PHP as l|Seat, u|Seat, c|index|Seat — avoid altering pipe/format.
+									if ($scope_s === '' || !is_array($rows)) {
+										continue;
+									}
+									$clean[ $scope_s ] = [];
+									foreach ($rows as $tid => $price) {
+										$t_s = sanitize_text_field((string) $tid);
+										if ($t_s === '' || $price === '' || $price === null) {
+											continue;
+										}
+										if (!is_numeric($price)) {
+											continue;
+										}
+										$clean[ $scope_s ][ $t_s ] = (string) max(0, floatval($price));
+									}
+									if (empty($clean[ $scope_s ])) {
+										unset($clean[ $scope_s ]);
+									}
+								}
+								update_post_meta($post_id, 'wbtm_seat_price_overrides', $clean);
+							}
+						}
+					}
 				}
 				//Extra service configuration
 				if (get_post_type($post_id) == WBTM_Functions::get_cpt()) {

--- a/admin/WBTM_Settings.php
+++ b/admin/WBTM_Settings.php
@@ -115,7 +115,13 @@
 				}
 			}
 			public function save_settings($post_id) {
-				if (!isset($_POST['wbtm_type_nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['wbtm_type_nonce'])), 'wbtm_type_nonce') && defined('DOING_AUTOSAVE') && DOING_AUTOSAVE && !current_user_can('edit_post', $post_id)) {
+				if ( ! isset( $_POST['wbtm_type_nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['wbtm_type_nonce'] ) ), 'wbtm_type_nonce' ) ) {
+					return;
+				}
+				if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+					return;
+				}
+				if ( ! current_user_can( 'manage_options' ) ) {
 					return;
 				}
 				//General settings
@@ -460,7 +466,7 @@
 				if (get_post_type($post_id) == WBTM_Functions::get_cpt()) {
 					$cabin_mode_enabled = isset($_POST['wbtm_cabin_mode_enabled']) && sanitize_text_field(wp_unslash($_POST['wbtm_cabin_mode_enabled'])) ? 'yes' : 'no';
 					update_post_meta($post_id, 'wbtm_cabin_mode_enabled', $cabin_mode_enabled);
-					$cabin_count = isset($_POST['wbtm_cabin_count']) ? sanitize_text_field(wp_unslash($_POST['wbtm_cabin_count'])) : 1;
+					$cabin_count = isset($_POST['wbtm_cabin_count']) ? max(1, min(20, absint(wp_unslash($_POST['wbtm_cabin_count'])))) : 1;
 					$cabin_names = isset($_POST['wbtm_cabin_name']) ? array_map('sanitize_text_field', wp_unslash($_POST['wbtm_cabin_name'])) : [];
 					$cabin_enabled = isset($_POST['wbtm_cabin_enabled']) ? array_map('sanitize_text_field', wp_unslash($_POST['wbtm_cabin_enabled'])) : [];
 					$cabin_rows = isset($_POST['wbtm_cabin_rows']) ? array_map('sanitize_text_field', wp_unslash($_POST['wbtm_cabin_rows'])) : [];
@@ -491,10 +497,12 @@
 							$cabin_seat_info = [];
 							if ($rows > 0 && $cols > 0) {
 								for ($j = 1; $j <= $cols; $j++) {
-									/*$col_infos = isset($_POST['wbtm_cabin_' . $cabin_index . '_seat' . $j]) ? sanitize_text_field(wp_unslash($_POST['wbtm_cabin_' . $cabin_index . '_seat' . $j])) : null;
-									$col_rotation_infos = isset($_POST['wbtm_cabin_' . $cabin_index . '_seat' . $j . '_rotation']) ? sanitize_text_field(wp_unslash($_POST['wbtm_cabin_' . $cabin_index . '_seat' . $j . '_rotation'])) : null;*/
-									$col_infos = isset($_POST['wbtm_cabin_' . $cabin_index . '_seat' . $j]) ?$_POST['wbtm_cabin_' . $cabin_index . '_seat' . $j] : null;
-									$col_rotation_infos = isset($_POST['wbtm_cabin_' . $cabin_index . '_seat' . $j . '_rotation']) ? $_POST['wbtm_cabin_' . $cabin_index . '_seat' . $j . '_rotation'] : null;
+									$col_infos = isset($_POST['wbtm_cabin_' . $cabin_index . '_seat' . $j])
+										? array_map('sanitize_text_field', wp_unslash((array) $_POST['wbtm_cabin_' . $cabin_index . '_seat' . $j]))
+										: null;
+									$col_rotation_infos = isset($_POST['wbtm_cabin_' . $cabin_index . '_seat' . $j . '_rotation'])
+										? array_map('sanitize_text_field', wp_unslash((array) $_POST['wbtm_cabin_' . $cabin_index . '_seat' . $j . '_rotation']))
+										: null;
 									if ($col_infos === null) {
 										$col_infos = [];
 									} elseif (is_array($col_infos)) {
@@ -545,11 +553,12 @@
 					$total_seat = 0;
 					if ($rows > 0 && $columns > 0) {
 						for ($j = 1; $j <= $columns; $j++) {
-							/*$col_infos = isset($_POST['wbtm_seat' . $j]) ? sanitize_text_field(wp_unslash($_POST['wbtm_seat' . $j])) : '';
-							$col_rotation_infos = isset($_POST['wbtm_seat' . $j . '_rotation']) ? sanitize_text_field(wp_unslash($_POST['wbtm_seat' . $j . '_rotation'])) : '';*/
-
-                            $col_infos = isset($_POST['wbtm_seat' . $j]) ? $_POST['wbtm_seat' . $j] : '';
-                            $col_rotation_infos = isset($_POST['wbtm_seat' . $j . '_rotation']) ? $_POST['wbtm_seat' . $j . '_rotation'] : '';
+							$col_infos = isset($_POST['wbtm_seat' . $j])
+								? array_map('sanitize_text_field', wp_unslash((array) $_POST['wbtm_seat' . $j]))
+								: [];
+							$col_rotation_infos = isset($_POST['wbtm_seat' . $j . '_rotation'])
+								? array_map('sanitize_text_field', wp_unslash((array) $_POST['wbtm_seat' . $j . '_rotation']))
+								: [];
 
 							if ($col_infos === null) {
 								$col_infos = [];
@@ -583,7 +592,7 @@
 					$wbtm_show_upper_desk = isset($_POST['wbtm_show_upper_desk']) && sanitize_text_field(wp_unslash($_POST['wbtm_show_upper_desk'])) ? 'yes' : 'no';
 					$rows_dd = isset($_POST['wbtm_seat_rows_dd_hidden']) ? sanitize_text_field(wp_unslash($_POST['wbtm_seat_rows_dd_hidden'])) : 0;
 					$cols_dd = isset($_POST['wbtm_seat_cols_dd_hidden']) ? sanitize_text_field(wp_unslash($_POST['wbtm_seat_cols_dd_hidden'])) : 0;
-					$wbtm_seat_dd_price_parcent = isset($_POST['wbtm_seat_dd_price_parcent']) ? sanitize_text_field(wp_unslash($_POST['wbtm_seat_dd_price_parcent'])) : '';
+					$wbtm_seat_dd_price_parcent = isset($_POST['wbtm_seat_dd_price_parcent']) ? max(0, absint(wp_unslash($_POST['wbtm_seat_dd_price_parcent']))) : 0;
 					update_post_meta($post_id, 'show_upper_desk', $wbtm_show_upper_desk);
 					update_post_meta($post_id, 'wbtm_seat_rows_dd', $rows_dd);
 					update_post_meta($post_id, 'wbtm_seat_cols_dd', $cols_dd);
@@ -591,11 +600,12 @@
 					$upper_deck_info = [];
 					if ($rows_dd > 0 && $cols_dd > 0) {
 						for ($j = 1; $j <= $cols_dd; $j++) {
-							/*$col_infos = isset($_POST['wbtm_dd_seat' . $j]) ? sanitize_text_field(wp_unslash($_POST['wbtm_dd_seat' . $j])) : null;
-							$col_rotation_infos = isset($_POST['wbtm_dd_seat' . $j . '_rotation']) ? sanitize_text_field(wp_unslash($_POST['wbtm_dd_seat' . $j . '_rotation'])) : null;*/
-
-							$col_infos = isset($_POST['wbtm_dd_seat' . $j]) ?$_POST['wbtm_dd_seat' . $j] : null;
-							$col_rotation_infos = isset($_POST['wbtm_dd_seat' . $j . '_rotation']) ? $_POST['wbtm_dd_seat' . $j . '_rotation'] : null;
+							$col_infos = isset($_POST['wbtm_dd_seat' . $j])
+								? array_map('sanitize_text_field', wp_unslash((array) $_POST['wbtm_dd_seat' . $j]))
+								: null;
+							$col_rotation_infos = isset($_POST['wbtm_dd_seat' . $j . '_rotation'])
+								? array_map('sanitize_text_field', wp_unslash((array) $_POST['wbtm_dd_seat' . $j . '_rotation']))
+								: null;
 							if ($col_infos === null) {
 								$col_infos = [];
 							} elseif (is_array($col_infos)) {
@@ -640,8 +650,8 @@
 								$clean = [];
 								foreach ($decoded as $scope => $rows) {
 									$scope_s = (string) $scope;
-									// Keys are generated in JS/PHP as l|Seat, u|Seat, c|index|Seat — avoid altering pipe/format.
-									if ($scope_s === '' || !is_array($rows)) {
+									// Keys must match l|Seat, u|Seat, or c|N|Seat — reject anything malformed.
+									if ( ! preg_match( '/^(l|u)\|[^|]+$|^c\|\d+\|[^|]+$/', $scope_s ) || ! is_array( $rows ) ) {
 										continue;
 									}
 									$clean[ $scope_s ] = [];

--- a/admin/WBTM_Settings.php
+++ b/admin/WBTM_Settings.php
@@ -517,7 +517,7 @@
 											if ($enable_rotation == 'yes') {
 												$cabin_seat_info[$i]['cabin_' . $cabin_index . '_seat' . $j . '_rotation'] = $rotation_value;
 											}
-											if ($seat_value && $seat_value != 'door' && $seat_value != 'wc') {
+											if ($seat_value && !WBTM_Seat_Configuration::is_non_seat_item($seat_value)) {
 												$total_seat++;
 											}
 										}
@@ -572,7 +572,7 @@
 								if ($wbtm_enable_seat_rotation == 'yes') {
 									$lower_deck_info[$i]['seat' . $j . '_rotation'] = $rotation_value;
 								}
-								if ($seat_value && $seat_value != 'door' && $seat_value != 'wc') {
+								if ($seat_value && !WBTM_Seat_Configuration::is_non_seat_item($seat_value)) {
 									$total_seat++;
 								}
 							}
@@ -617,7 +617,7 @@
 								if ($wbtm_enable_seat_rotation == 'yes') {
 									$upper_deck_info[$i]['dd_seat' . $j . '_rotation'] = $rotation_value;
 								}
-								if ($seat_value && $seat_value != 'door' && $seat_value != 'wc' && $wbtm_show_upper_desk == 'yes') {
+								if ($seat_value && !WBTM_Seat_Configuration::is_non_seat_item($seat_value) && $wbtm_show_upper_desk == 'yes') {
 									$total_seat++;
 								}
 							}

--- a/admin/settings/WBTM_Seat_Configuration.php
+++ b/admin/settings/WBTM_Seat_Configuration.php
@@ -110,6 +110,31 @@
                 <div class="tabsItem wbtm_settings_seat" data-tabs="#wbtm_settings_seat">
                     <h3><?php esc_html_e('Seat Configuration', 'bus-ticket-booking-with-seat-reservation'); ?></h3>
                     <p><?php esc_html_e('Configure seats for bus/train with support for multiple cabins/coaches.', 'bus-ticket-booking-with-seat-reservation'); ?></p>
+					<?php
+					// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+					$wbtm_price_overrides = WBTM_Global_Function::get_post_info($post_id, 'wbtm_seat_price_overrides', []);
+					if (!is_array($wbtm_price_overrides)) {
+						$wbtm_price_overrides = [];
+					}
+					?>
+					<?php // Textarea avoids HTML attribute size/encoding limits for JSON; value is synced only via JS. ?>
+					<textarea name="wbtm_seat_price_overrides" id="wbtm_seat_price_overrides_field" class="wbtm_seat_price_overrides_field" rows="1" cols="40" autocomplete="off" tabindex="-1" aria-hidden="true"><?php echo esc_textarea(!empty($wbtm_price_overrides) ? wp_json_encode($wbtm_price_overrides) : '{}'); ?></textarea>
+					<div id="wbtm_seat_price_modal" class="wbtm_seat_price_modal" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="wbtm_seat_price_modal_title">
+						<div class="wbtm_seat_price_modal_overlay"></div>
+						<div class="wbtm_seat_price_modal_box">
+							<div class="wbtm_seat_price_modal_header">
+								<h4 id="wbtm_seat_price_modal_title"><?php esc_html_e('Per-seat ticket prices', 'bus-ticket-booking-with-seat-reservation'); ?></h4>
+								<button type="button" class="wbtm_seat_price_modal_close" aria-label="<?php esc_attr_e('Close', 'bus-ticket-booking-with-seat-reservation'); ?>">&times;</button>
+							</div>
+							<p class="wbtm_seat_price_modal_hint"><?php esc_html_e('Leave a field empty to use the route default fare for that ticket type. Prices are in store currency (same as routing & pricing).', 'bus-ticket-booking-with-seat-reservation'); ?></p>
+							<p class="wbtm_seat_price_modal_seat_label"><strong><?php esc_html_e('Seat:', 'bus-ticket-booking-with-seat-reservation'); ?></strong> <span class="wbtm_seat_price_modal_seat_name"></span></p>
+							<div class="wbtm_seat_price_modal_body"></div>
+							<div class="wbtm_seat_price_modal_footer">
+								<button type="button" class="button button-primary wbtm_seat_price_modal_save"><?php esc_html_e('Save', 'bus-ticket-booking-with-seat-reservation'); ?></button>
+								<button type="button" class="button wbtm_seat_price_modal_cancel"><?php esc_html_e('Cancel', 'bus-ticket-booking-with-seat-reservation'); ?></button>
+							</div>
+						</div>
+					</div>
                     <div class="">
                         <div class="_dLayout_padding_dFlex_justifyBetween_alignCenter_bgLight">
                             <div class="col_6 _dFlex_fdColumn">
@@ -401,6 +426,10 @@
                                            value="<?php echo esc_attr($seat_name); ?>"
                                     />
                                 </label>
+								<button type="button" class="button button-small wbtm_seat_price_view" data-override-scope="<?php echo esc_attr($dd ? 'u' : 'l'); ?>"
+									title="<?php esc_attr_e('View or override ticket prices for this seat', 'bus-ticket-booking-with-seat-reservation'); ?>">
+									<?php esc_html_e('View', 'bus-ticket-booking-with-seat-reservation'); ?>
+								</button>
 								<?php if ($enable_rotation == 'yes') { ?>
                                     <div class="wbtm_seat_rotation_controls">
                                         <button type="button" class="wbtm_rotate_seat _whiteButton_xs"
@@ -452,7 +481,7 @@
 									<?php for ($j = 1; $j <= $cols; $j++) { ?>
 										<?php $key = 'cabin_' . $cabin_index . '_seat' . $j; ?>
                                         <th>
-                                            <div class="wbtm_seat_container">
+                                                                <div class="wbtm_seat_container">
                                                 <label>
                                                     <input type="text" class="formControl wbtm_id_validation"
                                                            name="wbtm_template_<?php echo esc_attr($key); ?>[]"
@@ -461,6 +490,10 @@
                                                            disabled
                                                     />
                                                 </label>
+												<button type="button" class="button button-small wbtm_seat_price_view wbtm_seat_price_view_disabled" disabled data-override-scope="c" data-cabin-index="<?php echo esc_attr($cabin_index); ?>"
+													title="<?php esc_attr_e('View or override ticket prices for this seat', 'bus-ticket-booking-with-seat-reservation'); ?>">
+													<?php esc_html_e('View', 'bus-ticket-booking-with-seat-reservation'); ?>
+												</button>
 												<?php if ($enable_rotation == 'yes') { ?>
                                                     <div class="wbtm_seat_rotation_controls">
                                                         <button type="button" class="wbtm_rotate_seat _whiteButton_xs"
@@ -506,6 +539,10 @@
                                            value="<?php echo esc_attr($seat_name); ?>"
                                     />
                                 </label>
+								<button type="button" class="button button-small wbtm_seat_price_view" data-override-scope="c" data-cabin-index="<?php echo esc_attr($cabin_index); ?>"
+									title="<?php esc_attr_e('View or override ticket prices for this seat', 'bus-ticket-booking-with-seat-reservation'); ?>">
+									<?php esc_html_e('View', 'bus-ticket-booking-with-seat-reservation'); ?>
+								</button>
 								<?php if ($enable_rotation == 'yes') { ?>
                                     <div class="wbtm_seat_rotation_controls">
                                         <button type="button" class="wbtm_rotate_seat _whiteButton_xs"

--- a/admin/settings/WBTM_Seat_Configuration.php
+++ b/admin/settings/WBTM_Seat_Configuration.php
@@ -8,6 +8,90 @@
 	} // Cannot access pages directly.
 	if (!class_exists('WBTM_Seat_Configuration')) {
 		class WBTM_Seat_Configuration {
+			private static $non_seat_items = [
+				'door'           => ['icon' => 'fa-door-open',       'label' => 'Door'],
+				'toilet'         => ['icon' => 'fa-restroom',        'label' => 'Toilet'],
+				'wc'             => ['icon' => 'fa-restroom',        'label' => 'Toilet'],
+				'driver'         => ['icon' => 'fa-user-tie',        'label' => 'Driver'],
+				'window'         => ['icon' => 'fa-window-maximize', 'label' => 'Window'],
+				'food_stall'     => ['icon' => 'fa-utensils',        'label' => 'Food Stall'],
+				'luggage'        => ['icon' => 'fa-suitcase',        'label' => 'Luggage'],
+				'stairs'         => ['icon' => 'fa-level-up-alt',    'label' => 'Stairs'],
+				'aisle'          => ['icon' => 'fa-arrows-alt-h',    'label' => 'Aisle'],
+				'emergency_exit' => ['icon' => 'fa-sign-out-alt',    'label' => 'Exit'],
+			];
+			public static function is_non_seat_item($value) {
+				return isset(self::$non_seat_items[strtolower(trim($value))]);
+			}
+			public static function get_non_seat_item_data($value) {
+				$key = strtolower(trim($value));
+				return self::$non_seat_items[$key] ?? null;
+			}
+			public static function get_non_seat_keywords() {
+				return array_keys(self::$non_seat_items);
+			}
+			public static function get_toolbar_items() {
+				$toolbar = [];
+				$seen = [];
+				foreach (self::$non_seat_items as $keyword => $data) {
+					if ($keyword === 'wc') {
+						continue;
+					}
+					if (in_array($data['label'], $seen, true)) {
+						continue;
+					}
+					$toolbar[$keyword] = $data;
+					$seen[] = $data['label'];
+				}
+				return $toolbar;
+			}
+			public static function count_actual_seats($post_id) {
+				$total = 0;
+				$seat_type = WBTM_Global_Function::get_post_info($post_id, 'wbtm_seat_type_conf', 'wbtm_without_seat_plan');
+				if ($seat_type !== 'wbtm_seat_plan') {
+					return (int) WBTM_Global_Function::get_post_info($post_id, 'wbtm_get_total_seat', 0);
+				}
+				$cabin_mode = WBTM_Global_Function::get_post_info($post_id, 'wbtm_cabin_mode_enabled', 'no');
+				$cabin_config = WBTM_Global_Function::get_post_info($post_id, 'wbtm_cabin_config', []);
+				$has_cabin = $cabin_mode === 'yes' && !empty($cabin_config) && count(array_filter($cabin_config, function ($c) { return ($c['enabled'] ?? 'yes') === 'yes'; })) > 0;
+				if ($has_cabin) {
+					foreach ($cabin_config as $index => $cabin) {
+						if (($cabin['enabled'] ?? 'yes') !== 'yes') continue;
+						$cabin_seats = WBTM_Global_Function::get_post_info($post_id, 'wbtm_cabin_seats_info_' . $index, []);
+						foreach ($cabin_seats as $row) {
+							foreach ($row as $key => $val) {
+								if (strpos($key, '_rotation') !== false) continue;
+								if (!empty($val) && !self::is_non_seat_item($val)) {
+									$total++;
+								}
+							}
+						}
+					}
+				} else {
+					$seat_infos = WBTM_Global_Function::get_post_info($post_id, 'wbtm_bus_seats_info', []);
+					foreach ($seat_infos as $row) {
+						foreach ($row as $key => $val) {
+							if (strpos($key, '_rotation') !== false) continue;
+							if (!empty($val) && !self::is_non_seat_item($val)) {
+								$total++;
+							}
+						}
+					}
+					$show_upper = WBTM_Global_Function::get_post_info($post_id, 'show_upper_desk');
+					if ($show_upper === 'yes') {
+						$upper_seats = WBTM_Global_Function::get_post_info($post_id, 'wbtm_bus_seats_info_dd', []);
+						foreach ($upper_seats as $row) {
+							foreach ($row as $key => $val) {
+								if (strpos($key, '_rotation') !== false) continue;
+								if (!empty($val) && !self::is_non_seat_item($val)) {
+									$total++;
+								}
+							}
+						}
+					}
+				}
+				return $total;
+			}
 			public function __construct() {
 				add_action('wbtm_add_settings_tab_content', [$this, 'tab_content']);
 				/*********************/
@@ -248,6 +332,26 @@
                 </div>
 				<?php
 			}
+			public function render_seat_item_toolbar() {
+				$items = self::get_toolbar_items();
+				?>
+				<div class="wbtm_seat_toolbar">
+					<div class="wbtm_seat_toolbar_label"><?php esc_html_e('Drag items to seat grid:', 'bus-ticket-booking-with-seat-reservation'); ?></div>
+					<div class="wbtm_seat_toolbar_items">
+						<?php foreach ($items as $keyword => $data) : ?>
+							<div class="wbtm_draggable_item" data-item-type="<?php echo esc_attr($keyword); ?>" title="<?php echo esc_attr($data['label']); ?>">
+								<span class="fas <?php echo esc_attr($data['icon']); ?>"></span>
+								<span class="wbtm_toolbar_item_label"><?php echo esc_html($data['label']); ?></span>
+							</div>
+						<?php endforeach; ?>
+						<div class="wbtm_draggable_item wbtm_draggable_eraser" data-item-type="" title="<?php esc_attr_e('Eraser - clear cell', 'bus-ticket-booking-with-seat-reservation'); ?>">
+							<span class="fas fa-eraser"></span>
+							<span class="wbtm_toolbar_item_label"><?php esc_html_e('Clear', 'bus-ticket-booking-with-seat-reservation'); ?></span>
+						</div>
+					</div>
+				</div>
+				<?php
+			}
 			public function create_seat_plan($post_id, $seat_row, $seat_column, $dd = false) {
 				if ($seat_row > 0 && $seat_column > 0) {
 					$info_key = $dd ? 'wbtm_bus_seats_info_dd' : 'wbtm_bus_seats_info';
@@ -256,6 +360,7 @@
 					$rotation_class = $enable_rotation == 'yes' ? 'wbtm_enable_rotation' : '';
 					?>
                     <div class="wbtm_settings_area <?php echo esc_attr($rotation_class); ?>">
+						<?php $this->render_seat_item_toolbar(); ?>
                         <div class="ovAuto">
                             <table>
                                 <tbody class="wbtm_item_insert wbtm_sortable_area">
@@ -324,6 +429,7 @@
 					$rotation_class = $enable_rotation == 'yes' ? 'wbtm_enable_rotation' : '';
 					?>
                     <div class="wbtm_cabin_settings_area <?php echo esc_attr($rotation_class); ?>">
+						<?php $this->render_seat_item_toolbar(); ?>
                         <div class="ovAuto">
                             <table>
                                 <tbody class="wbtm_cabin_item_insert wbtm_sortable_area">

--- a/admin/settings/WBTM_Seat_Configuration.php
+++ b/admin/settings/WBTM_Seat_Configuration.php
@@ -581,7 +581,7 @@
                         <div class="mpPanel wbtm_cabin_item" data-cabin-index="<?php echo esc_attr($index); ?>">
                             <div class="_padding_dFlex_justifyBetween_alignCenter_bgLight">
                                 <div class="_dFlex_fdColumn">
-                                    <label><?php printf('Cabin %d Configuration', esc_html($index + 1)); ?></label>
+                                    <label><?php echo esc_html(sprintf('Cabin %d Configuration', $index + 1)); ?></label>
                                     <span><?php esc_html_e('Configure seat layout for this cabin.', 'bus-ticket-booking-with-seat-reservation'); ?></span>
                                 </div>
                             </div>
@@ -621,7 +621,7 @@
                                     </div>
                                     <div class="col_6 wbtm_cabin_fields">
                                         <div class="wbtm_cabin_seat_preview" data-cabin-index="<?php echo esc_attr($index); ?>">
-                                            <label><?php printf('Cabin %d Preview', esc_html($index + 1)); ?></label>
+                                            <label><?php echo esc_html(sprintf('Cabin %d Preview', $index + 1)); ?></label>
                                             <div class="wbtm_cabin_seat_plan">
 												<?php
 													$cabin_rows = $cabin['rows'] ?? 0;
@@ -645,7 +645,7 @@
 				if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'wbtm_admin_nonce' ) ) {
 					wp_send_json_error( 'Invalid nonce!' );
 				}
-				if ( ! current_user_can( 'edit_posts' ) ) {
+				if ( ! current_user_can( 'manage_options' ) ) {
 					wp_send_json_error( 'Unauthorized' );
 				}
 				$post_id = isset( $_POST['post_id'] ) ? intval( wp_unslash( $_POST['post_id'] ) ) : 0;
@@ -661,7 +661,7 @@
 				if ( ! isset( $_POST['nonce'] ) || ! wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'wbtm_admin_nonce' ) ) {
 					wp_send_json_error( 'Invalid nonce!' );
 				}
-				if ( ! current_user_can( 'edit_posts' ) ) {
+				if ( ! current_user_can( 'manage_options' ) ) {
 					wp_send_json_error( 'Unauthorized' );
 				}
 				$post_id = isset( $_POST['post_id'] ) ? intval( wp_unslash( $_POST['post_id'] ) ) : 0;

--- a/assets/admin/wbtm_admin.css
+++ b/assets/admin/wbtm_admin.css
@@ -337,3 +337,126 @@
 		display: none;
 	}
 }
+
+/* Per-seat overrides JSON field (offscreen textarea; submitted with post) */
+textarea#wbtm_seat_price_overrides_field.wbtm_seat_price_overrides_field,
+textarea.wbtm_seat_price_overrides_field {
+	position: fixed;
+	left: -9999px;
+	top: 0;
+	width: 2px;
+	height: 2px;
+	min-height: 0;
+	padding: 0;
+	margin: 0;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border: 0;
+	resize: none;
+	opacity: 0;
+	pointer-events: none;
+	z-index: -1;
+}
+
+/* Per-seat pricing modal (seat plan admin) */
+.wbtm_seat_container .wbtm_seat_price_view {
+	display: block;
+	width: 100%;
+	margin-top: 6px;
+	font-size: 11px;
+	line-height: 1.2;
+	text-align: center;
+	position: relative;
+}
+.wbtm_seat_price_view .wbtm_seat_price_badge {
+	position: absolute;
+	top: -7px;
+	right: -5px;
+	min-width: 18px;
+	height: 18px;
+	padding: 0 5px;
+	border-radius: 9px;
+	background: #d63638;
+	color: #fff;
+	font-size: 11px;
+	font-weight: 700;
+	line-height: 18px;
+	text-align: center;
+	box-sizing: border-box;
+	pointer-events: none;
+	z-index: 2;
+}
+.wbtm_seat_price_modal {
+	position: fixed;
+	inset: 0;
+	z-index: 100050;
+}
+.wbtm_seat_price_modal .wbtm_seat_price_modal_overlay {
+	position: absolute;
+	inset: 0;
+	background: rgba(0, 0, 0, 0.45);
+}
+.wbtm_seat_price_modal_box {
+	position: relative;
+	max-width: 520px;
+	margin: 6vh auto;
+	background: #fff;
+	border-radius: 6px;
+	box-shadow: 0 8px 32px rgba(0, 0, 0, 0.2);
+	padding: 0;
+	overflow: hidden;
+}
+.wbtm_seat_price_modal_header {
+	display: flex;
+	align-items: center;
+	justify-content: space-between;
+	padding: 14px 18px;
+	background: #f6f7f9;
+	border-bottom: 1px solid #e0e0e0;
+}
+.wbtm_seat_price_modal_header h4 {
+	margin: 0;
+	font-size: 16px;
+}
+.wbtm_seat_price_modal_close {
+	background: none;
+	border: none;
+	font-size: 22px;
+	line-height: 1;
+	cursor: pointer;
+	padding: 0 6px;
+	color: #444;
+}
+.wbtm_seat_price_modal_hint,
+.wbtm_seat_price_modal_seat_label {
+	padding: 12px 18px 0;
+	margin: 0;
+	font-size: 13px;
+	line-height: 1.45;
+}
+.wbtm_seat_price_modal_body {
+	padding: 14px 18px 10px;
+	max-height: 55vh;
+	overflow-y: auto;
+}
+.wbtm_seat_price_row {
+	margin-bottom: 12px;
+}
+.wbtm_seat_price_row label.wbtm_seat_price_label {
+	display: block;
+	font-weight: 600;
+	margin-bottom: 4px;
+	font-size: 13px;
+}
+.wbtm_seat_price_row .formControl {
+	width: 100%;
+}
+.wbtm_seat_price_modal_footer {
+	padding: 14px 18px 18px;
+	display: flex;
+	gap: 10px;
+	justify-content: flex-end;
+	border-top: 1px solid #eee;
+	background: #fafafa;
+}

--- a/assets/admin/wbtm_admin.css
+++ b/assets/admin/wbtm_admin.css
@@ -208,6 +208,107 @@
 	flex-wrap: wrap;
 }
 
+/* ===== Seat Plan Drag & Drop Toolbar ===== */
+.wbtm_seat_toolbar {
+	background: #f8f9fa;
+	border: 1px solid #dee2e6;
+	border-radius: 6px;
+	padding: 10px 12px;
+	margin-bottom: 12px;
+}
+.wbtm_seat_toolbar_label {
+	font-size: 12px;
+	font-weight: 600;
+	color: #495057;
+	margin-bottom: 8px;
+	text-transform: uppercase;
+	letter-spacing: 0.04em;
+}
+.wbtm_seat_toolbar_items {
+	display: flex;
+	flex-wrap: wrap;
+	gap: 6px;
+}
+.wbtm_draggable_item {
+	display: inline-flex;
+	align-items: center;
+	gap: 5px;
+	background: #ffffff;
+	border: 1px solid #ced4da;
+	border-radius: 4px;
+	padding: 5px 10px;
+	font-size: 12px;
+	color: #495057;
+	cursor: grab;
+	transition: all 0.15s ease;
+	user-select: none;
+}
+.wbtm_draggable_item:hover {
+	background: #e9ecef;
+	border-color: #adb5bd;
+	box-shadow: 0 1px 3px rgba(0,0,0,0.1);
+}
+.wbtm_draggable_item:active {
+	cursor: grabbing;
+}
+.wbtm_draggable_item .fas {
+	font-size: 13px;
+	color: #6c757d;
+}
+.wbtm_draggable_eraser {
+	border-color: #dc3545;
+	color: #dc3545;
+}
+.wbtm_draggable_eraser .fas {
+	color: #dc3545;
+}
+.wbtm_draggable_eraser:hover {
+	background: #fff5f5;
+	border-color: #dc3545;
+}
+.wbtm_toolbar_item_label {
+	white-space: nowrap;
+}
+
+/* Drop target highlighting */
+.wbtm_seat_container.wbtm_drop_highlight {
+	outline: 2px dashed #4a6cf7;
+	outline-offset: -2px;
+	border-radius: 4px;
+}
+.wbtm_seat_container.wbtm_drop_hover {
+	background-color: #e8f0fe !important;
+	outline-color: #1a73e8;
+}
+
+/* Non-seat badge overlay on admin cells */
+.wbtm_nonseat_badge {
+	position: absolute;
+	top: 2px;
+	right: 2px;
+	width: 22px;
+	height: 22px;
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	background: #6c757d;
+	color: #fff;
+	border-radius: 50%;
+	font-size: 10px;
+	pointer-events: auto;
+	cursor: pointer;
+	z-index: 2;
+	line-height: 1;
+}
+.wbtm_nonseat_badge:hover {
+	background: #dc3545;
+}
+.wbtm_seat_container.wbtm_has_nonseat input.formControl {
+	background-color: #f1f3f5;
+	color: #868e96;
+	font-style: italic;
+}
+
 /* Responsive adjustments */
 @media only screen and (max-width: 768px) {
 	.wbtm_seat_container {
@@ -223,5 +324,16 @@
 	.wbtm_seat_plan_settings table th {
 		min-height: 60px;
 		padding: 4px 2px;
+	}
+
+	.wbtm_seat_toolbar_items {
+		gap: 4px;
+	}
+	.wbtm_draggable_item {
+		padding: 4px 6px;
+		font-size: 11px;
+	}
+	.wbtm_toolbar_item_label {
+		display: none;
 	}
 }

--- a/assets/admin/wbtm_admin.js
+++ b/assets/admin/wbtm_admin.js
@@ -126,6 +126,7 @@
                         parent.find('[name="wbtm_seat_cols_hidden"]').val(column);
                         parent.find('[name="wbtm_seat_rows_hidden"]').val(row);
                         target.html(data);
+                        $(document).trigger("wbtm_seat_plan_dom_updated");
                         //wbtm_loaderRemove(parent);
                     },
                     error: function (response) {
@@ -191,6 +192,7 @@
                         parent.find('[name="wbtm_seat_cols_dd_hidden"]').val(column);
                         parent.find('[name="wbtm_seat_rows_dd_hidden"]').val(row);
                         target.html(data);
+                        $(document).trigger("wbtm_seat_plan_dom_updated");
                         //wbtm_loaderRemove(parent);
                     },
                     error: function (response) {
@@ -450,14 +452,21 @@
 
     $(document).ready(function () {
         initDragDrop();
+        wbtmSyncSeatPriceBadges($('.wbtm_settings_seat'));
     });
 
     $(document).on('DOMNodeInserted', '.wbtm_seat_plan_preview, .wbtm_seat_plan_preview_dd, .wbtm_cabin_seat_plan', function () {
-        setTimeout(function () { initDragDrop(); }, 50);
+        setTimeout(function () {
+            initDragDrop();
+            wbtmSyncSeatPriceBadges($('.wbtm_settings_seat'));
+        }, 50);
     });
 
     $(document).on('click', '.wbtm_generate_cabin_seats', function () {
-        setTimeout(function () { initDragDrop(); }, 150);
+        setTimeout(function () {
+            initDragDrop();
+            wbtmSyncSeatPriceBadges($('.wbtm_settings_seat'));
+        }, 150);
     });
 
     $(document).on('change', '.wbtm_seat_container input.formControl', function () {
@@ -469,6 +478,9 @@
             $c.find('.wbtm_nonseat_badge').remove();
             $c.removeClass('wbtm_has_nonseat');
         }
+        if ($(this).closest('.wbtm_settings_seat').length) {
+            wbtmSyncSeatPriceBadges($(this).closest('.wbtm_settings_seat'));
+        }
     });
 
     $(document).on('dblclick', '.wbtm_nonseat_badge', function () {
@@ -476,5 +488,181 @@
         $c.find('input.formControl').val('').trigger('change');
         $(this).remove();
         $c.removeClass('wbtm_has_nonseat');
+    });
+
+    // Per-seat ticket price overrides (Seat Configuration admin).
+    function wbtmGetOverridesField() {
+        let $scoped = $('.wbtm_settings_seat #wbtm_seat_price_overrides_field');
+        if ($scoped.length) {
+            return $scoped;
+        }
+        return $('#wbtm_seat_price_overrides_field');
+    }
+    function wbtmReadOverridesState() {
+        let $f = wbtmGetOverridesField();
+        if (!$f.length) {
+            return {};
+        }
+        try {
+            let parsed = JSON.parse($f.val() || '{}');
+            if (!parsed || Array.isArray(parsed) || typeof parsed !== 'object') {
+                return {};
+            }
+            return parsed;
+        } catch (err) {
+            return {};
+        }
+    }
+    function wbtmWriteOverridesState(obj) {
+        let $f = wbtmGetOverridesField();
+        if ($f.length) {
+            $f.val(JSON.stringify(obj));
+        }
+    }
+    function wbtmBuildScopeKey(scope, cabinIndex, seatName) {
+        seatName = (seatName || '').trim();
+        if (!seatName) {
+            return '';
+        }
+        if (scope === 'c') {
+            return 'c|' + String(parseInt(cabinIndex, 10)) + '|' + seatName;
+        }
+        return scope + '|' + seatName;
+    }
+    function wbtmGetSavedPriceForType(row, typeId) {
+        if (!row || typeof row !== 'object') {
+            return '';
+        }
+        let id = String(typeId);
+        if (Object.prototype.hasOwnProperty.call(row, id)) {
+            let v = row[id];
+            if (v != null && String(v) !== '') {
+                return String(v);
+            }
+        }
+        return '';
+    }
+    function wbtmCountOverridesForKey(all, key) {
+        if (!key || !all || typeof all !== 'object' || !all[key] || typeof all[key] !== 'object') {
+            return 0;
+        }
+        let row = all[key];
+        let n = 0;
+        $.each(row, function (tid, val) {
+            if (val !== '' && val !== null && val !== undefined && !isNaN(parseFloat(val))) {
+                n++;
+            }
+        });
+        return n;
+    }
+    function wbtmSyncSeatPriceBadges($root) {
+        $root = $root && $root.length ? $root : $('.wbtm_settings_seat');
+        if (!$root || !$root.length) {
+            return;
+        }
+        let all = wbtmReadOverridesState();
+        $root.find('.wbtm_seat_price_view').each(function () {
+            let $btn = $(this);
+            if ($btn.hasClass('wbtm_seat_price_view_disabled')) {
+                $btn.find('.wbtm_seat_price_badge').remove();
+                return;
+            }
+            let $container = $btn.closest('.wbtm_seat_container');
+            let seatName = $.trim($container.find('input.formControl').first().val() || '');
+            if (!seatName) {
+                $btn.find('.wbtm_seat_price_badge').remove();
+                return;
+            }
+            let scope = $btn.attr('data-override-scope') || 'l';
+            let cabinIdx = $btn.attr('data-cabin-index');
+            let key = wbtmBuildScopeKey(scope, cabinIdx, seatName);
+            let c = wbtmCountOverridesForKey(all, key);
+            let $badge = $btn.find('.wbtm_seat_price_badge');
+            if (c > 0) {
+                if (!$badge.length) {
+                    $badge = $('<span class="wbtm_seat_price_badge" aria-hidden="true"></span>');
+                    $btn.append($badge);
+                }
+                $badge.text(String(c));
+            } else {
+                $badge.remove();
+            }
+        });
+    }
+
+    $(document).on('wbtm_seat_plan_dom_updated', function () {
+        wbtmSyncSeatPriceBadges($('.wbtm_settings_seat'));
+    });
+
+    var wbtmPriceModalKey = '';
+    $(document).on('click', '.wbtm_seat_price_view:not(:disabled)', function (e) {
+        e.preventDefault();
+        if ($(this).hasClass('wbtm_seat_price_view_disabled')) {
+            return;
+        }
+        let ticketTypes = (typeof wbtm_admin_var !== 'undefined' && wbtm_admin_var.ticket_types) ? wbtm_admin_var.ticket_types : [];
+        if (!ticketTypes.length) {
+            alert((wbtm_admin_var && wbtm_admin_var.seat_price_no_types) ? wbtm_admin_var.seat_price_no_types : '');
+            return;
+        }
+        let $btn = $(this);
+        let $container = $btn.closest('.wbtm_seat_container');
+        let seatName = $.trim($container.find('input.formControl').first().val() || '');
+        if (!seatName) {
+            alert((wbtm_admin_var && wbtm_admin_var.seat_price_need_name) ? wbtm_admin_var.seat_price_need_name : '');
+            return;
+        }
+        let scope = $btn.attr('data-override-scope') || 'l';
+        let cabinIdx = $btn.attr('data-cabin-index');
+        wbtmPriceModalKey = wbtmBuildScopeKey(scope, cabinIdx, seatName);
+        if (!wbtmPriceModalKey) {
+            return;
+        }
+        let all = wbtmReadOverridesState();
+        let row = all[wbtmPriceModalKey] || {};
+        let $modal = $('#wbtm_seat_price_modal');
+        let $body = $modal.find('.wbtm_seat_price_modal_body');
+        $body.empty();
+        $modal.find('.wbtm_seat_price_modal_seat_name').text(seatName);
+        ticketTypes.forEach(function (tt) {
+            let v = wbtmGetSavedPriceForType(row, tt.id);
+            let $r = $('<div class="wbtm_seat_price_row"/>');
+            $r.append($('<label class="wbtm_seat_price_label"/>').text(tt.label + ' (' + tt.id + ')'));
+            let $inp = $('<input type="number" class="formControl wbtm_seat_price_input" step="0.01" min="0"/>');
+            $inp.attr('data-type-id', String(tt.id));
+            if (v !== '') {
+                $inp.val(v);
+            }
+            $r.append($inp);
+            $body.append($r);
+        });
+        $modal.show();
+    });
+    $(document).on('click', '.wbtm_seat_price_modal_close, .wbtm_seat_price_modal_cancel, .wbtm_seat_price_modal_overlay', function (e) {
+        e.preventDefault();
+        $('#wbtm_seat_price_modal').hide();
+    });
+    $(document).on('click', '.wbtm_seat_price_modal_save', function (e) {
+        e.preventDefault();
+        if (!wbtmPriceModalKey) {
+            return;
+        }
+        let all = wbtmReadOverridesState();
+        let newRow = {};
+        $('#wbtm_seat_price_modal .wbtm_seat_price_input').each(function () {
+            let tid = $(this).attr('data-type-id');
+            let val = $.trim($(this).val());
+            if (val !== '' && !isNaN(parseFloat(val))) {
+                newRow[String(tid)] = String(Math.max(0, parseFloat(val)));
+            }
+        });
+        if ($.isEmptyObject(newRow)) {
+            delete all[wbtmPriceModalKey];
+        } else {
+            all[wbtmPriceModalKey] = newRow;
+        }
+        wbtmWriteOverridesState(all);
+        wbtmSyncSeatPriceBadges($('.wbtm_settings_seat'));
+        $('#wbtm_seat_price_modal').hide();
     });
 })(jQuery);

--- a/assets/admin/wbtm_admin.js
+++ b/assets/admin/wbtm_admin.js
@@ -369,3 +369,112 @@
         }
     });
 })(jQuery);
+//==========Seat Plan Drag & Drop Non-Seat Items=================//
+(function ($) {
+    "use strict";
+
+    let nonSeatItems = (typeof wbtm_admin_var !== 'undefined' && wbtm_admin_var.non_seat_items) ? wbtm_admin_var.non_seat_items : {};
+
+    function isNonSeatItem(val) {
+        return val && nonSeatItems.hasOwnProperty(val.toLowerCase().trim());
+    }
+
+    function getNonSeatIcon(val) {
+        let key = val.toLowerCase().trim();
+        return nonSeatItems[key] || '';
+    }
+
+    function applyBadge($container, itemType) {
+        $container.find('.wbtm_nonseat_badge').remove();
+        if (!itemType) {
+            $container.removeClass('wbtm_has_nonseat');
+            return;
+        }
+        let icon = getNonSeatIcon(itemType);
+        if (!icon) return;
+        let $badge = $('<span class="wbtm_nonseat_badge"><span class="fas ' + icon + '"></span></span>');
+        $container.addClass('wbtm_has_nonseat').append($badge);
+    }
+
+    function refreshAllBadges($scope) {
+        ($scope || $(document)).find('.wbtm_seat_container').each(function () {
+            let $c = $(this);
+            let val = $c.find('input.formControl').val();
+            if (val && isNonSeatItem(val)) {
+                applyBadge($c, val);
+            } else {
+                $c.find('.wbtm_nonseat_badge').remove();
+                $c.removeClass('wbtm_has_nonseat');
+            }
+        });
+    }
+
+    function initDragDrop($scope) {
+        $scope = $scope || $(document);
+
+        $scope.find('.wbtm_draggable_item').each(function () {
+            if ($(this).hasClass('ui-draggable')) return;
+            $(this).draggable({
+                helper: 'clone',
+                appendTo: 'body',
+                zIndex: 10000,
+                revert: 'invalid',
+                revertDuration: 200,
+                cursor: 'grabbing',
+                start: function () {
+                    $('.wbtm_seat_container').addClass('wbtm_drop_highlight');
+                },
+                stop: function () {
+                    $('.wbtm_seat_container').removeClass('wbtm_drop_highlight');
+                }
+            });
+        });
+
+        $scope.find('.wbtm_seat_container').each(function () {
+            if ($(this).hasClass('ui-droppable')) return;
+            $(this).droppable({
+                accept: '.wbtm_draggable_item',
+                hoverClass: 'wbtm_drop_hover',
+                tolerance: 'pointer',
+                drop: function (event, ui) {
+                    let itemType = ui.draggable.attr('data-item-type');
+                    let $input = $(this).find('input.formControl');
+                    $input.val(itemType).trigger('change');
+                    applyBadge($(this), itemType);
+                }
+            });
+        });
+
+        refreshAllBadges($scope);
+    }
+
+    $(document).ready(function () {
+        initDragDrop();
+    });
+
+    $(document).on('DOMNodeInserted', '.wbtm_seat_plan_preview, .wbtm_seat_plan_preview_dd, .wbtm_cabin_seat_plan', function () {
+        setTimeout(function () { initDragDrop(); }, 50);
+    });
+
+    $(document).on('click', '.wbtm_generate_cabin_seats', function () {
+        setTimeout(function () { initDragDrop(); }, 150);
+    });
+
+    $(document).on('change', '.wbtm_seat_container input.formControl', function () {
+        let $c = $(this).closest('.wbtm_seat_container');
+        let val = $(this).val();
+        if (val && isNonSeatItem(val)) {
+            applyBadge($c, val);
+        } else {
+            $c.find('.wbtm_nonseat_badge').remove();
+            $c.removeClass('wbtm_has_nonseat');
+        }
+    });
+
+    $(document).on('dblclick', '.wbtm_nonseat_badge', function () {
+        let $c = $(this).closest('.wbtm_seat_container');
+        $c.find('input.formControl').val('').trigger('change');
+        $(this).remove();
+        $c.removeClass('wbtm_has_nonseat');
+    });
+})(jQuery);

--- a/assets/frontend/wbtm.css
+++ b/assets/frontend/wbtm.css
@@ -2604,3 +2604,51 @@ div.wbtm_bus_list_area div.wbtm_seat_plan_upper div.seat_in_cart .seat_visual {
     width: 25%;
   }
 }
+
+/* ===== Non-Seat Items (Frontend) ===== */
+.wbtm_non_seat_item {
+  text-align: center;
+  vertical-align: middle;
+  cursor: default !important;
+  user-select: none;
+  pointer-events: none;
+  padding: 6px 4px;
+  min-width: 50px;
+}
+
+.wbtm_non_seat_item .wbtm_non_seat_icon {
+  display: block;
+  font-size: 18px;
+  color: #6c757d;
+  margin-bottom: 3px;
+  line-height: 1;
+}
+
+.wbtm_non_seat_item .wbtm_non_seat_label {
+  display: block;
+  font-size: 10px;
+  color: #868e96;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  line-height: 1.2;
+  font-weight: 600;
+  white-space: nowrap;
+}
+
+.wbtm_seat_plan_area table td.wbtm_non_seat_item,
+.wbtm_seat_plan_upper table td.wbtm_non_seat_item,
+.wbtm_cabin_seat_plan table td.wbtm_non_seat_item {
+  background-color: #f1f3f5 !important;
+  border: 1px dashed #ced4da !important;
+  border-radius: 4px;
+  opacity: 0.85;
+}
+
+@media only screen and (max-width: 768px) {
+  .wbtm_non_seat_item .wbtm_non_seat_icon {
+    font-size: 14px;
+  }
+  .wbtm_non_seat_item .wbtm_non_seat_label {
+    font-size: 8px;
+  }
+}

--- a/inc/WBTM_Dependencies.php
+++ b/inc/WBTM_Dependencies.php
@@ -86,11 +86,29 @@
 					}
 					$non_seat_icon_map['wc'] = 'fa-restroom';
 				}
+				$ticket_types_payload = [];
+				if (function_exists('get_current_screen')) {
+					$screen = get_current_screen();
+					if ($screen && $screen->post_type === 'wbtm_bus' && isset($_GET['post'])) {
+						$bus_pid = absint($_GET['post']);
+						if ($bus_pid > 0 && class_exists('WBTM_Functions')) {
+							foreach (WBTM_Functions::get_ticket_types_for_seat_price_modal($bus_pid) as $tt) {
+								$ticket_types_payload[] = [
+									'id' => (string) $tt['id'],
+									'label' => $tt['label'],
+								];
+							}
+						}
+					}
+				}
 				wp_localize_script( 'wbtm_admin', 'wbtm_admin_var', array(
 					'url'               => admin_url( 'admin-ajax.php' ),
 					'nonce'             => wp_create_nonce( 'wbtm_admin_nonce' ),
 					'seat_row_col_error' => esc_html__( 'Number of rows & columns must be greater than 0', 'bus-ticket-booking-with-seat-reservation' ),
 					'non_seat_items'    => $non_seat_icon_map,
+					'ticket_types'      => $ticket_types_payload,
+					'seat_price_need_name' => esc_html__( 'Enter a seat label first (e.g. A1).', 'bus-ticket-booking-with-seat-reservation' ),
+					'seat_price_no_types' => esc_html__( 'Add a route fare for at least one passenger type under Routing & Pricing, or save a per-seat price first.', 'bus-ticket-booking-with-seat-reservation' ),
 				) );
 				do_action('wbtm_add_admin_script');
 			}

--- a/inc/WBTM_Dependencies.php
+++ b/inc/WBTM_Dependencies.php
@@ -79,10 +79,18 @@
 				wp_enqueue_script('wtbm_bus_taxonomy', WBTM_PLUGIN_URL . '/assets/admin/wtbm_bus_taxonomy.js', array('jquery'), time(), true);
 				wp_enqueue_style('wbtm_admin', WBTM_PLUGIN_URL . '/assets/admin/wbtm_admin.css', array(), time());
 				wp_enqueue_style('wtbm_bus_taxonomy', WBTM_PLUGIN_URL . '/assets/admin/wtbm_bus_taxonomy.css', array(), time());
+				$non_seat_icon_map = [];
+				if (class_exists('WBTM_Seat_Configuration')) {
+					foreach (WBTM_Seat_Configuration::get_toolbar_items() as $kw => $d) {
+						$non_seat_icon_map[$kw] = $d['icon'];
+					}
+					$non_seat_icon_map['wc'] = 'fa-restroom';
+				}
 				wp_localize_script( 'wbtm_admin', 'wbtm_admin_var', array(
 					'url'               => admin_url( 'admin-ajax.php' ),
 					'nonce'             => wp_create_nonce( 'wbtm_admin_nonce' ),
 					'seat_row_col_error' => esc_html__( 'Number of rows & columns must be greater than 0', 'bus-ticket-booking-with-seat-reservation' ),
+					'non_seat_items'    => $non_seat_icon_map,
 				) );
 				do_action('wbtm_add_admin_script');
 			}

--- a/inc/WBTM_Functions.php
+++ b/inc/WBTM_Functions.php
@@ -648,8 +648,12 @@
 									if ( $bp_date && strtolower( (string) $end_route ) === strtolower( (string) $info['place'] ) && ( $info['type'] == 'dp' || $info['type'] == 'both' ) ) {
 										$slice_time = self::slice_buffer_time( $bp_date );
 										if ( strtotime( $now_full ) < strtotime( $slice_time ) ) {
-											$total_seat = WBTM_Global_Function::get_post_info( $post_id, 'wbtm_get_total_seat', 0 );
 											$seat_type  = WBTM_Global_Function::get_post_info( $post_id, 'wbtm_seat_type_conf' );
+											if ( $seat_type == 'wbtm_seat_plan' && class_exists( 'WBTM_Seat_Configuration' ) ) {
+												$total_seat = WBTM_Seat_Configuration::count_actual_seats( $post_id );
+											} else {
+												$total_seat = (int) WBTM_Global_Function::get_post_info( $post_id, 'wbtm_get_total_seat', 0 );
+											}
 											if ( $seat_type == 'wbtm_seat_plan' ) {
 												$sold_seat = max(
 													sizeof( array_unique( WBTM_Query::query_seat_booked( $post_id, $start_route, $end_route, $route_info[0]['time'] ) ) ),

--- a/inc/WBTM_Functions.php
+++ b/inc/WBTM_Functions.php
@@ -402,6 +402,60 @@
 				return '';
 			}
 
+			/**
+			 * Passenger types for the per-seat pricing modal: any type with at least one route fare in
+			 * wbtm_bus_prices, or a non-empty saved per-seat override (so existing overrides stay editable).
+			 *
+			 * @param int $post_id Bus post ID.
+			 * @return array<int, array{id: string, label: string}>
+			 */
+			public static function get_ticket_types_for_seat_price_modal( $post_id ) {
+				$post_id = absint( $post_id );
+				if ( ! $post_id ) {
+					return [];
+				}
+				$all_types = self::get_ticket_types( $post_id );
+				if ( empty( $all_types ) ) {
+					return [];
+				}
+				$has_route = [];
+				$price_infos = WBTM_Global_Function::get_post_info( $post_id, 'wbtm_bus_prices', [] );
+				if ( is_array( $price_infos ) && sizeof( $price_infos ) > 0 ) {
+					foreach ( $all_types as $tt ) {
+						$tid = (string) $tt['id'];
+						foreach ( $price_infos as $row ) {
+							$p = self::get_ticket_price_by_type( $row, $tid );
+							if ( $p !== '' ) {
+								$has_route[ $tid ] = true;
+								break;
+							}
+						}
+					}
+				}
+				$has_override = [];
+				$overrides    = WBTM_Global_Function::get_post_info( $post_id, 'wbtm_seat_price_overrides', [] );
+				if ( is_array( $overrides ) && sizeof( $overrides ) > 0 ) {
+					foreach ( $overrides as $row ) {
+						if ( ! is_array( $row ) ) {
+							continue;
+						}
+						foreach ( $row as $tid => $val ) {
+							if ( $val !== '' && $val !== null ) {
+								$has_override[ (string) $tid ] = true;
+							}
+						}
+					}
+				}
+				$out = [];
+				foreach ( $all_types as $tt ) {
+					$tid = (string) $tt['id'];
+					if ( ! empty( $has_route[ $tid ] ) || ! empty( $has_override[ $tid ] ) ) {
+						$out[] = $tt;
+					}
+				}
+				return $out;
+			}
+
 			public static function get_legacy_price_fields( $ticket_prices = [] ) {
 				return [
 					'wbtm_bus_price'        => array_key_exists( 'adult', $ticket_prices ) ? $ticket_prices['adult'] : '',
@@ -853,7 +907,47 @@
 				return $date;
 			}
 			//==========================//
-			public static function get_seat_price( $post_id, $start_route, $end_route, $seat_type = 0, $dd = false, $price_leg = 'outbound' ) {
+			/**
+			 * Storage key for per-seat ticket price overrides (post meta wbtm_seat_price_overrides).
+			 * Lower deck: l|{seatLabel}, upper: u|{seatLabel}, cabin: c|{index}|{seatLabel}.
+			 *
+			 * @param string       $seat_name     Seat label (e.g. A1).
+			 * @param bool         $is_upper_deck Upper deck leg uses u| prefix when $cabin_index is null.
+			 * @param int|null     $cabin_index   Null for lower/upper; integer cabin index for cabin coaches.
+			 */
+			public static function seat_price_override_storage_key( $seat_name, $is_upper_deck, $cabin_index ) {
+				$seat_name = trim( (string) $seat_name );
+				if ( $seat_name === '' ) {
+					return '';
+				}
+				if ( null !== $cabin_index && $cabin_index !== '' ) {
+					return 'c|' . (int) $cabin_index . '|' . $seat_name;
+				}
+				return ( $is_upper_deck ? 'u' : 'l' ) . '|' . $seat_name;
+			}
+
+			/**
+			 * @param string $storage_key From seat_price_override_storage_key().
+			 * @param string $ticket_type_id Ticket type id (slug) as used in wbtm_ticket_types.
+			 * @return float|null Override amount in store raw price units, or null to use route fare.
+			 */
+			public static function get_seat_price_override_raw( $post_id, $storage_key, $ticket_type_id ) {
+				if ( ! $post_id || $storage_key === '' ) {
+					return null;
+				}
+				$map = WBTM_Global_Function::get_post_info( $post_id, 'wbtm_seat_price_overrides', [] );
+				if ( ! is_array( $map ) || ! isset( $map[ $storage_key ] ) || ! is_array( $map[ $storage_key ] ) ) {
+					return null;
+				}
+				$row  = $map[ $storage_key ];
+				$tkey = (string) $ticket_type_id;
+				if ( ! isset( $row[ $tkey ] ) || $row[ $tkey ] === '' || $row[ $tkey ] === null ) {
+					return null;
+				}
+				return max( 0, (float) $row[ $tkey ] );
+			}
+
+			public static function get_seat_price( $post_id, $start_route, $end_route, $seat_type = 0, $dd = false, $price_leg = 'outbound', $seat_name = '', $cabin_index = null ) {
 				if ( $post_id && $start_route && $end_route ) {
 					$ticket_infos = self::get_ticket_info( $post_id, $start_route, $end_route, $price_leg );
 					if ( sizeof( $ticket_infos ) > 0 ) {
@@ -864,6 +958,11 @@
 						foreach ( $ticket_infos as $ticket_info ) {
 							if ( (string) $ticket_info['type'] === $requested_seat_type ) {
 								$price          = $ticket_info['price'];
+								$key            = self::seat_price_override_storage_key( $seat_name, (bool) $dd, $cabin_index );
+								$override_price = self::get_seat_price_override_raw( $post_id, $key, $requested_seat_type );
+								if ( null !== $override_price ) {
+									$price = $override_price;
+								}
 								$seat_plan_type = WBTM_Global_Function::get_post_info( $post_id, 'wbtm_seat_type_conf' );
 								if ( $seat_plan_type == 'wbtm_seat_plan' && $dd ) {
 									$seat_dd_increase = (int) WBTM_Global_Function::get_post_info( $post_id, 'wbtm_seat_dd_price_parcent', 0 );

--- a/inc/WBTM_Query.php
+++ b/inc/WBTM_Query.php
@@ -280,7 +280,10 @@
 						$guest_ids= get_posts($args);
 						if(sizeof($guest_ids)>0){
 							foreach ($guest_ids as $guest_id){
-								$seat_booked[]=WBTM_Global_Function::get_post_info($guest_id,'wbtm_seat');
+								$seat_name = WBTM_Global_Function::get_post_info($guest_id,'wbtm_seat');
+								if ($seat_name && !(class_exists('WBTM_Seat_Configuration') && WBTM_Seat_Configuration::is_non_seat_item($seat_name))) {
+									$seat_booked[] = $seat_name;
+								}
 							}
 						}
 					}

--- a/inc/WBTM_Woocommerce.php
+++ b/inc/WBTM_Woocommerce.php
@@ -103,7 +103,11 @@
 										WC()->cart->remove_cart_item($key);
 //									wc_add_notice(sprintf(__("Seat %s in %s has already been booked by another user. Please choose another seat.", 'bus-ticket-booking-with-seat-reservation'), $seat_name, $seat_info['cabin_name']), 'error');
 										wc_add_notice(
-											sprintf('Seat %1$s in %2$s has already been booked by another user. Please choose another seat.',$seat_name,$seat_info['cabin_name']),
+											sprintf(
+												esc_html__( 'Seat %1$s in %2$s has already been booked by another user. Please choose another seat.', 'bus-ticket-booking-with-seat-reservation' ),
+												esc_html( $seat_name ),
+												esc_html( $seat_info['cabin_name'] )
+											),
 											'error'
 										);
 									}
@@ -114,7 +118,13 @@
 									$seat_name = array_key_exists('seat_name', $seat_info) ? $seat_info['seat_name'] : '';
 									if (WBTM_Query::query_total_booked($post_id, $start_route, $end_route, $date, '', $seat_name) > 0) {
 										WC()->cart->remove_cart_item($key);
-										wc_add_notice(sprintf("Seat %s has already been booked by another user. Please choose another seat.", $seat_name), 'error');
+										wc_add_notice(
+											sprintf(
+												esc_html__( 'Seat %s has already been booked by another user. Please choose another seat.', 'bus-ticket-booking-with-seat-reservation' ),
+												esc_html( $seat_name )
+											),
+											'error'
+										);
 									}
 								}
 							}
@@ -385,9 +395,8 @@
 								$ex_service_price += floatval($canonical_svc_price) * $svc_qty;
 								$cart_object->cart_contents[$key]['wbtm_extra_services'][$idx]['price'] = floatval($canonical_svc_price);
 							} else {
-								// Fallback: service disabled/removed in DB, keep the cached session price
-								$fallback_price = isset($svc['price']) ? floatval($svc['price']) : 0;
-								$ex_service_price += $fallback_price * $svc_qty;
+								// Service removed from DB — zero out rather than trust stale session data.
+								$cart_object->cart_contents[$key]['wbtm_extra_services'][$idx]['price'] = 0;
 							}
 						}
 						$total_price = max(0, floatval($seat_price) + floatval($ex_service_price));
@@ -464,7 +473,7 @@
 										$seat_name = array_key_exists('seat_name', $seat_info) ? $seat_info['seat_name'] : '';
 										if ($seat_name && WBTM_Query::query_total_booked($post_id, $start_route, $end_route, $date, '', $seat_name) > 0) {
 											WC()->cart->empty_cart();
-											wc_add_notice(__("Sorry, Your Selected seat Already Booked by another user", 'bus-ticket-booking-with-seat-reservation'), 'error');
+											wc_add_notice(esc_html__("Sorry, Your Selected seat Already Booked by another user", 'bus-ticket-booking-with-seat-reservation'), 'error');
 										}
 									}
 								}
@@ -1075,9 +1084,9 @@
 									$type = $passenger_type[$i] ?? '';
 									$ticket_name = WBTM_Functions::get_ticket_name($type, $post_id);
 									$seat_price = WBTM_Functions::get_seat_price($post_id, $start_place, $end_place, $type, false, $price_leg);
-									// Fall back to the price submitted from the form when route name mismatch causes get_seat_price to return false
+									// Reject ticket if the route price cannot be determined — never trust user-submitted price.
 									if ($seat_price === false || $seat_price < 0) {
-										$seat_price = isset($submitted_prices[$i]) ? floatval($submitted_prices[$i]) : 0;
+										continue;
 									}
 									$ticket_info[$i]['ticket_name'] = $ticket_name;
 									$ticket_info[$i]['seat_name'] = $ticket_name;

--- a/inc/WBTM_Woocommerce.php
+++ b/inc/WBTM_Woocommerce.php
@@ -239,6 +239,9 @@
             public static function get_cart_cabin_seat_price($post_id, $ticket_infos, $cabin_config) {
 				$total_price = 0;
 				if (isset($_POST['wbtm_form_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['wbtm_form_nonce'])), 'wbtm_form_nonce')) {
+					$bp = isset($_POST['wbtm_bp_place']) ? sanitize_text_field(wp_unslash($_POST['wbtm_bp_place'])) : '';
+					$dp = isset($_POST['wbtm_dp_place']) ? sanitize_text_field(wp_unslash($_POST['wbtm_dp_place'])) : '';
+					$price_leg = WBTM_Functions::get_requested_price_leg();
 					foreach ($cabin_config as $cabin_index => $cabin) {
 						if (($cabin['enabled'] ?? 'yes') !== 'yes')
 							continue;
@@ -251,18 +254,12 @@
 							$seat_types = $seat_types ? explode(',', $seat_types) : [];
 							foreach ($seat_names as $seat_index => $seat_name) {
 								$seat_type = isset($seat_types[$seat_index]) ? $seat_types[$seat_index] : 0;
-								// Find the corresponding ticket info
-								foreach ($ticket_infos as $ticket_info) {
-                                    /*if ($ticket_info['type'] == $
-                                    seat_type) {
-                                        $base_price = WBTM_Global_Function::get_wc_raw_price($post_id, $ticket_info['price']);*/
-									if ($ticket_info['seat_type'] == $seat_type) {
-										$base_price = WBTM_Global_Function::get_wc_raw_price($post_id, $ticket_info['ticket_price']);
-										$price_multiplier = $cabin['price_multiplier'] ?? 1.0;
-										$total_price += $base_price * $price_multiplier;
-										break;
-									}
+								$base = WBTM_Functions::get_seat_price($post_id, $bp, $dp, $seat_type, false, $price_leg, $seat_name, $cabin_index);
+								if ($base === false || $base < 0) {
+									$base = 0;
 								}
+								$price_multiplier = $cabin['price_multiplier'] ?? 1.0;
+								$total_price += floatval($base) * floatval($price_multiplier);
 							}
 						}
 					}
@@ -275,7 +272,7 @@
 					// Get ticket information for price calculation
 					$bp = isset($_POST['wbtm_bp_place']) ? sanitize_text_field(wp_unslash($_POST['wbtm_bp_place'])) : '';
 					$dp = isset($_POST['wbtm_dp_place']) ? sanitize_text_field(wp_unslash($_POST['wbtm_dp_place'])) : '';
-					$ticket_infos = WBTM_Functions::get_ticket_info($post_id, $bp, $dp, WBTM_Functions::get_requested_price_leg());
+					$price_leg_cart = WBTM_Functions::get_requested_price_leg();
 					foreach ($cabin_config as $cabin_index => $cabin) {
 						if (($cabin['enabled'] ?? 'yes') !== 'yes')
 							continue;
@@ -288,16 +285,12 @@
 							$seat_types = $selected_seat_types ? explode(',', $selected_seat_types) : [];
 							foreach ($seat_names as $seat_index => $seat_name) {
 								$seat_type = isset($seat_types[$seat_index]) ? $seat_types[$seat_index] : 0;
-								// Find the ticket price for this seat type
-								$ticket_price = 0;
-								foreach ($ticket_infos as $ticket_info) {
-									if ($ticket_info['type'] == $seat_type) {
-										$base_price = WBTM_Global_Function::get_wc_raw_price($post_id, $ticket_info['price']);
-										$price_multiplier = $cabin['price_multiplier'] ?? 1.0;
-										$ticket_price = $base_price * $price_multiplier;
-										break;
-									}
+								$base_price = WBTM_Functions::get_seat_price($post_id, $bp, $dp, $seat_type, false, $price_leg_cart, $seat_name, $cabin_index);
+								if ($base_price === false || $base_price < 0) {
+									$base_price = 0;
 								}
+								$price_multiplier = $cabin['price_multiplier'] ?? 1.0;
+								$ticket_price = floatval($base_price) * floatval($price_multiplier);
 								$cabin_seats[] = [
 									'cabin_index' => $cabin_index,
 									'cabin_name' => $cabin['name'] ?? 'Cabin ' . ($cabin_index + 1),
@@ -349,36 +342,35 @@
 						if (isset($value['wbtm_booking_mode']) && $value['wbtm_booking_mode'] === 'full_bus') {
 							// Full-bus price is already re-derived from the route price row above.
 						} elseif ($has_cabin_seats) {
-							$ticket_infos  = WBTM_Functions::get_ticket_info($post_id, $bp, $dp, $price_leg);
 							$cabin_config  = isset($value['wbtm_cabin_config']) && is_array($value['wbtm_cabin_config']) ? $value['wbtm_cabin_config'] : [];
 							foreach ($value['wbtm_cabin_seats'] as $idx => $cabin_seat) {
 								$seat_type = isset($cabin_seat['seat_type']) ? $cabin_seat['seat_type'] : 0;
 								$cabin_index = isset($cabin_seat['cabin_index']) ? $cabin_seat['cabin_index'] : 0;
+								$seat_label = isset($cabin_seat['seat_name']) ? $cabin_seat['seat_name'] : '';
 								$price_multiplier = isset($cabin_config[$cabin_index]['price_multiplier']) ? floatval($cabin_config[$cabin_index]['price_multiplier']) : 1.0;
-								foreach ($ticket_infos as $ti) {
-									if ((string) $ti['type'] === (string) $seat_type) {
-										$canonical_price = floatval($ti['price']) * $price_multiplier;
-										$seat_price += $canonical_price;
-										$cart_object->cart_contents[$key]['wbtm_cabin_seats'][$idx]['ticket_price'] = $canonical_price;
-										break;
-									}
+								$unit = WBTM_Functions::get_seat_price($post_id, $bp, $dp, $seat_type, false, $price_leg, $seat_label, $cabin_index);
+								if ($unit === false || $unit < 0) {
+									$unit = 0;
 								}
+								$canonical_price = floatval($unit) * floatval($price_multiplier);
+								$seat_price += $canonical_price;
+								$cart_object->cart_contents[$key]['wbtm_cabin_seats'][$idx]['ticket_price'] = $canonical_price;
 							}
 						} else {
 							$legacy_seats = isset($value['wbtm_seats']) && is_array($value['wbtm_seats']) ? $value['wbtm_seats'] : [];
 							if (!empty($legacy_seats)) {
-								$ticket_infos = WBTM_Functions::get_ticket_info($post_id, $bp, $dp, $price_leg);
 								foreach ($legacy_seats as $idx => $seat_info) {
 									$seat_type = isset($seat_info['ticket_type']) ? $seat_info['ticket_type'] : 0;
-									$qty       = isset($seat_info['ticket_qty']) ? max(1, intval($seat_info['ticket_qty'])) : 1;
-									foreach ($ticket_infos as $ti) {
-										if ((string) $ti['type'] === (string) $seat_type) {
-											$canonical_unit = floatval($ti['price']);
-											$seat_price += $canonical_unit * $qty;
-											$cart_object->cart_contents[$key]['wbtm_seats'][$idx]['ticket_price'] = $canonical_unit;
-											break;
-										}
+									$seat_label = isset($seat_info['seat_name']) ? $seat_info['seat_name'] : '';
+									$is_dd = !empty($seat_info['dd']);
+									$qty = isset($seat_info['ticket_qty']) ? max(1, intval($seat_info['ticket_qty'])) : 1;
+									$canonical_unit = WBTM_Functions::get_seat_price($post_id, $bp, $dp, $seat_type, $is_dd, $price_leg, $seat_label, null);
+									if ($canonical_unit === false || $canonical_unit < 0) {
+										$canonical_unit = 0;
 									}
+									$canonical_unit = floatval($canonical_unit);
+									$seat_price += $canonical_unit * $qty;
+									$cart_object->cart_contents[$key]['wbtm_seats'][$idx]['ticket_price'] = $canonical_unit;
 								}
 							}
 						}
@@ -1030,7 +1022,7 @@
 							foreach ($selected_seat as $key => $seat_name) {
 								$type = isset($selected_ticket_type[$key]) ? $selected_ticket_type[$key] : $default_ticket_type;
 								if ($seat_name) {
-									$seat_price = WBTM_Functions::get_seat_price($post_id, $start_place, $end_place, $type, false, $price_leg);
+									$seat_price = WBTM_Functions::get_seat_price($post_id, $start_place, $end_place, $type, false, $price_leg, $seat_name, null);
 									// Handle false return value from get_seat_price
 									if ($seat_price === false || $seat_price < 0) {
 										$seat_price = 0;
@@ -1054,7 +1046,7 @@
 							foreach ($selected_seat_dd as $key => $seat_name) {
 								$type = isset($selected_ticket_type_dd[$key]) ? $selected_ticket_type_dd[$key] : $default_ticket_type;
 								if ($seat_name) {
-									$seat_price = WBTM_Functions::get_seat_price($post_id, $start_place, $end_place, $type, true, $price_leg);
+									$seat_price = WBTM_Functions::get_seat_price($post_id, $start_place, $end_place, $type, true, $price_leg, $seat_name, null);
 									// Handle false return value from get_seat_price
 									if ($seat_price === false || $seat_price < 0) {
 										$seat_price = 0;

--- a/inc/WBTM_Woocommerce.php
+++ b/inc/WBTM_Woocommerce.php
@@ -456,7 +456,7 @@
 						if (get_post_type($post_id) == WBTM_Functions::get_cpt()) {
 							$seat_type = WBTM_Global_Function::get_post_info($post_id, 'wbtm_seat_type_conf');
 							if (isset($cart_item['wbtm_booking_mode']) && $cart_item['wbtm_booking_mode'] === 'full_bus') {
-								$total_seat = (int) WBTM_Global_Function::get_post_info($post_id, 'wbtm_get_total_seat', 0);
+								$total_seat = class_exists('WBTM_Seat_Configuration') ? WBTM_Seat_Configuration::count_actual_seats($post_id) : (int) WBTM_Global_Function::get_post_info($post_id, 'wbtm_get_total_seat', 0);
 								$sold_seat = WBTM_Query::query_total_booked($post_id, $start_route, $end_route, $date);
 							$full_bus_seat_count = isset($cart_item['wbtm_full_bus_seat_count']) ? (int) $cart_item['wbtm_full_bus_seat_count'] : 0;
 							if ($sold_seat > 0 || $full_bus_seat_count < $total_seat) {
@@ -493,7 +493,7 @@
 								}
 								do_action('wbtm_something');
 							} else {
-								$total_seat = WBTM_Global_Function::get_post_info($post_id, 'wbtm_get_total_seat', 0);
+								$total_seat = class_exists('WBTM_Seat_Configuration') ? WBTM_Seat_Configuration::count_actual_seats($post_id) : (int) WBTM_Global_Function::get_post_info($post_id, 'wbtm_get_total_seat', 0);
 								$sold_seat = WBTM_Query::query_total_booked($post_id, $start_route, $end_route, $date);
 								$available_seat = max(0, $total_seat - $sold_seat);
 								if ($available_seat < $seats_qty) {

--- a/mp_global/WBTM_Global_File_Load.php
+++ b/mp_global/WBTM_Global_File_Load.php
@@ -54,6 +54,8 @@
 				wp_enqueue_media();
 				//admin script
 				wp_enqueue_script('jquery-ui-sortable');
+				wp_enqueue_script('jquery-ui-draggable');
+				wp_enqueue_script('jquery-ui-droppable');
 				wp_enqueue_style('wp-color-picker');
 				wp_enqueue_script('wp-color-picker');
 				wp_enqueue_style('wp-codemirror');

--- a/templates/layout/seat_plan.php
+++ b/templates/layout/seat_plan.php
@@ -57,6 +57,36 @@
         }
     }
 
+    if (!function_exists('wbtm_is_non_seat_item_check')) {
+        function wbtm_is_non_seat_item_check($value) {
+            if (class_exists('WBTM_Seat_Configuration')) {
+                return WBTM_Seat_Configuration::is_non_seat_item($value);
+            }
+            $non_seat_keys = ['door','toilet','wc','driver','window','food_stall','luggage','stairs','aisle','emergency_exit'];
+            return in_array(strtolower(trim($value)), $non_seat_keys, true);
+        }
+    }
+    if (!function_exists('wbtm_get_non_seat_data_check')) {
+        function wbtm_get_non_seat_data_check($value) {
+            if (class_exists('WBTM_Seat_Configuration')) {
+                return WBTM_Seat_Configuration::get_non_seat_item_data($value);
+            }
+            $items = [
+                'door' => ['icon' => 'fa-door-open', 'label' => 'Door'],
+                'toilet' => ['icon' => 'fa-restroom', 'label' => 'Toilet'],
+                'wc' => ['icon' => 'fa-restroom', 'label' => 'Toilet'],
+                'driver' => ['icon' => 'fa-user-tie', 'label' => 'Driver'],
+                'window' => ['icon' => 'fa-window-maximize', 'label' => 'Window'],
+                'food_stall' => ['icon' => 'fa-utensils', 'label' => 'Food Stall'],
+                'luggage' => ['icon' => 'fa-suitcase', 'label' => 'Luggage'],
+                'stairs' => ['icon' => 'fa-level-up-alt', 'label' => 'Stairs'],
+                'aisle' => ['icon' => 'fa-arrows-alt-h', 'label' => 'Aisle'],
+                'emergency_exit' => ['icon' => 'fa-sign-out-alt', 'label' => 'Exit'],
+            ];
+            return $items[strtolower(trim($value))] ?? null;
+        }
+    }
+
     if ($has_cabin_seat_plan || (sizeof($seat_infos) > 0 && $seat_row > 0 && $seat_column > 0)) {
     //		$date = $_POST['date'] ?? '';
         // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
@@ -79,8 +109,11 @@
         // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
             foreach ($seat_infos as $seats) {
                 // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
-                foreach ($seats as $seat) {
-                    if (!empty($seat)) {
+                foreach ($seats as $seat_key_tmp => $seat) {
+                    if (strpos($seat_key_tmp, '_rotation') !== false) {
+                        continue;
+                    }
+                    if (!empty($seat) && !wbtm_is_non_seat_item_check($seat)) {
                         $seat_count++;
                     }
                 }
@@ -169,8 +202,14 @@
                                                         }
                                                         ?>
                                                         <?php if ($seat_name): ?>
-                                                            <?php if ($seat_name == 'door' || $seat_name == 'wc'): ?>
-                                                                <td><?php echo esc_html($seat_name); ?></td>
+                                                            <?php if (wbtm_is_non_seat_item_check($seat_name)):
+                                                                // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+                                                                $ns_data = wbtm_get_non_seat_data_check($seat_name);
+                                                            ?>
+                                                                <td class="wbtm_non_seat_item" title="<?php echo esc_attr($ns_data['label']); ?>">
+                                                                    <span class="wbtm_non_seat_icon fas <?php echo esc_attr($ns_data['icon']); ?>"></span>
+                                                                    <span class="wbtm_non_seat_label"><?php echo esc_html($ns_data['label']); ?></span>
+                                                                </td>
                                                             <?php else: ?>
                                                                 <?php
                                                                 // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
@@ -182,8 +221,6 @@
                                                                 // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
                                                                 $rotation_class = $rotation > 0 ? 'wbtm_seat_rotated_' . $rotation : '';
 
-                                                                // Enhanced by Shahnur Alam - 2025-10-08
-                                                                // Fix cabin seat availability check - use cabin-specific identifiers
                                                                 // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
                                                                 $cabin_seat_identifier = 'cabin_' . $cabin_index . '_' . $seat_name;
                                                                 // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
@@ -291,8 +328,14 @@
                                             }
                                             ?>
                                             <?php if ($seat_name) { ?>
-                                                <?php if ($seat_name == 'door' || $seat_name == 'wc') { ?>
-                                                    <td><?php echo esc_html($seat_name); ?></td>
+                                                <?php if (wbtm_is_non_seat_item_check($seat_name)) {
+                                                    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+                                                    $ns_data_lower = wbtm_get_non_seat_data_check($seat_name);
+                                                ?>
+                                                    <td class="wbtm_non_seat_item" title="<?php echo esc_attr($ns_data_lower['label']); ?>">
+                                                        <span class="wbtm_non_seat_icon fas <?php echo esc_attr($ns_data_lower['icon']); ?>"></span>
+                                                        <span class="wbtm_non_seat_label"><?php echo esc_html($ns_data_lower['label']); ?></span>
+                                                    </td>
                                                 <?php } else { ?>
                                                     <?php
                                                     // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
@@ -307,8 +350,6 @@
                                                     <th>
                                                         <div class="mp_seat_item <?php echo esc_attr($rotation_class); ?>">
                                                             <?php
-                                                            // Enhanced by Shahnur Alam - 2025-10-08
-                                                            // Check both legacy seat names and cabin-specific identifiers for backward compatibility
                                                             // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
                                                             $is_booked_legacy = in_array($seat_name, $seat_booked);
                                                             // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
@@ -398,8 +439,14 @@
                                             }
                                             ?>
                                             <?php if ($info) { ?>
-                                                <?php if ($info == 'door' || $info == 'wc') { ?>
-                                                    <td><?php echo esc_html($info) ?></td>
+                                                <?php if (wbtm_is_non_seat_item_check($info)) {
+                                                    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+                                                    $ns_data_upper = wbtm_get_non_seat_data_check($info);
+                                                ?>
+                                                    <td class="wbtm_non_seat_item" title="<?php echo esc_attr($ns_data_upper['label']); ?>">
+                                                        <span class="wbtm_non_seat_icon fas <?php echo esc_attr($ns_data_upper['icon']); ?>"></span>
+                                                        <span class="wbtm_non_seat_label"><?php echo esc_html($ns_data_upper['label']); ?></span>
+                                                    </td>
                                                 <?php } else { ?>
                                                     <?php
                                                     // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
@@ -411,8 +458,6 @@
                                                     // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
                                                     $rotation_class = $rotation > 0 ? 'wbtm_seat_rotated_' . $rotation : '';
 
-                                                    // Enhanced by Shahnur Alam - 2025-10-08
-                                                    // Fix upper deck seat availability check - support cabin-specific identifiers
                                                     // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
                                                     $seat_available = WBTM_Query::query_total_booked($post_id, $start_route, $end_route, $date, '', $info);
                                                     ?>

--- a/templates/layout/seat_plan.php
+++ b/templates/layout/seat_plan.php
@@ -140,8 +140,6 @@
                             $cabin_seat_infos = WBTM_Global_Function::get_post_info($post_id, 'wbtm_cabin_seats_info_' . $cabin_index, []);
 
                             if ($cabin_rows > 0 && $cabin_cols > 0 && !empty($cabin_seat_infos)) {
-                                // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
-                                $cabin_price = $adult_price * $price_multiplier;
                                 ?>
                                 <div class="wbtm_cabin_section">
                                     <div class="wbtm_cabin_header wbtm_cabin_toggle" data-cabin-index="<?php echo esc_attr($cabin_index); ?>" style="cursor: pointer;">
@@ -227,6 +225,13 @@
                                                                 $is_booked = in_array($cabin_seat_identifier, $seat_booked) || in_array($seat_name, $seat_booked);
                                                                 // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
                                                                 $is_in_cart = !$is_booked && (WBTM_Functions::check_seat_in_cart($post_id, $start_route, $end_route, $date, $cabin_seat_identifier) || WBTM_Functions::check_seat_in_cart($post_id, $start_route, $end_route, $date, $seat_name));
+                                                                // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+                                                                $cell_base_cabin = WBTM_Functions::get_seat_price($post_id, $start_route, $end_route, $ticket_infos[0]['type'], false, $wbtm_pl, $seat_name, $cabin_index);
+                                                                if ($cell_base_cabin === false) {
+                                                                    $cell_base_cabin = 0;
+                                                                }
+                                                                // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+                                                                $cabin_price = floatval($cell_base_cabin) * floatval($price_multiplier);
                                                                 ?>
                                                                 <th>
                                                                     <div class="mp_seat_item <?php echo esc_attr($rotation_class); ?>">
@@ -259,9 +264,12 @@
                                                                                         foreach ($ticket_infos as $key => $ticket_info): ?>
                                                                                             <?php
                                                                                             // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
-                                                                                            $ticket_price = $key > 0 ? $ticket_info['price'] : $adult_price;
+                                                                                            $cell_t_cabin = WBTM_Functions::get_seat_price($post_id, $start_route, $end_route, $ticket_info['type'], false, $wbtm_pl, $seat_name, $cabin_index);
+                                                                                            if ($cell_t_cabin === false) {
+                                                                                                $cell_t_cabin = 0;
+                                                                                            }
                                                                                             // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
-                                                                                            $ticket_price = $ticket_price * $price_multiplier;
+                                                                                            $ticket_price = floatval($cell_t_cabin) * floatval($price_multiplier);
                                                                                             ?>
                                                                                             <li class="justifyBetween"
                                                                                                 data-seat_label="<?php echo esc_attr($ticket_info['name']); ?>"
@@ -346,6 +354,11 @@
                                                     }
                                                     // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
                                                     $rotation_class = $rotation > 0 ? 'wbtm_seat_rotated_' . $rotation : '';
+                                                    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+                                                    $cell_lower = WBTM_Functions::get_seat_price($post_id, $start_route, $end_route, $ticket_infos[0]['type'], false, $wbtm_pl, $seat_name, null);
+                                                    if ($cell_lower === false) {
+                                                        $cell_lower = 0;
+                                                    }
                                                     ?>
                                                     <th>
                                                         <div class="mp_seat_item <?php echo esc_attr($rotation_class); ?>">
@@ -370,7 +383,7 @@
                                                                     data-seat_name="<?php echo esc_attr($seat_name); ?>"
                                                                     data-seat_label="<?php echo esc_attr($ticket_infos[0]['name']); ?>"
                                                                     data-seat_type="<?php echo esc_attr($ticket_infos[0]['type']); ?>"
-                                                                    data-seat_price="<?php echo esc_attr($adult_price); ?>"
+                                                                    data-seat_price="<?php echo esc_attr($cell_lower); ?>"
                                                                 >
                                                                     <div class="seat_visual"></div>
                                                                     <div class="seat_number"><?php echo esc_html($seat_name); ?></div>
@@ -382,7 +395,11 @@
                                                                             // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
                                                                             foreach ($ticket_infos as $key => $ticket_info) {
                                                                                 // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
-                                                                                 $ticket_price = $key > 0 ? $ticket_info['price'] : $adult_price; ?>
+                                                                                $ticket_price = WBTM_Functions::get_seat_price($post_id, $start_route, $end_route, $ticket_info['type'], false, $wbtm_pl, $seat_name, null);
+                                                                                if ($ticket_price === false) {
+                                                                                    $ticket_price = 0;
+                                                                                }
+                                                                                ?>
                                                                                 <li class="justifyBetween"
                                                                                     data-seat_label="<?php echo esc_attr($ticket_info['name']); ?>"
                                                                                     data-seat_type="<?php echo esc_attr($ticket_info['type']); ?>"
@@ -411,12 +428,6 @@
                         </div>
                     <?php } ?>
                     <?php if ($show_upper_desk == 'yes' && sizeof($seat_infos_dd) > 0) { ?>
-                        <?php
-                        // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
-                        $seat_dd_increase = (int)WBTM_Global_Function::get_post_info($post_id, 'wbtm_seat_dd_price_parcent', 0);
-                        // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
-                        $adult_price_dd = $adult_price + ($adult_price * $seat_dd_increase / 100);
-                        ?>
                         <div class="wbtm_seat_plan_upper ovAuto">
                             <input type="hidden" name="wbtm_selected_seat_dd" value=""/>
                             <input type="hidden" name="wbtm_selected_seat_dd_type" value=""/>
@@ -459,6 +470,12 @@
                                                     $rotation_class = $rotation > 0 ? 'wbtm_seat_rotated_' . $rotation : '';
 
                                                     // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+                                                    $cell_upper = WBTM_Functions::get_seat_price($post_id, $start_route, $end_route, $ticket_infos[0]['type'], true, $wbtm_pl, $info, null);
+                                                    if ($cell_upper === false) {
+                                                        $cell_upper = 0;
+                                                    }
+
+                                                    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
                                                     $seat_available = WBTM_Query::query_total_booked($post_id, $start_route, $end_route, $date, '', $info);
                                                     ?>
                                                     <th>
@@ -478,7 +495,7 @@
                                                                     data-seat_name="<?php echo esc_attr($info); ?>"
                                                                     data-seat_label="<?php echo esc_attr($ticket_infos[0]['name']); ?>"
                                                                     data-seat_type="<?php echo esc_attr($ticket_infos[0]['type']); ?>"
-                                                                    data-seat_price="<?php echo esc_attr($adult_price_dd); ?>"
+                                                                    data-seat_price="<?php echo esc_attr($cell_upper); ?>"
                                                                 >
                                                                     <div class="seat_visual"></div>
                                                                     <div class="seat_number"><?php echo esc_html($info); ?></div>
@@ -491,9 +508,10 @@
                                                                             foreach ($ticket_infos as $key => $ticket_info) { ?>
                                                                                 <?php
                                                                                 // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
-                                                                                $ticket_price = $key > 0 ? WBTM_Global_Function::get_wc_raw_price($post_id, $ticket_info['price']) : $adult_price;
-                                                                                // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
-                                                                                $ticket_price = $ticket_price + ($ticket_price * $seat_dd_increase / 100);
+                                                                                $ticket_price = WBTM_Functions::get_seat_price($post_id, $start_route, $end_route, $ticket_info['type'], true, $wbtm_pl, $info, null);
+                                                                                if ($ticket_price === false) {
+                                                                                    $ticket_price = 0;
+                                                                                }
                                                                                 ?>
                                                                                 <li class="justifyBetween"
                                                                                     data-seat_label="<?php echo esc_attr($ticket_info['name']); ?>"


### PR DESCRIPTION


Summary
-------
Improves bus seat plans so admin can place non-passenger cells (door, toilet, driver, window, food stall, luggage, stairs, aisle, emergency exit) via a toolbar and drag-and-drop. Those cells are excluded from passenger seat totals, not bookable on the frontend, and shown with icon + label styling.

Admin
-----
- WBTM_Global_File_Load: enqueue jquery-ui-draggable and jquery-ui-droppable.
- WBTM_Seat_Configuration: central non_seat_items map; helpers is_non_seat_item, get_non_seat_item_data, get_non_seat_keywords, get_toolbar_items; toolbar render; count_actual_seats() to derive bookable seat count from live meta.
- WBTM_Dependencies: localize non_seat_items for admin JS.
- wbtm_admin.js: draggable toolbar, droppable cells, badges, refresh on grid regen.
- wbtm_admin.css: toolbar and drop-target styles.

Save / meta
-----------
- WBTM_Settings: total_seat increments skip all non-seat keywords (not only door/wc).

Frontend
--------
- seat_plan.php: render non-seat cells as td.wbtm_non_seat_item; helpers wbtm_is_non_seat_item_check / wbtm_get_non_seat_data_check for resilience if class load order differs.
- wbtm.css: .wbtm_non_seat_item muted, dashed border, non-interactive cues.

Availability and WooCommerce
----------------------------
- WBTM_Functions::get_bus_all_info: for wbtm_seat_plan, total_seat uses WBTM_Seat_Configuration::count_actual_seats when class exists so listing available/total matches the grid (avoids stale wbtm_get_total_seat).
- WBTM_Woocommerce: full-bus and non-seat-plan quantity checks use the same recounted total when applicable.
- WBTM_Query::query_seat_booked: omit entries that match non-seat keywords so fixtures never appear in booked-seat arrays.