### PR TITLE
feat(seat-plan): gate non-seat items & seat-price override behind PRO…… + add enable/disable toggle

### DIFF
--- a/admin/WBTM_Settings.php
+++ b/admin/WBTM_Settings.php
@@ -519,7 +519,7 @@
 									}
 									for ($i = 0; $i < $rows; $i++) {
 										if (isset($col_infos[$i])) {
-											$seat_value = $col_infos[$i];
+											$seat_value = WBTM_Seat_Configuration::normalize_saved_seat_value($col_infos[$i]);
 											$rotation_value = $col_rotation_infos[$i] ?? '0';
 											$cabin_seat_info[$i]['cabin_' . $cabin_index . '_seat' . $j] = $seat_value;
 											if ($enable_rotation == 'yes') {
@@ -545,10 +545,12 @@
 					$rows = isset($_POST['wbtm_seat_rows_hidden']) ? sanitize_text_field(wp_unslash($_POST['wbtm_seat_rows_hidden'])) : 0;
 					$columns = isset($_POST['wbtm_seat_cols_hidden']) ? sanitize_text_field(wp_unslash($_POST['wbtm_seat_cols_hidden'])) : 0;
 					$wbtm_enable_seat_rotation = isset($_POST['wbtm_enable_seat_rotation']) && sanitize_text_field(wp_unslash($_POST['wbtm_enable_seat_rotation'])) ? 'yes' : 'no';
+					$wbtm_enable_seat_price_override = isset($_POST['wbtm_enable_seat_price_override']) && sanitize_text_field(wp_unslash($_POST['wbtm_enable_seat_price_override'])) ? 'yes' : 'no';
 					update_post_meta($post_id, 'driver_seat_position', $driver_seat_position);
 					update_post_meta($post_id, 'wbtm_seat_rows', $rows);
 					update_post_meta($post_id, 'wbtm_seat_cols', $columns);
 					update_post_meta($post_id, 'wbtm_enable_seat_rotation', $wbtm_enable_seat_rotation);
+					update_post_meta($post_id, 'wbtm_enable_seat_price_override', $wbtm_enable_seat_price_override);
 					$lower_deck_info = [];
 					$total_seat = 0;
 					if ($rows > 0 && $columns > 0) {
@@ -575,7 +577,7 @@
 								$col_rotation_infos = [$col_rotation_infos];
 							}
 							for ($i = 0; $i < $rows; $i++) {
-								$seat_value = $col_infos[$i] ?? '';
+								$seat_value = WBTM_Seat_Configuration::normalize_saved_seat_value($col_infos[$i] ?? '');
 								$rotation_value = $col_rotation_infos[$i] ?? '0';
 								$lower_deck_info[$i]['seat' . $j] = $seat_value;
 								if ($wbtm_enable_seat_rotation == 'yes') {
@@ -621,7 +623,7 @@
 								$col_rotation_infos = [$col_rotation_infos];
 							}
 							for ($i = 0; $i < $rows_dd; $i++) {
-								$seat_value = $col_infos[$i] ?? '';
+								$seat_value = WBTM_Seat_Configuration::normalize_saved_seat_value($col_infos[$i] ?? '');
 								$rotation_value = $col_rotation_infos[$i] ?? '0';
 								$upper_deck_info[$i]['dd_seat' . $j] = $seat_value;
 								if ($wbtm_enable_seat_rotation == 'yes') {

--- a/admin/settings/WBTM_Seat_Configuration.php
+++ b/admin/settings/WBTM_Seat_Configuration.php
@@ -20,15 +20,41 @@
 				'aisle'          => ['icon' => 'fa-arrows-alt-h',    'label' => 'Aisle'],
 				'emergency_exit' => ['icon' => 'fa-sign-out-alt',    'label' => 'Exit'],
 			];
-			public static function is_non_seat_item($value) {
+			private static function is_non_seat_keyword($value) {
 				return isset(self::$non_seat_items[strtolower(trim($value))]);
 			}
+			public static function is_non_seat_item($value) {
+				return self::has_pro_seat_features() && self::is_non_seat_keyword($value);
+			}
 			public static function get_non_seat_item_data($value) {
+				if (!self::has_pro_seat_features()) {
+					return null;
+				}
 				$key = strtolower(trim($value));
 				return self::$non_seat_items[$key] ?? null;
 			}
 			public static function get_non_seat_keywords() {
 				return array_keys(self::$non_seat_items);
+			}
+			public static function normalize_saved_seat_value($value) {
+				$value = trim((string) $value);
+				if ($value !== '' && !self::has_pro_seat_features() && self::is_non_seat_keyword($value)) {
+					return '';
+				}
+				return $value;
+			}
+			public static function is_seat_price_override_enabled($post_id) {
+				/**
+				 * FIX: Add a backward-compatible seat-wise price override feature toggle.
+				 * AUTHOR: shahnur alam
+				 * ISSUE: #WBTM-SEAT-002
+				 * SOLVED: 2026-05-15
+				 * CONTEXT: Seat-specific pricing already existed in production, so the new enable/disable control must default to ON for older buses while still allowing admins to turn the feature off explicitly.
+				 */
+				return self::has_pro_seat_features() && WBTM_Global_Function::get_post_info($post_id, 'wbtm_enable_seat_price_override', 'yes') === 'yes';
+			}
+			public static function has_pro_seat_features() {
+				return class_exists('WBTM_Functions') && WBTM_Functions::is_pro_active();
 			}
 			public static function get_toolbar_items() {
 				$toolbar = [];
@@ -44,6 +70,47 @@
 					$seen[] = $data['label'];
 				}
 				return $toolbar;
+			}
+			/**
+			 * FIX: Disable seat-price actions for non-sellable seat-grid items.
+			 * AUTHOR: shahnur alam
+			 * ISSUE: #WBTM-SEAT-001
+			 * SOLVED: 2026-05-15
+			 * CONTEXT: Drag-and-drop items like Door, Window, and Aisle are layout markers, not sellable seats, so the per-seat ticket-price button must not appear active for them.
+			 */
+			private static function render_seat_price_button($scope, $seat_name = '', $cabin_index = null, $is_template = false, $is_feature_enabled = true) {
+				$is_non_seat = !$is_template && !empty($seat_name) && self::is_non_seat_item($seat_name);
+				$is_disabled = $is_template || !$is_feature_enabled || $is_non_seat;
+				$classes = ['button', 'button-small', 'wbtm_seat_price_view'];
+				if ($is_disabled) {
+					$classes[] = 'wbtm_seat_price_view_disabled';
+				}
+				if (!$is_feature_enabled) {
+					$title = esc_attr__('Enable Seat-wise Price Override to manage custom seat fares', 'bus-ticket-booking-with-seat-reservation');
+				} elseif ($is_non_seat) {
+					$title = esc_attr__('Price overrides apply only to sellable seats', 'bus-ticket-booking-with-seat-reservation');
+				} else {
+					$title = esc_attr__('View or override ticket prices for this seat', 'bus-ticket-booking-with-seat-reservation');
+				}
+				?>
+				<button type="button"
+						class="<?php echo esc_attr(implode(' ', $classes)); ?>"
+						data-override-scope="<?php echo esc_attr($scope); ?>"
+						data-seat-price-feature-enabled="<?php echo esc_attr($is_feature_enabled ? '1' : '0'); ?>"
+						data-default-title="<?php echo esc_attr__('View or override ticket prices for this seat', 'bus-ticket-booking-with-seat-reservation'); ?>"
+						data-disabled-title="<?php echo esc_attr__('Price overrides apply only to sellable seats', 'bus-ticket-booking-with-seat-reservation'); ?>"
+						data-feature-disabled-title="<?php echo esc_attr__('Enable Seat-wise Price Override to manage custom seat fares', 'bus-ticket-booking-with-seat-reservation'); ?>"
+						<?php if ($cabin_index !== null) { ?>
+						data-cabin-index="<?php echo esc_attr($cabin_index); ?>"
+						<?php } ?>
+						<?php if ($is_template) { ?>
+						data-price-view-template="1"
+						<?php } ?>
+						title="<?php echo $title; ?>"
+						<?php echo $is_disabled ? 'disabled' : ''; ?>>
+					<?php esc_html_e('View', 'bus-ticket-booking-with-seat-reservation'); ?>
+				</button>
+				<?php
 			}
 			public static function count_actual_seats($post_id) {
 				$total = 0;
@@ -61,6 +128,7 @@
 						foreach ($cabin_seats as $row) {
 							foreach ($row as $key => $val) {
 								if (strpos($key, '_rotation') !== false) continue;
+								$val = self::normalize_saved_seat_value($val);
 								if (!empty($val) && !self::is_non_seat_item($val)) {
 									$total++;
 								}
@@ -72,6 +140,7 @@
 					foreach ($seat_infos as $row) {
 						foreach ($row as $key => $val) {
 							if (strpos($key, '_rotation') !== false) continue;
+							$val = self::normalize_saved_seat_value($val);
 							if (!empty($val) && !self::is_non_seat_item($val)) {
 								$total++;
 							}
@@ -83,6 +152,7 @@
 						foreach ($upper_seats as $row) {
 							foreach ($row as $key => $val) {
 								if (strpos($key, '_rotation') !== false) continue;
+								$val = self::normalize_saved_seat_value($val);
 								if (!empty($val) && !self::is_non_seat_item($val)) {
 									$total++;
 								}
@@ -113,28 +183,31 @@
 					<?php
 					// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 					$wbtm_price_overrides = WBTM_Global_Function::get_post_info($post_id, 'wbtm_seat_price_overrides', []);
+					$has_pro_seat_features = self::has_pro_seat_features();
 					if (!is_array($wbtm_price_overrides)) {
 						$wbtm_price_overrides = [];
 					}
 					?>
-					<?php // Textarea avoids HTML attribute size/encoding limits for JSON; value is synced only via JS. ?>
-					<textarea name="wbtm_seat_price_overrides" id="wbtm_seat_price_overrides_field" class="wbtm_seat_price_overrides_field" rows="1" cols="40" autocomplete="off" tabindex="-1" aria-hidden="true"><?php echo esc_textarea(!empty($wbtm_price_overrides) ? wp_json_encode($wbtm_price_overrides) : '{}'); ?></textarea>
-					<div id="wbtm_seat_price_modal" class="wbtm_seat_price_modal" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="wbtm_seat_price_modal_title">
-						<div class="wbtm_seat_price_modal_overlay"></div>
-						<div class="wbtm_seat_price_modal_box">
-							<div class="wbtm_seat_price_modal_header">
-								<h4 id="wbtm_seat_price_modal_title"><?php esc_html_e('Per-seat ticket prices', 'bus-ticket-booking-with-seat-reservation'); ?></h4>
-								<button type="button" class="wbtm_seat_price_modal_close" aria-label="<?php esc_attr_e('Close', 'bus-ticket-booking-with-seat-reservation'); ?>">&times;</button>
-							</div>
-							<p class="wbtm_seat_price_modal_hint"><?php esc_html_e('Leave a field empty to use the route default fare for that ticket type. Prices are in store currency (same as routing & pricing).', 'bus-ticket-booking-with-seat-reservation'); ?></p>
-							<p class="wbtm_seat_price_modal_seat_label"><strong><?php esc_html_e('Seat:', 'bus-ticket-booking-with-seat-reservation'); ?></strong> <span class="wbtm_seat_price_modal_seat_name"></span></p>
-							<div class="wbtm_seat_price_modal_body"></div>
-							<div class="wbtm_seat_price_modal_footer">
-								<button type="button" class="button button-primary wbtm_seat_price_modal_save"><?php esc_html_e('Save', 'bus-ticket-booking-with-seat-reservation'); ?></button>
-								<button type="button" class="button wbtm_seat_price_modal_cancel"><?php esc_html_e('Cancel', 'bus-ticket-booking-with-seat-reservation'); ?></button>
+					<?php if ($has_pro_seat_features) { ?>
+						<?php // Textarea avoids HTML attribute size/encoding limits for JSON; value is synced only via JS. ?>
+						<textarea name="wbtm_seat_price_overrides" id="wbtm_seat_price_overrides_field" class="wbtm_seat_price_overrides_field" rows="1" cols="40" autocomplete="off" tabindex="-1" aria-hidden="true"><?php echo esc_textarea(!empty($wbtm_price_overrides) ? wp_json_encode($wbtm_price_overrides) : '{}'); ?></textarea>
+						<div id="wbtm_seat_price_modal" class="wbtm_seat_price_modal" style="display:none;" role="dialog" aria-modal="true" aria-labelledby="wbtm_seat_price_modal_title">
+							<div class="wbtm_seat_price_modal_overlay"></div>
+							<div class="wbtm_seat_price_modal_box">
+								<div class="wbtm_seat_price_modal_header">
+									<h4 id="wbtm_seat_price_modal_title"><?php esc_html_e('Per-seat ticket prices', 'bus-ticket-booking-with-seat-reservation'); ?></h4>
+									<button type="button" class="wbtm_seat_price_modal_close" aria-label="<?php esc_attr_e('Close', 'bus-ticket-booking-with-seat-reservation'); ?>">&times;</button>
+								</div>
+								<p class="wbtm_seat_price_modal_hint"><?php esc_html_e('If you set a specific price, it will override the default route fare. Seat-wise pricing remains fixed and is not affected by route settings. Leaving the field empty will apply the default route fare automatically.', 'bus-ticket-booking-with-seat-reservation'); ?></p>
+								<p class="wbtm_seat_price_modal_seat_label"><strong><?php esc_html_e('Seat:', 'bus-ticket-booking-with-seat-reservation'); ?></strong> <span class="wbtm_seat_price_modal_seat_name"></span></p>
+								<div class="wbtm_seat_price_modal_body"></div>
+								<div class="wbtm_seat_price_modal_footer">
+									<button type="button" class="button button-primary wbtm_seat_price_modal_save"><?php esc_html_e('Save', 'bus-ticket-booking-with-seat-reservation'); ?></button>
+									<button type="button" class="button wbtm_seat_price_modal_cancel"><?php esc_html_e('Cancel', 'bus-ticket-booking-with-seat-reservation'); ?></button>
+								</div>
 							</div>
 						</div>
-					</div>
+					<?php } ?>
                     <div class="">
                         <div class="_dLayout_padding_dFlex_justifyBetween_alignCenter_bgLight">
                             <div class="col_6 _dFlex_fdColumn">
@@ -227,6 +300,9 @@
 				/***************************/
 				$enable_rotation = WBTM_Global_Function::get_post_info($post_id, 'wbtm_enable_seat_rotation');
 				$checked_rotation = $enable_rotation == 'yes' ? 'checked' : '';
+				$has_pro_seat_features = self::has_pro_seat_features();
+				$enable_seat_price_override = self::is_seat_price_override_enabled($post_id);
+				$checked_seat_price_override = $enable_seat_price_override ? 'checked' : '';
 				?>
                 <div class="mpPanel mT">
                     <div class="_padding_dFlex_justifyBetween_alignCenter_bgLight">
@@ -247,6 +323,18 @@
 								<?php WBTM_Custom_Layout::switch_button('wbtm_enable_seat_rotation', $checked_rotation); ?>
                             </div>
                             <div class="divider"></div>
+							<?php if ($has_pro_seat_features) { ?>
+                            <div class="_dFlex_justifyBetween_alignCenter">
+                                <div class="col_6 _dFlex_fdColumn">
+                                    <label>
+										<?php esc_html_e('Enable Seat-wise Price Override', 'bus-ticket-booking-with-seat-reservation'); ?>
+                                    </label>
+                                    <span><?php esc_html_e('Turn on to set a custom fare for individual sellable seats.', 'bus-ticket-booking-with-seat-reservation'); ?></span>
+                                </div>
+								<?php WBTM_Custom_Layout::switch_button('wbtm_enable_seat_price_override', $checked_seat_price_override); ?>
+                            </div>
+                            <div class="divider"></div>
+							<?php } ?>
                             <div class="_dFlex_justifyBetween_alignCenter">
                                 <div class="col_6 _dFlex_fdColumn">
                                     <label>
@@ -358,6 +446,9 @@
 				<?php
 			}
 			public function render_seat_item_toolbar() {
+				if (!self::has_pro_seat_features()) {
+					return;
+				}
 				$items = self::get_toolbar_items();
 				?>
 				<div class="wbtm_seat_toolbar">
@@ -382,6 +473,7 @@
 					$info_key = $dd ? 'wbtm_bus_seats_info_dd' : 'wbtm_bus_seats_info';
 					$seat_infos = WBTM_Global_Function::get_post_info($post_id, $info_key, []);
 					$enable_rotation = WBTM_Global_Function::get_post_info($post_id, 'wbtm_enable_seat_rotation');
+					$enable_seat_price_override = self::is_seat_price_override_enabled($post_id);
 					$rotation_class = $enable_rotation == 'yes' ? 'wbtm_enable_rotation' : '';
 					?>
                     <div class="wbtm_settings_area <?php echo esc_attr($rotation_class); ?>">
@@ -391,7 +483,7 @@
                                 <tbody class="wbtm_item_insert wbtm_sortable_area">
 								<?php for ($i = 0; $i < $seat_row; $i++) { ?>
 									<?php $row_info = array_key_exists($i, $seat_infos) ? $seat_infos[$i] : []; ?>
-									<?php $this->seat_plan_row($seat_column, $dd, $row_info); ?>
+									<?php $this->seat_plan_row($seat_column, $dd, $row_info, $enable_seat_price_override); ?>
 								<?php } ?>
                                 </tbody>
                             </table>
@@ -400,14 +492,14 @@
                         <div class="wbtm_hidden_content">
                             <table>
                                 <tbody class="wbtm_hidden_item">
-								<?php $this->seat_plan_row($seat_column, $dd); ?>
+								<?php $this->seat_plan_row($seat_column, $dd, [], $enable_seat_price_override); ?>
                                 </tbody>
                             </table>
                         </div>
                     </div>
 				<?php }
 			}
-			public function seat_plan_row($seat_column, $dd, $row_info = []) {
+			public function seat_plan_row($seat_column, $dd, $row_info = [], $enable_seat_price_override = true) {
 				$seat_key = $dd ? 'dd_seat' : 'seat';
 				$post_id = get_the_ID();
 				$enable_rotation = WBTM_Global_Function::get_post_info($post_id, 'wbtm_enable_seat_rotation');
@@ -415,7 +507,7 @@
                 <tr class="wbtm_remove_area">
 					<?php for ($j = 1; $j <= $seat_column; $j++) { ?>
 						<?php $key = $seat_key . $j; ?>
-						<?php $seat_name = array_key_exists($key, $row_info) ? $row_info[$key] : ''; ?>
+						<?php $seat_name = array_key_exists($key, $row_info) ? self::normalize_saved_seat_value($row_info[$key]) : ''; ?>
 						<?php $seat_rotation = array_key_exists($key . '_rotation', $row_info) ? $row_info[$key . '_rotation'] : '0'; ?>
                         <th>
                             <div class="wbtm_seat_container">
@@ -426,10 +518,7 @@
                                            value="<?php echo esc_attr($seat_name); ?>"
                                     />
                                 </label>
-								<button type="button" class="button button-small wbtm_seat_price_view" data-override-scope="<?php echo esc_attr($dd ? 'u' : 'l'); ?>"
-									title="<?php esc_attr_e('View or override ticket prices for this seat', 'bus-ticket-booking-with-seat-reservation'); ?>">
-									<?php esc_html_e('View', 'bus-ticket-booking-with-seat-reservation'); ?>
-								</button>
+								<?php self::render_seat_price_button($dd ? 'u' : 'l', $seat_name, null, false, $enable_seat_price_override); ?>
 								<?php if ($enable_rotation == 'yes') { ?>
                                     <div class="wbtm_seat_rotation_controls">
                                         <button type="button" class="wbtm_rotate_seat _whiteButton_xs"
@@ -455,6 +544,7 @@
 					$seat_key_prefix = 'cabin_' . $cabin_index . '_seat';
 					$seat_infos = WBTM_Global_Function::get_post_info($post_id, 'wbtm_cabin_seats_info_' . $cabin_index, []);
 					$enable_rotation = WBTM_Global_Function::get_post_info($post_id, 'wbtm_enable_seat_rotation');
+					$enable_seat_price_override = self::is_seat_price_override_enabled($post_id);
 					$rotation_class = $enable_rotation == 'yes' ? 'wbtm_enable_rotation' : '';
 					?>
                     <div class="wbtm_cabin_settings_area <?php echo esc_attr($rotation_class); ?>">
@@ -464,7 +554,7 @@
                                 <tbody class="wbtm_cabin_item_insert wbtm_sortable_area">
 								<?php for ($i = 0; $i < $rows; $i++) { ?>
 									<?php $row_info = array_key_exists($i, $seat_infos) ? $seat_infos[$i] : []; ?>
-									<?php $this->cabin_seat_plan_row($cols, $cabin_index, $row_info); ?>
+									<?php $this->cabin_seat_plan_row($cols, $cabin_index, $row_info, $enable_seat_price_override); ?>
 								<?php } ?>
                                 </tbody>
                             </table>
@@ -488,12 +578,9 @@
                                                            placeholder="<?php esc_attr_e('Blank', 'bus-ticket-booking-with-seat-reservation'); ?>"
                                                            value=""
                                                            disabled
-                                                    />
+                                                   />
                                                 </label>
-												<button type="button" class="button button-small wbtm_seat_price_view wbtm_seat_price_view_disabled" disabled data-override-scope="c" data-cabin-index="<?php echo esc_attr($cabin_index); ?>"
-													title="<?php esc_attr_e('View or override ticket prices for this seat', 'bus-ticket-booking-with-seat-reservation'); ?>">
-													<?php esc_html_e('View', 'bus-ticket-booking-with-seat-reservation'); ?>
-												</button>
+												<?php self::render_seat_price_button('c', '', $cabin_index, true, $enable_seat_price_override); ?>
 												<?php if ($enable_rotation == 'yes') { ?>
                                                     <div class="wbtm_seat_rotation_controls">
                                                         <button type="button" class="wbtm_rotate_seat _whiteButton_xs"
@@ -520,7 +607,7 @@
 					<?php
 				}
 			}
-			public function cabin_seat_plan_row($cols, $cabin_index, $row_info = []) {
+			public function cabin_seat_plan_row($cols, $cabin_index, $row_info = [], $enable_seat_price_override = true) {
 				$seat_key_prefix = 'cabin_' . $cabin_index . '_seat';
 				$post_id = get_the_ID();
 				$enable_rotation = WBTM_Global_Function::get_post_info($post_id, 'wbtm_enable_seat_rotation');
@@ -528,7 +615,7 @@
                 <tr class="wbtm_remove_area">
 					<?php for ($j = 1; $j <= $cols; $j++) { ?>
 						<?php $key = $seat_key_prefix . $j; ?>
-						<?php $seat_name = array_key_exists($key, $row_info) ? $row_info[$key] : ''; ?>
+						<?php $seat_name = array_key_exists($key, $row_info) ? self::normalize_saved_seat_value($row_info[$key]) : ''; ?>
 						<?php $seat_rotation = array_key_exists($key . '_rotation', $row_info) ? $row_info[$key . '_rotation'] : '0'; ?>
                         <th>
                             <div class="wbtm_seat_container">
@@ -539,10 +626,7 @@
                                            value="<?php echo esc_attr($seat_name); ?>"
                                     />
                                 </label>
-								<button type="button" class="button button-small wbtm_seat_price_view" data-override-scope="c" data-cabin-index="<?php echo esc_attr($cabin_index); ?>"
-									title="<?php esc_attr_e('View or override ticket prices for this seat', 'bus-ticket-booking-with-seat-reservation'); ?>">
-									<?php esc_html_e('View', 'bus-ticket-booking-with-seat-reservation'); ?>
-								</button>
+								<?php self::render_seat_price_button('c', $seat_name, $cabin_index, false, $enable_seat_price_override); ?>
 								<?php if ($enable_rotation == 'yes') { ?>
                                     <div class="wbtm_seat_rotation_controls">
                                         <button type="button" class="wbtm_rotate_seat _whiteButton_xs"

--- a/assets/admin/wbtm_admin.css
+++ b/assets/admin/wbtm_admin.css
@@ -369,6 +369,9 @@ textarea.wbtm_seat_price_overrides_field {
 	text-align: center;
 	position: relative;
 }
+.wbtm_seat_container .wbtm_seat_price_view_disabled {
+	display: none;
+}
 .wbtm_seat_price_view .wbtm_seat_price_badge {
 	position: absolute;
 	top: -7px;

--- a/assets/admin/wbtm_admin.js
+++ b/assets/admin/wbtm_admin.js
@@ -375,6 +375,7 @@
 (function ($) {
     "use strict";
 
+    let proSeatFeaturesEnabled = !!(typeof wbtm_admin_var !== 'undefined' && wbtm_admin_var.pro_seat_features_enabled);
     let nonSeatItems = (typeof wbtm_admin_var !== 'undefined' && wbtm_admin_var.non_seat_items) ? wbtm_admin_var.non_seat_items : {};
 
     function isNonSeatItem(val) {
@@ -388,6 +389,10 @@
 
     function applyBadge($container, itemType) {
         $container.find('.wbtm_nonseat_badge').remove();
+        if (!proSeatFeaturesEnabled) {
+            $container.removeClass('wbtm_has_nonseat');
+            return;
+        }
         if (!itemType) {
             $container.removeClass('wbtm_has_nonseat');
             return;
@@ -399,6 +404,11 @@
     }
 
     function refreshAllBadges($scope) {
+        if (!proSeatFeaturesEnabled) {
+            ($scope || $(document)).find('.wbtm_nonseat_badge').remove();
+            ($scope || $(document)).find('.wbtm_seat_container').removeClass('wbtm_has_nonseat');
+            return;
+        }
         ($scope || $(document)).find('.wbtm_seat_container').each(function () {
             let $c = $(this);
             let val = $c.find('input.formControl').val();
@@ -412,6 +422,9 @@
     }
 
     function initDragDrop($scope) {
+        if (!proSeatFeaturesEnabled) {
+            return;
+        }
         $scope = $scope || $(document);
 
         $scope.find('.wbtm_draggable_item').each(function () {
@@ -478,6 +491,7 @@
             $c.find('.wbtm_nonseat_badge').remove();
             $c.removeClass('wbtm_has_nonseat');
         }
+        wbtmSyncSeatPriceButtonState($c);
         if ($(this).closest('.wbtm_settings_seat').length) {
             wbtmSyncSeatPriceBadges($(this).closest('.wbtm_settings_seat'));
         }
@@ -519,6 +533,12 @@
             $f.val(JSON.stringify(obj));
         }
     }
+    function wbtmSeatPriceOverrideFeatureEnabled() {
+        if (!proSeatFeaturesEnabled) {
+            return false;
+        }
+        return $('input[name="wbtm_enable_seat_price_override"]').is(':checked');
+    }
     function wbtmBuildScopeKey(scope, cabinIndex, seatName) {
         seatName = (seatName || '').trim();
         if (!seatName) {
@@ -555,6 +575,31 @@
         });
         return n;
     }
+    function wbtmSyncSeatPriceButtonState($container) {
+        let $btn = $container.find('.wbtm_seat_price_view').first();
+        if (!$btn.length || $btn.attr('data-price-view-template') === '1') {
+            return false;
+        }
+        let seatName = $.trim($container.find('input.formControl').first().val() || '');
+        let featureEnabled = wbtmSeatPriceOverrideFeatureEnabled();
+        let isNonSeat = seatName && isNonSeatItem(seatName);
+        let isDisabled = !featureEnabled || !!isNonSeat;
+        let defaultTitle = $btn.attr('data-default-title') || '';
+        let disabledTitle = $btn.attr('data-disabled-title') || defaultTitle;
+        let featureDisabledTitle = $btn.attr('data-feature-disabled-title') || defaultTitle;
+        $btn.attr('data-seat-price-feature-enabled', featureEnabled ? '1' : '0');
+        $btn.prop('disabled', isDisabled);
+        $btn.toggleClass('wbtm_seat_price_view_disabled', isDisabled);
+        if (!featureEnabled) {
+            $btn.attr('title', featureDisabledTitle);
+        } else {
+            $btn.attr('title', isNonSeat ? disabledTitle : defaultTitle);
+        }
+        if (isDisabled) {
+            $btn.find('.wbtm_seat_price_badge').remove();
+        }
+        return isDisabled;
+    }
     function wbtmSyncSeatPriceBadges($root) {
         $root = $root && $root.length ? $root : $('.wbtm_settings_seat');
         if (!$root || !$root.length) {
@@ -563,11 +608,14 @@
         let all = wbtmReadOverridesState();
         $root.find('.wbtm_seat_price_view').each(function () {
             let $btn = $(this);
-            if ($btn.hasClass('wbtm_seat_price_view_disabled')) {
+            if ($btn.attr('data-price-view-template') === '1') {
                 $btn.find('.wbtm_seat_price_badge').remove();
                 return;
             }
             let $container = $btn.closest('.wbtm_seat_container');
+            if (wbtmSyncSeatPriceButtonState($container)) {
+                return;
+            }
             let seatName = $.trim($container.find('input.formControl').first().val() || '');
             if (!seatName) {
                 $btn.find('.wbtm_seat_price_badge').remove();
@@ -592,6 +640,13 @@
 
     $(document).on('wbtm_seat_plan_dom_updated', function () {
         wbtmSyncSeatPriceBadges($('.wbtm_settings_seat'));
+    });
+    $(document).on('change', 'input[name="wbtm_enable_seat_price_override"]', function () {
+        wbtmSyncSeatPriceBadges($('.wbtm_settings_seat'));
+        if (!wbtmSeatPriceOverrideFeatureEnabled()) {
+            $('#wbtm_seat_price_modal').hide();
+            wbtmPriceModalKey = '';
+        }
     });
 
     var wbtmPriceModalKey = '';

--- a/assets/frontend/wbtm.css
+++ b/assets/frontend/wbtm.css
@@ -166,7 +166,6 @@
 }
 
 .wbtm_search_action_button {
-  display: inline-flex !important;
   align-items: center;
   justify-content: center;
 }

--- a/inc/WBTM_Dependencies.php
+++ b/inc/WBTM_Dependencies.php
@@ -87,6 +87,7 @@
 					$non_seat_icon_map['wc'] = 'fa-restroom';
 				}
 				$ticket_types_payload = [];
+				$pro_seat_features_enabled = class_exists('WBTM_Functions') && WBTM_Functions::is_pro_active();
 				if (function_exists('get_current_screen')) {
 					$screen = get_current_screen();
 					if ($screen && $screen->post_type === 'wbtm_bus' && isset($_GET['post'])) {
@@ -106,6 +107,7 @@
 					'nonce'             => wp_create_nonce( 'wbtm_admin_nonce' ),
 					'seat_row_col_error' => esc_html__( 'Number of rows & columns must be greater than 0', 'bus-ticket-booking-with-seat-reservation' ),
 					'non_seat_items'    => $non_seat_icon_map,
+					'pro_seat_features_enabled' => $pro_seat_features_enabled,
 					'ticket_types'      => $ticket_types_payload,
 					'seat_price_need_name' => esc_html__( 'Enter a seat label first (e.g. A1).', 'bus-ticket-booking-with-seat-reservation' ),
 					'seat_price_no_types' => esc_html__( 'Add a route fare for at least one passenger type under Routing & Pricing, or save a per-seat price first.', 'bus-ticket-booking-with-seat-reservation' ),

--- a/inc/WBTM_Functions.php
+++ b/inc/WBTM_Functions.php
@@ -8,15 +8,7 @@
 	} // Cannot access pages directly.
 	if ( ! class_exists( 'WBTM_Functions' ) ) {
 		class WBTM_Functions {
-			public static function template_path( $file_name ): string {
-				$template_path = get_stylesheet_directory() . '/templates/';
-				$default_dir   = WBTM_PLUGIN_DIR . '/templates/';
-				$dir           = is_dir( $template_path ) ? $template_path : $default_dir;
-				$file_path     = $dir . $file_name;
-				return locate_template( array( 'templates/' . $file_name ) ) ? $file_path : $default_dir . $file_name;
-			}
-			// Fixed by Shahnur — Pro-only full bus feature gate 2026-05-07 01:55 PM
-			public static function is_full_bus_feature_enabled() {
+			public static function is_pro_active() {
 				if ( class_exists( 'WBTM_Dependencies_Pro' ) || class_exists( 'Wbtm_Woocommerce_bus_Pro' ) ) {
 					return true;
 				}
@@ -26,6 +18,17 @@
 				return function_exists( 'is_plugin_active' )
 					&& is_plugin_active( 'addon-bus--ticket-booking-with-seat-pro/wbtm-pro.php' )
 					&& file_exists( WP_PLUGIN_DIR . '/addon-bus--ticket-booking-with-seat-pro/wbtm-pro.php' );
+			}
+			public static function template_path( $file_name ): string {
+				$template_path = get_stylesheet_directory() . '/templates/';
+				$default_dir   = WBTM_PLUGIN_DIR . '/templates/';
+				$dir           = is_dir( $template_path ) ? $template_path : $default_dir;
+				$file_path     = $dir . $file_name;
+				return locate_template( array( 'templates/' . $file_name ) ) ? $file_path : $default_dir . $file_name;
+			}
+			// Fixed by Shahnur — Pro-only full bus feature gate 2026-05-07 01:55 PM
+			public static function is_full_bus_feature_enabled() {
+				return self::is_pro_active();
 			}
 			//==========================//
 			public static function get_bus_route( $post_id = 0, $start_route = '' ) {
@@ -411,7 +414,7 @@
 			 */
 			public static function get_ticket_types_for_seat_price_modal( $post_id ) {
 				$post_id = absint( $post_id );
-				if ( ! $post_id ) {
+				if ( ! $post_id || ! self::is_pro_active() ) {
 					return [];
 				}
 				$all_types = self::get_ticket_types( $post_id );
@@ -932,7 +935,10 @@
 			 * @return float|null Override amount in store raw price units, or null to use route fare.
 			 */
 			public static function get_seat_price_override_raw( $post_id, $storage_key, $ticket_type_id ) {
-				if ( ! $post_id || $storage_key === '' ) {
+				if ( ! $post_id || $storage_key === '' || ! self::is_pro_active() ) {
+					return null;
+				}
+				if ( class_exists( 'WBTM_Seat_Configuration' ) && ! WBTM_Seat_Configuration::is_seat_price_override_enabled( $post_id ) ) {
 					return null;
 				}
 				$map = WBTM_Global_Function::get_post_info( $post_id, 'wbtm_seat_price_overrides', [] );

--- a/inc/WBTM_Query.php
+++ b/inc/WBTM_Query.php
@@ -281,6 +281,9 @@
 						if(sizeof($guest_ids)>0){
 							foreach ($guest_ids as $guest_id){
 								$seat_name = WBTM_Global_Function::get_post_info($guest_id,'wbtm_seat');
+								if (class_exists('WBTM_Seat_Configuration')) {
+									$seat_name = WBTM_Seat_Configuration::normalize_saved_seat_value($seat_name);
+								}
 								if ($seat_name && !(class_exists('WBTM_Seat_Configuration') && WBTM_Seat_Configuration::is_non_seat_item($seat_name))) {
 									$seat_booked[] = $seat_name;
 								}

--- a/templates/layout/seat_plan.php
+++ b/templates/layout/seat_plan.php
@@ -66,6 +66,14 @@
             return in_array(strtolower(trim($value)), $non_seat_keys, true);
         }
     }
+    if (!function_exists('wbtm_normalize_seat_value_check')) {
+        function wbtm_normalize_seat_value_check($value) {
+            if (class_exists('WBTM_Seat_Configuration')) {
+                return WBTM_Seat_Configuration::normalize_saved_seat_value($value);
+            }
+            return trim((string) $value);
+        }
+    }
     if (!function_exists('wbtm_get_non_seat_data_check')) {
         function wbtm_get_non_seat_data_check($value) {
             if (class_exists('WBTM_Seat_Configuration')) {
@@ -113,6 +121,7 @@
                     if (strpos($seat_key_tmp, '_rotation') !== false) {
                         continue;
                     }
+                    $seat = wbtm_normalize_seat_value_check($seat);
                     if (!empty($seat) && !wbtm_is_non_seat_item_check($seat)) {
                         $seat_count++;
                     }
@@ -198,6 +207,7 @@
                                                         if (strpos($seat_key, '_rotation') !== false) {
                                                             continue;
                                                         }
+                                                        $seat_name = wbtm_normalize_seat_value_check($seat_name);
                                                         ?>
                                                         <?php if ($seat_name): ?>
                                                             <?php if (wbtm_is_non_seat_item_check($seat_name)):
@@ -334,6 +344,7 @@
                                             if (strpos($seat_key, '_rotation') !== false) {
                                                 continue;
                                             }
+                                            $seat_name = wbtm_normalize_seat_value_check($seat_name);
                                             ?>
                                             <?php if ($seat_name) { ?>
                                                 <?php if (wbtm_is_non_seat_item_check($seat_name)) {
@@ -448,6 +459,7 @@
                                             if (strpos($seat_key, '_rotation') !== false) {
                                                 continue;
                                             }
+                                            $info = wbtm_normalize_seat_value_check($info);
                                             ?>
                                             <?php if ($info) { ?>
                                                 <?php if (wbtm_is_non_seat_item_check($info)) {


### PR DESCRIPTION


- Add WBTM_Seat_Configuration::has_pro_seat_features() and ::is_seat_price_override_enabled()
- Normalize saved seat values: strip non-seat keywords when PRO is inactive
- Add 'Enable Seat-wise Price Override' switch (defaults ON for backward compat)
- Disable price-view buttons for non-seat items (door/window/aisle/etc.)
- Hide drag-drop toolbar and price modal DOM when PRO is not active
- Update seat count logic to use normalized values
- Update frontend seat_plan template to normalize values before counting/rendering
- Add pro_seat_features_enabled flag to wbtm_admin_var JS object
- Sync seat price button state dynamically via JS on feature toggle and seat name change
- Minor CSS: hide disabled price-view buttons, remove stray !important from search button

Fixes: #WBTM-SEAT-001, #WBTM-SEAT-002