### PR TITLE
fix(css): resolve merge conflict & make plugin fully mobile responsive

### DIFF
--- a/assets/frontend/wbtm.css
+++ b/assets/frontend/wbtm.css
@@ -255,7 +255,6 @@
 /*# sourceMappingURL=wbtm.css.map */
 @media (min-width:0px) {
 
-<<<<<<< HEAD
 div[class*=wbtm_loader] {
   background: rgba(0, 0, 0, 0.2);
   color: var(--wbtm_color_theme);
@@ -1154,7 +1153,8 @@ div.wbtm_bus_list_area div.wbtm_seat_plan_upper div.seat_in_cart .seat_visual {
 .wbtm_search_input_fields_holder{
   display: flex;
   width: 100%;
-  gap: 5px;
+  gap: 10px;
+  align-items: flex-end;
 }
 
 .wbtm_input_start_end_location{
@@ -1209,7 +1209,8 @@ div.wbtm_bus_list_area div.wbtm_seat_plan_upper div.seat_in_cart .seat_visual {
 
 .wbtm_input_fields_holder{
   display: flex;
-  width: calc( 100% - 140px );
+  flex: 1 1 auto;
+  min-width: 0;
 }
 .wbtm_search_action_button{
   display: inline-flex;
@@ -1231,8 +1232,9 @@ div.wbtm_bus_list_area div.wbtm_seat_plan_upper div.seat_in_cart .seat_visual {
 }
 
 .wtbm_bus_search_button_holder{
+  flex: 0 0 auto;
   display: flex;
-  justify-content: center;
+  align-items: flex-end;
 }
 .wbtm_input_start_end_location,
 .wbtm_input_start_end_date{
@@ -1240,856 +1242,6 @@ div.wbtm_bus_list_area div.wbtm_seat_plan_upper div.seat_in_cart .seat_visual {
   width: 50%;
   position: relative;
 }
-=======
-  div[class*=wbtm_loader] {
-    background: rgba(0, 0, 0, 0.2);
-    color: var(--wbtm_color_theme);
-  }
-
-  div[class*=wbtm_loader] span {
-    width: initial !important;
-    margin: 0 !important;
-  }
-
-  div[class*=wbtm_loader].border_spin_loader span {
-    border-top: 5px solid var(--wbtm_color_theme_alter);
-    border-right: 5px solid var(--wbtm_color_theme);
-    border-bottom: 5px solid var(--wbtm_color_theme_alter);
-    border-left: 5px solid var(--wbtm_color_theme);
-    width: 60px;
-    height: 60px;
-    -webkit-animation: spin 1000ms linear infinite;
-    animation: spin 1000ms linear infinite;
-  }
-
-  div[class*=simpleSpinner] {
-    padding: var(--wbtm_dmp);
-    color: var(--wbtm_color_theme);
-  }
-
-  .wbtm_ex_service_area h3 {
-    font-size: 14px;
-    font-weight: normal;
-  }
-
-  /*****Text Theme*********/
-  div.wbtm_style .textTheme,
-  div.wbtm_style [class*=_textTheme] {
-    color: var(--wbtm_color_theme);
-  }
-
-  div.wbtm_style .bgTheme,
-  div.wbtm_style [class*=_bgTheme] {
-    background-color: var(--wbtm_color_theme);
-    color: var(--wbtm_color_theme_alter);
-  }
-
-  div.wbtm_style [class*=_bTheme],
-  .bTheme {
-    border: 1px solid var(--wbtm_color_theme);
-  }
-
-  .pickup-point,
-  .drop-off-point {
-    margin-left: 8px;
-    border-left: 1px solid;
-    flex-direction: column;
-  }
-
-  .pickup-point .point,
-  .drop-off-point .point {
-    margin-left: -0.57em;
-    padding: 15px 0;
-  }
-
-  .pickup-point .point:first-child,
-  .drop-off-point .point:first-child {
-    padding-top: 21px;
-  }
-
-  .pickup-point .point:last-child,
-  .drop-off-point .point:last-child {
-    padding-bottom: 0;
-    line-height: 0;
-    margin-bottom: 24px;
-  }
-
-  .wbtm_selected_seat_details table thead th {
-    font-size: 16px;
-    color: #666;
-    font-weight: normal;
-  }
-
-  .wbtm_selected_seat_details table tbody tr {
-    border-bottom: 1px solid #d8d8d8;
-  }
-
-  table.wbtm_totals tbody tr h5 {
-    font-size: 16px;
-    color: #333;
-  }
-
-  div.wbtm_selected_seat_details table tbody tr td {
-    border-bottom: 1px solid #d8d8d8;
-  }
-
-  .wbtm_ex_service_area table thead th {
-    font-size: 16px;
-    color: #666;
-  }
-
-  .wbtm_ex_service_area table tbody tr:nth-child(2n+1) {
-    background: none;
-  }
-
-  .wbtm_ex_service_area table tr:nth-child(2n) {
-    background: none;
-  }
-
-  .wbtm-seat-book.hide {
-    display: none;
-  }
-
-  /* Frontend Seat Rotation Styles */
-  .wbtm_seat_rotated_90 .mp_seat .seat_visual {
-    transform: rotate(90deg);
-    transform-origin: center;
-  }
-
-  .wbtm_seat_rotated_180 .mp_seat .seat_visual {
-    transform: rotate(180deg);
-    transform-origin: center;
-  }
-
-  .wbtm_seat_rotated_270 .mp_seat .seat_visual {
-    transform: rotate(270deg);
-    transform-origin: center;
-  }
-
-  /* Ensure seat number text never rotates */
-  .wbtm_seat_rotated_90 .mp_seat .seat_number,
-  .wbtm_seat_rotated_180 .mp_seat .seat_number,
-  .wbtm_seat_rotated_270 .mp_seat .seat_number {
-    transform: none !important;
-    writing-mode: horizontal-tb !important;
-    text-orientation: mixed !important;
-    rotate: none !important;
-    transform-origin: initial !important;
-  }
-
-  /* Additional protection for seat numbers */
-  .mp_seat_item .seat_number {
-    transform: none !important;
-    writing-mode: horizontal-tb !important;
-    text-orientation: mixed !important;
-    rotate: none !important;
-    transform-origin: initial !important;
-    position: relative !important;
-    z-index: 999 !important;
-  }
-
-  /* Ensure rotated seats maintain proper spacing and alignment */
-  .wbtm_seat_plan_area .mp_seat_item {
-    position: relative;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    min-height: 40px;
-  }
-
-  .wbtm_seat_plan_area .mp_seat_item .mp_seat {
-    transition: transform 0.3s ease;
-    display: flex;
-    justify-content: center;
-    align-items: center;
-    width: 100%;
-    height: 100%;
-    position: relative;
-    flex-direction: column;
-    background-color: transparent;
-    border: none;
-  }
-
-  /* Seat structure styles */
-  .seat_visual {
-    width: 100%;
-    height: 100%;
-    background-color: inherit;
-    border: inherit;
-    border-radius: inherit;
-    position: absolute;
-    top: 0;
-    left: 0;
-    z-index: 1;
-    transition: transform 0.3s ease;
-  }
-
-  /* Ensure seat_visual inherits all visual styling from parent seat */
-  .mp_seat .seat_visual {
-    background-color: inherit;
-    border: inherit;
-    border-radius: inherit;
-    cursor: inherit;
-  }
-
-  /* Specific seat state styling for seat_visual */
-  .seat_available .seat_visual {
-    background-color: var(--wbtm_color_theme_alter);
-    cursor: pointer;
-  }
-
-  .seat_selected.seat_available .seat_visual {
-    background-color: var(--wbtm_color_theme);
-  }
-
-  .seat_booked .seat_visual {
-    cursor: not-allowed;
-    background-color: var(--wbtm_color_warning);
-  }
-
-  .seat_in_cart .seat_visual {
-    cursor: not-allowed;
-    background-color: var(--wbtm_color_light_3);
-  }
-
-  /* Override existing seat styling to move visual properties to seat_visual */
-  .mp_seat.seat_available {
-    background-color: transparent !important;
-    border: none !important;
-  }
-
-  .mp_seat.seat_booked {
-    background-color: transparent !important;
-    border: none !important;
-  }
-
-  .mp_seat.seat_in_cart {
-    background-color: transparent !important;
-    border: none !important;
-  }
-
-  /* Ensure seat_visual gets the border styling */
-  .seat_visual {
-    border: 1px solid var(--wbtm_color_border) !important;
-  }
-
-  .seat_number {
-    position: relative;
-    z-index: 2;
-    font-weight: bold;
-    color: inherit;
-    text-align: center;
-    line-height: 1;
-    pointer-events: none;
-    transform: none !important;
-    writing-mode: horizontal-tb !important;
-    text-orientation: mixed !important;
-  }
-
-  /* Ensure consistent seat styling for both lower and upper deck */
-  .wbtm_seat_plan_area table th,
-  .wbtm_seat_plan_area table td {
-    min-height: 60px !important;
-    text-align: center !important;
-    height: 60px !important;
-    width: 60px !important;
-    background-color: var(--wbtm_color_theme_alter) !important;
-    padding: 5px !important;
-    min-width: 60px !important;
-  }
-
-  /* Make upper deck exactly the same as lower deck */
-  .wbtm_seat_plan_upper {
-    /* Inherit all lower deck styles */
-  }
-
-  .wbtm_seat_plan_upper table {
-    margin: 0 auto !important;
-  }
-
-  .wbtm_seat_plan_upper table tr {
-    background-color: var(--wbtm_color_theme_alter) !important;
-  }
-
-  .wbtm_seat_plan_upper table th,
-  .wbtm_seat_plan_upper table td {
-    min-height: 60px !important;
-    text-align: center !important;
-    height: 60px !important;
-    width: 60px !important;
-    background-color: var(--wbtm_color_theme_alter) !important;
-    padding: 5px !important;
-    min-width: 60px !important;
-  }
-
-  .wbtm_seat_plan_upper table thead th {
-    height: auto !important;
-  }
-
-  /* More specific selectors to override global CSS */
-  div.wbtm_bus_list_area div.wbtm_seat_plan_area table th,
-  div.wbtm_bus_list_area div.wbtm_seat_plan_area table td,
-  div.wbtm_bus_list_area div.wbtm_seat_plan_upper table th,
-  div.wbtm_bus_list_area div.wbtm_seat_plan_upper table td {
-    min-height: 60px !important;
-    text-align: center !important;
-    height: 60px !important;
-    width: 60px !important;
-    background-color: var(--wbtm_color_theme_alter) !important;
-    padding: 5px !important;
-    min-width: 60px !important;
-  }
-
-  /* Ensure seat items have consistent styling */
-  .wbtm_seat_plan_area .mp_seat_item,
-  .wbtm_seat_plan_upper .mp_seat_item {
-    position: relative;
-    width: 100%;
-    height: 100%;
-  }
-
-  /* Ensure seats have consistent styling */
-  .wbtm_seat_plan_area .mp_seat,
-  .wbtm_seat_plan_upper .mp_seat {
-    border: 1px solid var(--wbtm_color_border);
-    width: 100%;
-    height: 100%;
-    border-radius: 15px 15px 0 0;
-    border-bottom: 5px solid var(--wbtm_color_light);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-  }
-
-  /* More specific selectors for seat styling - moved visual properties to seat_visual */
-  div.wbtm_bus_list_area div.wbtm_seat_plan_area div.mp_seat,
-  div.wbtm_bus_list_area div.wbtm_seat_plan_upper div.mp_seat {
-    border: none !important;
-    background-color: transparent !important;
-    width: 100% !important;
-    height: 100% !important;
-    display: flex !important;
-    align-items: center !important;
-    justify-content: center !important;
-  }
-
-  /* Apply visual styling to seat_visual instead */
-  div.wbtm_bus_list_area div.wbtm_seat_plan_area div.mp_seat .seat_visual,
-  div.wbtm_bus_list_area div.wbtm_seat_plan_upper div.mp_seat .seat_visual {
-    border: 1px solid var(--wbtm_color_border) !important;
-    border-radius: 15px 15px 0 0 !important;
-    border-bottom: 5px solid var(--wbtm_color_light) !important;
-  }
-
-  /* Force upper deck to use exact same styling as lower deck */
-  .wbtm_seat_plan_upper div.mp_seat_item {
-    position: relative !important;
-    width: 100% !important;
-    height: 100% !important;
-  }
-
-  .wbtm_seat_plan_upper div.mp_seat {
-    border: 1px solid var(--wbtm_color_border) !important;
-    width: 100% !important;
-    height: 100% !important;
-    border-radius: 15px 15px 0 0 !important;
-    border-bottom: 5px solid var(--wbtm_color_light) !important;
-    display: flex !important;
-    align-items: center !important;
-    justify-content: center !important;
-  }
-
-  /* Most aggressive approach - copy exact lower deck styles to upper deck */
-  div.wbtm_bus_list_area div.wbtm_seat_plan_upper table {
-    margin: 0 auto !important;
-  }
-
-  div.wbtm_bus_list_area div.wbtm_seat_plan_upper table tr {
-    background-color: var(--wbtm_color_theme_alter) !important;
-  }
-
-  div.wbtm_bus_list_area div.wbtm_seat_plan_upper table th,
-  div.wbtm_bus_list_area div.wbtm_seat_plan_upper table td {
-    min-height: 60px !important;
-    text-align: center !important;
-    height: 60px !important;
-    width: 60px !important;
-    background-color: var(--wbtm_color_theme_alter) !important;
-    padding: 5px !important;
-    min-width: 60px !important;
-  }
-
-  div.wbtm_bus_list_area div.wbtm_seat_plan_upper table thead th {
-    height: auto !important;
-  }
-
-  div.wbtm_bus_list_area div.wbtm_seat_plan_upper div.mp_seat_item {
-    position: relative !important;
-    width: 100% !important;
-    height: 100% !important;
-  }
-
-  div.wbtm_bus_list_area div.wbtm_seat_plan_upper div.mp_seat {
-    border: none !important;
-    background-color: transparent !important;
-    width: 100% !important;
-    height: 100% !important;
-    display: flex !important;
-    align-items: center !important;
-    justify-content: center !important;
-  }
-
-  /* Ensure seat states are consistent - moved to seat_visual */
-  div.wbtm_bus_list_area div.wbtm_seat_plan_upper div.seat_available {
-    background-color: transparent !important;
-    cursor: pointer !important;
-    color: var(--wbtm_d_color) !important;
-  }
-
-  div.wbtm_bus_list_area div.wbtm_seat_plan_upper div.seat_booked {
-    cursor: not-allowed !important;
-    background-color: transparent !important;
-    color: var(--wbtm_color_theme_alter) !important;
-  }
-
-  div.wbtm_bus_list_area div.wbtm_seat_plan_upper div.seat_in_cart {
-    cursor: not-allowed !important;
-    background-color: transparent !important;
-    color: var(--wbtm_color_theme_alter) !important;
-  }
-
-  /* Apply seat state styling to seat_visual */
-  div.wbtm_bus_list_area div.wbtm_seat_plan_upper div.seat_available .seat_visual {
-    background-color: var(--wbtm_color_theme_alter) !important;
-  }
-
-  div.wbtm_bus_list_area div.wbtm_seat_plan_upper div.seat_booked .seat_visual {
-    background-color: var(--wbtm_color_warning) !important;
-  }
-
-  div.wbtm_bus_list_area div.wbtm_seat_plan_upper div.seat_in_cart .seat_visual {
-    background-color: var(--wbtm_color_light_3) !important;
-  }
-
-  /* ULTIMATE FIX - Force upper deck to be exactly like lower deck */
-  .wbtm_seat_plan_upper * {
-    box-sizing: border-box !important;
-  }
-
-  .wbtm_seat_plan_upper table {
-    table-layout: fixed !important;
-    margin: 0 auto !important;
-  }
-
-  .wbtm_seat_plan_upper table th,
-  .wbtm_seat_plan_upper table td {
-    width: 60px !important;
-    height: 60px !important;
-    min-width: 60px !important;
-    min-height: 60px !important;
-    max-width: 60px !important;
-    max-height: 60px !important;
-    padding: 0 35px !important;
-    margin: 0 !important;
-    border: none !important;
-    background-color: var(--wbtm_color_theme_alter) !important;
-    text-align: center !important;
-    vertical-align: middle !important;
-    box-sizing: border-box !important;
-    font-size: 17px !important;
-  }
-
-  .wbtm_seat_plan_upper .mp_seat_item {
-    width: 60px !important;
-    height: 50px !important;
-    min-width: 60px !important;
-    min-height: 50px !important;
-    max-width: 60px !important;
-    max-height: 50px !important;
-    position: relative !important;
-    margin: 0 !important;
-    padding: 0 !important;
-    box-sizing: border-box !important;
-  }
-
-  .wbtm_seat_plan_upper .mp_seat {
-    width: 60px !important;
-    height: 50px !important;
-    min-width: 60px !important;
-    min-height: 50px !important;
-    max-width: 60px !important;
-    max-height: 50px !important;
-    border: 1px solid var(--wbtm_color_border) !important;
-    border-radius: 15px 15px 0 0 !important;
-    border-bottom: 5px solid var(--wbtm_color_light) !important;
-    display: flex !important;
-    align-items: center !important;
-    justify-content: center !important;
-    margin: 0 !important;
-    padding: 0 !important;
-    box-sizing: border-box !important;
-    font-size: 16px !important;
-    line-height: 1 !important;
-  }
-
-  /* Override any other styles that might be affecting upper deck */
-  .wbtm_seat_plan_upper {
-    font-size: inherit !important;
-  }
-
-  .wbtm_seat_plan_upper * {
-    font-size: inherit !important;
-  }
-
-  /* Force the same dimensions as lower deck */
-  .wbtm_seat_plan_upper table th,
-  .wbtm_seat_plan_upper table td {
-    font-size: 12px !important;
-    line-height: 1 !important;
-  }
-
-  /* Fix seat price dropdown positioning for ALL seat plans */
-  .wbtm_seat_plan_area .mp_seat_item,
-  .wbtm_seat_plan_upper .mp_seat_item,
-  .wbtm_cabin_seat_plan .mp_seat_item {
-    position: relative !important;
-    overflow: visible !important;
-    z-index: 1 !important;
-  }
-
-  /* Increase z-index when hovering to bring tooltip above other seats */
-  .wbtm_seat_plan_area .mp_seat_item:hover,
-  .wbtm_seat_plan_upper .mp_seat_item:hover,
-  .wbtm_cabin_seat_plan .mp_seat_item:hover {
-    z-index: 9999 !important;
-  }
-
-  .wbtm_seat_plan_area .mp_seat_item .wbtm_seat_item_list,
-  .wbtm_seat_plan_upper .mp_seat_item .wbtm_seat_item_list,
-  .wbtm_cabin_seat_plan .mp_seat_item .wbtm_seat_item_list {
-    position: absolute !important;
-    left: 0 !important;
-    top: 100% !important;
-    min-width: 150px !important;
-    width: 100% !important;
-    display: none !important;
-    z-index: 99999 !important;
-    margin: 0 !important;
-    padding: 0 !important;
-    list-style-type: none !important;
-    background-color: var(--wbtm_color_light) !important;
-    border: 1px solid var(--wbtm_color_theme) !important;
-    border-radius: var(--wbtm_dbr) !important;
-    box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1) !important;
-  }
-
-  .wbtm_seat_plan_area .mp_seat_item:hover .wbtm_seat_item_list,
-  .wbtm_seat_plan_upper .mp_seat_item:hover .wbtm_seat_item_list,
-  .wbtm_cabin_seat_plan .mp_seat_item:hover .wbtm_seat_item_list {
-    display: block !important;
-  }
-
-  .wbtm_seat_plan_area .mp_seat_item .wbtm_seat_item_list::before,
-  .wbtm_seat_plan_upper .mp_seat_item .wbtm_seat_item_list::before,
-  .wbtm_cabin_seat_plan .mp_seat_item .wbtm_seat_item_list::before {
-    position: absolute !important;
-    content: "" !important;
-    width: 20px !important;
-    height: 20px !important;
-    left: 15px !important;
-    top: -20px !important;
-    border: 10px solid transparent !important;
-    border-bottom-color: var(--wbtm_color_theme) !important;
-    z-index: 99998 !important;
-  }
-
-  .wbtm_seat_plan_area .mp_seat_item .wbtm_seat_item_list li,
-  .wbtm_seat_plan_upper .mp_seat_item .wbtm_seat_item_list li,
-  .wbtm_cabin_seat_plan .mp_seat_item .wbtm_seat_item_list li {
-    cursor: pointer !important;
-    padding: 5px var(--wbtm_dmp_xs) !important;
-    background-color: var(--wbtm_color_light) !important;
-    border-bottom: 1px solid #eee !important;
-    position: relative !important;
-    z-index: 99999 !important;
-  }
-
-  .wbtm_seat_plan_area .mp_seat_item .wbtm_seat_item_list li:last-child,
-  .wbtm_seat_plan_upper .mp_seat_item .wbtm_seat_item_list li:last-child,
-  .wbtm_cabin_seat_plan .mp_seat_item .wbtm_seat_item_list li:last-child {
-    border-bottom: none !important;
-  }
-
-  .wbtm_seat_plan_area .mp_seat_item .wbtm_seat_item_list li:hover,
-  .wbtm_seat_plan_upper .mp_seat_item .wbtm_seat_item_list li:hover,
-  .wbtm_cabin_seat_plan .mp_seat_item .wbtm_seat_item_list li:hover {
-    background-color: var(--wbtm_color_theme) !important;
-    color: var(--wbtm_color_theme_alter) !important;
-  }
-
-  /* Fix positioning for seats on the right side */
-  .wbtm_seat_plan_area table tr th:nth-last-child(2) .wbtm_seat_item_list,
-  .wbtm_seat_plan_area table tr th:last-child .wbtm_seat_item_list,
-  .wbtm_seat_plan_upper table tr th:nth-last-child(2) .wbtm_seat_item_list,
-  .wbtm_seat_plan_upper table tr th:last-child .wbtm_seat_item_list,
-  .wbtm_cabin_seat_plan table tr th:nth-last-child(2) .wbtm_seat_item_list,
-  .wbtm_cabin_seat_plan table tr th:last-child .wbtm_seat_item_list {
-    right: 0 !important;
-    left: inherit !important;
-  }
-
-  .wbtm_seat_plan_area table tr th:nth-last-child(2) .wbtm_seat_item_list::before,
-  .wbtm_seat_plan_area table tr th:last-child .wbtm_seat_item_list::before,
-  .wbtm_seat_plan_upper table tr th:nth-last-child(2) .wbtm_seat_item_list::before,
-  .wbtm_seat_plan_upper table tr th:last-child .wbtm_seat_item_list::before,
-  .wbtm_cabin_seat_plan table tr th:nth-last-child(2) .wbtm_seat_item_list::before,
-  .wbtm_cabin_seat_plan table tr th:last-child .wbtm_seat_item_list::before {
-    left: inherit !important;
-    right: 15px !important;
-  }
-
-  /* Fix positioning for seats on the bottom rows */
-  .wbtm_seat_plan_area table tr:nth-last-child(2) th .wbtm_seat_item_list,
-  .wbtm_seat_plan_area table tr:last-child th .wbtm_seat_item_list,
-  .wbtm_seat_plan_upper table tr:nth-last-child(2) th .wbtm_seat_item_list,
-  .wbtm_seat_plan_upper table tr:last-child th .wbtm_seat_item_list,
-  .wbtm_cabin_seat_plan table tr:nth-last-child(2) th .wbtm_seat_item_list,
-  .wbtm_cabin_seat_plan table tr:last-child th .wbtm_seat_item_list {
-    top: calc(-100% - 23px) !important;
-  }
-
-  .wbtm_seat_plan_area table tr:nth-last-child(2) th .wbtm_seat_item_list::before,
-  .wbtm_seat_plan_area table tr:last-child th .wbtm_seat_item_list::before,
-  .wbtm_seat_plan_upper table tr:nth-last-child(2) th .wbtm_seat_item_list::before,
-  .wbtm_seat_plan_upper table tr:last-child th .wbtm_seat_item_list::before,
-  .wbtm_cabin_seat_plan table tr:nth-last-child(2) th .wbtm_seat_item_list::before,
-  .wbtm_cabin_seat_plan table tr:last-child th .wbtm_seat_item_list::before {
-    top: 100% !important;
-    border-top-color: var(--wbtm_color_theme) !important;
-    border-bottom-color: transparent !important;
-  }
-
-  /* Ensure containers don't clip the dropdown */
-  .wbtm_seat_plan_area,
-  .wbtm_seat_plan_upper,
-  .wbtm_cabin_seat_plan {
-    overflow: visible !important;
-    position: relative !important;
-  }
-
-  .wbtm_seat_plan_area .ovAuto,
-  .wbtm_seat_plan_upper .ovAuto,
-  .wbtm_cabin_seat_plan .ovAuto {
-    overflow: visible !important;
-  }
-
-  /* Cabin-specific styles for train/bus multi-cabin support */
-  .wbtm_cabin_section {
-    margin-bottom: 15px;
-    border: 2px solid var(--wbtm_color_border);
-    border-radius: 8px;
-    background-color: var(--wbtm_color_light);
-    overflow: hidden;
-  }
-
-  .wbtm_cabin_section:last-child {
-    margin-bottom: 0;
-  }
-
-  /* Ensure collapsed cabins don't take extra space */
-  .wbtm_cabin_section.collapsed {
-    margin-bottom: 10px;
-  }
-
-  .wbtm_cabin_header {
-    background-color: var(--wbtm_color_theme);
-    color: white;
-    padding: 15px 20px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    user-select: none;
-  }
-
-  .wbtm_cabin_toggle {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    width: 100%;
-  }
-
-  .wbtm_cabin_title_container {
-    display: flex;
-    align-items: center;
-    gap: 15px;
-  }
-
-  .wbtm_cabin_toggle_icon {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 30px;
-    height: 30px;
-  }
-
-  .wbtm_toggle_arrow {
-    font-size: 16px;
-    font-weight: bold;
-    transition: transform 0.3s ease;
-    display: inline-block;
-  }
-
-  .wbtm_cabin_title_container .wbtm_cabin_title {
-    margin: 0;
-    font-size: 18px;
-    font-weight: 600;
-  }
-
-  .wbtm_cabin_price_info {
-    display: flex;
-    align-items: center;
-  }
-
-  .wbtm_price_multiplier {
-    background-color: rgba(255, 255, 255, 0.2);
-    color: white;
-    padding: 4px 8px;
-    border-radius: 12px;
-    font-size: 12px;
-    font-weight: 500;
-  }
-
-  .wbtm_price_discount {
-    background-color: rgba(76, 175, 80, 0.8);
-    color: white;
-    padding: 4px 8px;
-    border-radius: 12px;
-    font-size: 12px;
-    font-weight: 500;
-  }
-
-  .wbtm_cabin_seat_plan {
-    padding: 20px;
-    background-color: white;
-  }
-
-  .wbtm_cabin_seat_plan table {
-    margin: 0 auto;
-    border-collapse: separate;
-    border-spacing: 8px;
-  }
-
-  .wbtm_cabin_seat_plan .mp_seat_item {
-    position: relative;
-  }
-
-  .wbtm_cabin_direction {
-    text-align: center;
-    color: var(--wbtm_color_theme);
-    font-weight: 500;
-    margin-bottom: 10px;
-  }
-
-  .wbtm_cabin_separator {
-    height: 2px;
-    background: linear-gradient(90deg, transparent 0%, var(--wbtm_color_border) 50%, transparent 100%);
-    margin: 20px 0;
-  }
-
-  .wbtm_cabin_seat_plan .seat_available {
-    cursor: pointer;
-    transition: all 0.3s ease;
-  }
-
-  .wbtm_cabin_seat_plan .seat_available:hover {
-    transform: translateY(-2px);
-    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.15);
-  }
-
-  .wbtm_cabin_seat_plan .seat_booked,
-  .wbtm_cabin_seat_plan .seat_in_cart {
-    opacity: 0.7;
-  }
-
-
-  .wbtm_search_input_fields_holder {
-    display: flex;
-    width: 100%;
-    gap: 5px;
-  }
-
-  .wbtm_input_start_end_location {
-    position: relative;
-    display: flex;
-    align-items: center;
-  }
-
-  .wbtm_start_point,
-  .wbtm_dropping_point {
-    width: 50%;
-  }
-
-  .wbtm_search_location_toggle {
-    position: absolute;
-    margin: 9px -4px;
-    top: 60%;
-    left: 50%;
-    transform: translate(-50%, -50%);
-    z-index: 2;
-    padding: 5px 7px;
-    width: 30px;
-    height: 30px;
-    background-color: #ddd;
-    border-radius: 50%;
-    border: 1px solid #bbb;
-    cursor: pointer;
-    box-shadow: 0 0 5px rgba(50, 50, 50, 0.3);
-  }
-
-  .wbtm_search_location_toggle:hover {
-    background: var(--wbtm_color_theme);
-    border: 1px solid rgba(50, 50, 50, 0.3);
-  }
-
-  .wbtm_search_location_toggle:hover i {
-    color: #fff;
-  }
-
-  .wbtm_search_location_toggle i {
-    font-size: 15px;
-    line-height: 0;
-    transition: transform 0.35s ease;
-    color: var(--wbtm_color_theme);
-  }
-
-  .wbtm_search_location_toggle.rotate i {
-    transform: rotate(180deg);
-  }
-
-  .swap-animation {
-    transition: all .3s ease-in-out;
-    transform: translateY(6px);
-    opacity: 0.6;
-  }
-
-  .wbtm_input_fields_holder {
-    display: flex;
-    width: calc(100% - 140px);
-  }
-
-  .wtbm_bus_search_button_holder {
-    display: flex;
-    justify-content: center;
-  }
-
-  .wbtm_input_start_end_location,
-  .wbtm_input_start_end_date {
-    display: flex;
-    width: 50%;
-    position: relative;
-  }
-
->>>>>>> master
   .wbtm-bus-flix-style {
     display: flex;
     flex-direction: column;
@@ -2649,5 +1801,287 @@ div.wbtm_bus_list_area div.wbtm_seat_plan_upper div.seat_in_cart .seat_visual {
   }
   .wbtm_non_seat_item .wbtm_non_seat_label {
     font-size: 8px;
+  }
+}
+
+/* ============================================================
+   COMPREHENSIVE MOBILE RESPONSIVE FIXES
+   ============================================================ */
+
+/* ---- Search form layout ---- */
+._dFlex_fdColumn_justifyBetween_fullHeight {
+  display: flex;
+  flex-direction: column;
+  justify-content: flex-end;
+  width: 100%;
+}
+/* Hide the blank spacer above the search button — alignment handled by flex-end */
+._dFlex_fdColumn_justifyBetween_fullHeight > span:first-child {
+  display: none !important;
+}
+
+@media only screen and (max-width: 960px) {
+  /* Stack search form fields vertically */
+  .wbtm_search_input_fields_holder {
+    flex-direction: column !important;
+    align-items: stretch !important;
+  }
+  .wbtm_input_fields_holder {
+    flex: 1 1 auto !important;
+    flex-direction: column !important;
+    gap: 10px !important;
+    width: 100% !important;
+  }
+  .wbtm_input_start_end_location,
+  .wbtm_input_start_end_date {
+    width: 100% !important;
+    flex-direction: row;
+  }
+  .wtbm_bus_search_button_holder {
+    flex: 0 0 auto !important;
+    width: 100% !important;
+  }
+  ._dFlex_fdColumn_justifyBetween_fullHeight {
+    width: 100% !important;
+  }
+  .wbtm_bus_submit,
+  .get_wbtm_bus_list {
+    width: 100% !important;
+    justify-content: center !important;
+    padding: 12px !important;
+  }
+}
+
+@media only screen and (max-width: 600px) {
+  /* Stack From/To on very small screens */
+  .wbtm_input_start_end_location,
+  .wbtm_input_start_end_date {
+    flex-direction: column !important;
+    gap: 8px !important;
+  }
+  .wtbm_inputList {
+    width: 100% !important;
+    margin: 0 !important;
+  }
+  /* Swap icon repositioned */
+  .wbtm_search_location_toggle {
+    position: static !important;
+    transform: rotate(90deg) !important;
+    margin: 4px auto !important;
+    left: auto !important;
+    top: auto !important;
+  }
+  /* Search form padding */
+  ._dLayout.wbtm_search_area {
+    padding: 12px !important;
+  }
+  .wbtm_style {
+    padding: 8px !important;
+  }
+}
+
+/* ---- Seat plan: scrollable on mobile ---- */
+.wbtm_seat_plan_holder,
+.wbtm_seat_plan_area,
+.wbtm_seat_plan_upper {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+}
+
+@media only screen and (max-width: 600px) {
+  /* Smaller seat cells on phones */
+  .wbtm_seat_plan_area table th,
+  .wbtm_seat_plan_area table td,
+  div.wbtm_bus_list_area div.wbtm_seat_plan_area table th,
+  div.wbtm_bus_list_area div.wbtm_seat_plan_area table td,
+  .wbtm_seat_plan_upper table th,
+  .wbtm_seat_plan_upper table td,
+  div.wbtm_bus_list_area div.wbtm_seat_plan_upper table th,
+  div.wbtm_bus_list_area div.wbtm_seat_plan_upper table td,
+  .wbtm_cabin_seat_plan table th,
+  .wbtm_cabin_seat_plan table td {
+    width: 44px !important;
+    min-width: 44px !important;
+    height: 44px !important;
+    min-height: 44px !important;
+    padding: 3px !important;
+  }
+  .seat_number {
+    font-size: 10px !important;
+  }
+}
+
+/* ---- Date suggestion bar: horizontal scroll ---- */
+.wbtm-date-suggetion {
+  display: flex !important;
+  flex-wrap: nowrap !important;
+  overflow-x: auto !important;
+  -webkit-overflow-scrolling: touch;
+  gap: 6px;
+  padding-bottom: 4px;
+}
+.wbtm-date-suggetion .wbtm_next_date {
+  flex-shrink: 0 !important;
+  white-space: nowrap;
+}
+
+/* ---- Search results: bus list cards ---- */
+@media only screen and (max-width: 768px) {
+  .wbtm_search_result .wbtm-bus-list {
+    flex-direction: column !important;
+  }
+  .wbtm_search_result .wbtm-bus-list .wbtm-bus-image {
+    width: 100% !important;
+    height: 180px !important;
+    border-radius: 12px 12px 0 0 !important;
+  }
+  .wbtm_bus_info_details_holder {
+    width: 100% !important;
+  }
+  /* Route info container stacks */
+  .wbtm_search_route_container {
+    flex-direction: column !important;
+  }
+  .wbtm_search_route_cities_wrapper {
+    width: 100% !important;
+    flex-wrap: wrap;
+  }
+  .wbtm_search_route_icon_wrapper {
+    display: none !important;
+  }
+  .wbtm_search_route_city_section,
+  .wbtm_search_route_city_section_right {
+    width: 48% !important;
+    padding: 6px !important;
+  }
+  /* Bus info row stacks vertically */
+  .wbtm_bus_info_holder {
+    flex-direction: column !important;
+    gap: 8px;
+  }
+  /* Force all bus card children full width when stacked */
+  .wbtm_search_result .wbtm-bus-list .wbtm-bus-name,
+  .wbtm_search_result .wbtm-bus-route,
+  .wbtm_search_result .wbtm-bus-list .wbtm-seat-info {
+    width: 100% !important;
+    border-right: 0 !important;
+    border-top: 0 !important;
+  }
+  /* Show seat-info divs side by side (price + seats) */
+  .wbtm_bus_info_holder .wbtm-seat-info {
+    width: 50% !important;
+    display: inline-flex !important;
+    vertical-align: top;
+  }
+  /* Route display in flix-style */
+  .wbtm-bus-flix-style {
+    flex-direction: column !important;
+  }
+  .wbtm-bus-flix-style .title,
+  .wbtm-bus-flix-style .route,
+  .wbtm-bus-flix-style .feature,
+  .wbtm-bus-flix-style .price {
+    width: 100% !important;
+  }
+  /* Date-route header wraps */
+  .wbtm_search_result .wbtm-date-route,
+  .wbtm-date-return-route {
+    flex-direction: column !important;
+    gap: 8px;
+    align-items: flex-start !important;
+  }
+  /* Tabs scroll horizontally */
+  .wbtm_bus_detail_popup_tabs {
+    overflow-x: auto !important;
+    flex-wrap: nowrap !important;
+    -webkit-overflow-scrolling: touch;
+  }
+  .wbtm_bus_detail_popup_tab {
+    flex-shrink: 0 !important;
+  }
+}
+
+/* ---- Popup / modal on mobile ---- */
+@media only screen and (max-width: 768px) {
+  .wbtm-bus-popup-inner {
+    width: 95% !important;
+    margin: 3% auto !important;
+    padding: 14px !important;
+    border-radius: 8px !important;
+  }
+  .wbtm-popup-content {
+    max-width: 100% !important;
+  }
+}
+
+/* ---- Registration / passenger form ---- */
+@media only screen and (max-width: 768px) {
+  .wbtm_registration_area,
+  .wbtm_selected_seat_details {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+  .wbtm_selected_seat_details table {
+    min-width: 320px;
+  }
+  /* Totals table */
+  table.wbtm_totals {
+    width: 100% !important;
+  }
+  /* Passenger form fields full width */
+  .wbtm_passenger_form_area .col_6,
+  .wbtm_passenger_form_area .col_4,
+  .wbtm_passenger_form_area .col_3 {
+    width: 100% !important;
+    min-width: 100% !important;
+  }
+}
+
+/* ---- Left filter panel ---- */
+@media only screen and (max-width: 768px) {
+  .wbtm_bus_left_filter_holder {
+    width: 100% !important;
+    margin-bottom: 12px;
+  }
+  .wbtm_bus_list_area {
+    flex-direction: column !important;
+  }
+  .wbtm_bus_list_holder {
+    width: 100% !important;
+  }
+}
+
+/* ---- Bus details tabs ---- */
+@media only screen and (max-width: 768px) {
+  .wbtm_bus_details_tabs_holder {
+    overflow-x: auto !important;
+    flex-wrap: nowrap !important;
+    -webkit-overflow-scrolling: touch;
+    padding: 5px;
+  }
+  .wbtm_bus_details_tabs_holder > * {
+    flex-shrink: 0;
+  }
+}
+
+/* ---- Single bus feature image ---- */
+@media only screen and (max-width: 600px) {
+  .wbtm_car_details_feature_image {
+    width: 100% !important;
+    max-width: 100% !important;
+  }
+  .wbtm_car_details_gallery img {
+    width: 70px !important;
+    height: 56px !important;
+  }
+}
+
+/* ---- General overflow guard ---- */
+@media only screen and (max-width: 768px) {
+  .wbtm_style {
+    overflow-x: hidden;
+  }
+  #wbtm_area {
+    overflow-x: hidden;
   }
 }

--- a/assets/frontend/wtbm_search.css
+++ b/assets/frontend/wtbm_search.css
@@ -349,3 +349,65 @@
     }
 }
 @media (min-width: 1240px) {}
+
+/* ---- Mobile fixes for search results ---- */
+@media only screen and (max-width: 768px) {
+    /* Popup inner full-width on mobile */
+    .wbtm-bus-popup-inner {
+        width: 95% !important;
+        margin: 3% auto !important;
+        padding: 14px !important;
+        max-height: 90vh;
+    }
+    .wbtm-popup-content {
+        max-width: 100% !important;
+    }
+    /* Popup tab bar scrolls horizontally */
+    .wbtm_bus_detail_popup_tabs {
+        overflow-x: auto !important;
+        flex-wrap: nowrap !important;
+        -webkit-overflow-scrolling: touch;
+    }
+    .wbtm_bus_detail_popup_tab {
+        flex-shrink: 0 !important;
+    }
+    /* Bus popup links always visible on touch */
+    .wbtm_bus_list_area .wbtm_bus_popup_links {
+        visibility: visible !important;
+        opacity: 1 !important;
+        transform: scale(1) !important;
+    }
+    /* Route search result header */
+    .wbtm_search_result .wbtm-date-route,
+    .wbtm-date-return-route {
+        flex-direction: column;
+        align-items: flex-start;
+        gap: 6px;
+        padding: 10px;
+    }
+    /* Tab switcher full width on mobile */
+    .wbtm_bus_tab_wrapper {
+        gap: 6px;
+        padding: 2px;
+    }
+    .wbtm_bus_tab_wrapper .wtbm_start_route,
+    .wbtm_bus_tab_wrapper .wtbm_return_route {
+        padding: 10px 8px;
+        font-size: 13px;
+    }
+}
+
+@media only screen and (max-width: 480px) {
+    /* Route city sections side by side on small phones */
+    .wbtm_search_route_city_section,
+    .wbtm_search_route_city_section_right {
+        width: 50% !important;
+        padding: 6px !important;
+    }
+    .wbtm_search_route_label {
+        font-size: 12px;
+    }
+    .wbtm_search_route_city {
+        font-size: 11px;
+    }
+}

--- a/assets/frontend/wtbm_single_bus_details.css
+++ b/assets/frontend/wtbm_single_bus_details.css
@@ -1,6 +1,7 @@
 /* ===== FEATURE IMAGE ===== */
 .wbtm_car_details_feature_image {
-    width: 400px;
+    width: 100%;
+    max-width: 400px;
     margin: auto;
     border-radius: 10px;
     border: 1px solid #ddd;

--- a/assets/global/wbtm_global.css
+++ b/assets/global/wbtm_global.css
@@ -1,6 +1,25 @@
 /********************************************************************************************************************/
 @media only screen and (min-width: 10px) {
-  div.wbtm_container {    width: 100%;    max-width: 1200px;    margin: var(--wbtm_dmp) auto;  }
+  /* Break out of WordPress block theme narrow content width (e.g. Twenty Twenty-Five contentSize: 645px).
+     Falls back to width:100% / margin:0 on classic themes that don't define these variables. */
+  div.wbtm_container {
+    width: var(--wp--style--global--wide-size, 100%);
+    max-width: var(--wp--style--global--wide-size, 1200px);
+    margin-top: var(--wbtm_dmp);
+    margin-bottom: var(--wbtm_dmp);
+    margin-left: calc((var(--wp--style--global--content-size, 100%) - var(--wp--style--global--wide-size, 100%)) / 2);
+    margin-right: auto;
+  }
+}
+/* On mobile collapse the breakout — full width, no negative margin */
+@media only screen and (max-width: 768px) {
+  div.wbtm_container {
+    width: 100% !important;
+    max-width: 100% !important;
+    margin-left: 0 !important;
+    margin-right: 0 !important;
+    box-sizing: border-box;
+  }
 }
 /********************************************************************************************************************/
 @media only screen and (min-width: 10px) {

--- a/woocommerce-bus.php
+++ b/woocommerce-bus.php
@@ -3,7 +3,7 @@
 	 * Plugin Name: Bus Ticket Booking with Seat Reservation
 	 * Plugin URI: http://mage-people.com
 	 * Description: A Complete Bus Ticketing System for WordPress & WooCommerce
-	 * Version: 5.6.9
+	 * Version: 5.7.0
 	 * Author: MagePeople Team
 	 * Author URI: http://www.mage-people.com/
 	 * Text Domain: bus-ticket-booking-with-seat-reservation


### PR DESCRIPTION
## Problem
- assets/frontend/wbtm.css had an unresolved git merge conflict spanning lines 258–2092 (<<<<<<< HEAD / ======= / >>>>>>> master markers), which silently broke ALL CSS rules in that range including the search form flex layout and bus card layout.
- The plugin was not mobile responsive: search form, search results, seat plan, registration form, and popup were all broken on narrow screens.
- The search form container was constrained to 645 px by the Twenty Twenty-Five block theme's contentSize CSS variable.
- The "Search" button was misaligned (floating outside / above the input row) due to broken flex rules caused by the merge conflict.
- On mobile, the bus result cards used a 50%/50% two-column grid that broke badly when both departure and return journeys were shown.

## Changes

### assets/frontend/wbtm.css
- Resolved git merge conflict: kept HEAD section, removed ======= through
  >>>>>>> master block (~850 lines of duplicate/conflicting rules removed).
- Fixed search form flex layout: .wbtm_search_input_fields_holder  → align-items: flex-end
    .wbtm_input_fields_holder         → flex: 1 1 auto; min-width: 0
      (was width: calc(100% - 140px) which overflowed the flex container)
    .wtbm_bus_search_button_holder    → flex: 0 0 auto; align-items: flex-end
- Added class ._dFlex_fdColumn_justifyBetween_fullHeight used by the date
  picker label/spacer so the button aligns to the bottom of all inputs.
- Added comprehensive mobile responsive section (≤960 px, ≤768 px, ≤600 px,
  ≤480 px) covering:
    • Search form: stacks vertically, inputs full width, button full width
    • Seat plan: overflow-x: auto so the seat grid scrolls horizontally
    • Date suggestion bar: horizontal scroll on mobile
    • Bus result cards: flex-direction column, all children width 100%,
      seat-info pair kept side-by-side at 50% each
    • Popup / modal: 95% width, reduced padding
    • Registration / passenger form: fields stack to full width
    • Left filter panel: stacks above bus list
    • Bus details tabs: overflow-x scroll, no wrap
    • Single bus feature image: 100% width on small phones

### assets/frontend/wtbm_search.css
- Added mobile section (≤768 px, ≤480 px): • Popup inner full width (95%), reduced padding • Popup tab bar scrolls horizontally (flex-wrap: nowrap) • Bus popup action links always visible on touch devices (visibility: visible !important — hover-only was unusable on touch) • Route header (date-route, return-route) wraps to column on mobile • Tab switcher (departure / return) smaller padding and font on mobile

### assets/frontend/wtbm_single_bus_details.css
- .wbtm_car_details_feature_image: changed fixed width: 400px to width: 100%; max-width: 400px so the image is responsive.

### assets/global/wbtm_global.css
- div.wbtm_container: added CSS-variable-based breakout from TT5's 645 px content constraint: width: var(--wp--style--global--wide-size, 100%) max-width: var(--wp--style--global--wide-size, 1200px)
    margin-left: calc((content-size - wide-size) / 2)   ← negative offset
  Falls back gracefully to width: 100% / margin: 0 on classic themes.
- Added mobile collapse override (≤768 px) resetting width to 100% and
  clearing the negative margin so the container does not overflow on phones.

### woocommerce-bus.php
- Bumped plugin version: 5.6.9 → 5.7.0