### PR TITLE
Fix return-bus Details/Stops/Features popup not opening after outbound selection

### DIFF
--- a/assets/frontend/wtbm_single_bus_details.js
+++ b/assets/frontend/wtbm_single_bus_details.js
@@ -152,11 +152,25 @@ jQuery(document).ready(function ($) {
     });
 
     // ===== AJAX POPUP FOR BUS DETAILS =====
+    // NOTE: the search_result template (which holds #wbtm-bus-popup) is rendered
+    // once for the outbound list and once for the return list, so #wbtm-bus-popup
+    // exists twice in the DOM. A global $('#wbtm-bus-popup') only ever matches the
+    // first (outbound) one, which gets hidden once an outbound bus is selected --
+    // that is why the return-trip Details/Stops/Features buttons stopped working.
+    // Scope every popup lookup to the holder the clicked link actually lives in.
+    function wbtm_get_popup_for($el) {
+        let $scope = $el.closest('.wbtm_search_result_holder');
+        let $popup = $scope.find('#wbtm-bus-popup');
+        return $popup.length ? $popup : $('#wbtm-bus-popup').first();
+    }
+
     $(document).on('click','.wbtm_bus_popup_link', function () {
         let post_id = $(this).data('post-id');
         let tab_id = $(this).attr('id');
-        $('#wbtm-bus-popup').fadeIn();
-        $('.wbtm-popup-content').html('<p>Loading...</p>');
+        let $popup = wbtm_get_popup_for($(this));
+        let $content = $popup.find('.wbtm-popup-content');
+        $popup.fadeIn();
+        $content.html('<p>Loading...</p>');
 
         $.ajax({
             url: wbtm_ajax_url,
@@ -167,11 +181,11 @@ jQuery(document).ready(function ($) {
                 nonce: wbtm_nonce,
             },
             success: function (response) {
-                $('.wbtm-popup-content').html(response);
-                $('.wbtm_bus_detail_popup_tab').removeClass('active');
-                $('.wbtm_bus_popup_holder').removeClass('active');
-                $('#' + tab_id + '_popup_tab').addClass('active').trigger('click');
-                $("#" + tab_id + '_content').addClass('active').show();
+                $content.html(response);
+                $content.find('.wbtm_bus_detail_popup_tab').removeClass('active');
+                $content.find('.wbtm_bus_popup_holder').removeClass('active');
+                $content.find('#' + tab_id + '_popup_tab').addClass('active').trigger('click');
+                $content.find('#' + tab_id + '_content').addClass('active').show();
             }
         });
     });
@@ -179,19 +193,21 @@ jQuery(document).ready(function ($) {
     // Close popup
     $(document).on('click', '.wbtm-popup-close, #wbtm-bus-popup', function (e) {
         if ($(e.target).is('#wbtm-bus-popup, .wbtm-popup-close')) {
-            $('#wbtm-bus-popup').fadeOut();
+            $(e.target).closest('#wbtm-bus-popup').fadeOut();
         }
     });
 
     // popup tabs target content
     $(document).on('click', '.wbtm_bus_detail_popup_tab', function () {
-        $('.wbtm_bus_detail_popup_tab').removeClass('active');
-        $('.wbtm_bus_popup_holder').removeClass('active');
-        $('.wbtm_bus_popup_holder').hide();
+        let $content = $(this).closest('.wbtm-popup-content');
+        let $scope = $content.length ? $content : $(document);
+        $scope.find('.wbtm_bus_detail_popup_tab').removeClass('active');
+        $scope.find('.wbtm_bus_popup_holder').removeClass('active');
+        $scope.find('.wbtm_bus_popup_holder').hide();
         $(this).addClass('active');
         let targetId = $(this).data('tab-id');
         if (targetId) {
-            let $target = $('#' + targetId);
+            let $target = $scope.find('#' + targetId);
             if ($target.length) {
                 $target.addClass('active');
                 $target.show();


### PR DESCRIPTION


The bus details popup (Details / Stops / Features buttons) stopped working for return-trip buses once an outbound bus was selected. Before selecting an outbound bus the same buttons worked correctly.

Root cause
----------
The search_result template (and search_result_flix) holds the popup overlay markup `<div id="wbtm-bus-popup">`. That template is rendered twice on the search results page: once for the outbound list (nested inside #start_bus) and once for the return list. This puts TWO elements with the same id="wbtm-bus-popup" into the DOM.

The click handler used a global lookup, `$('#wbtm-bus-popup').fadeIn()`. With a duplicated id, jQuery only ever returns the FIRST match -- the popup inside the outbound #start_bus container.

- Before selecting an outbound bus, #start_bus is visible, so the first popup shows and the buttons appear to work.
- After selecting an outbound bus, wtbm_active_return_bus_tab_data() runs $('#start_bus').fadeOut(), hiding that first popup's parent. Clicking a return bus's Details/Stops/Features button still fades in the same hidden-parent popup, so nothing appears on screen.

The same duplicate-id flaw also affected the close handler and the AJAX success/tab lookups (`$('#' + tab_id + ...)`), which silently targeted the wrong (hidden) copy.

Fix
---
Scope every popup operation to the .wbtm_search_result_holder that the clicked link actually lives in, instead of relying on the global (duplicated) id:

- Open: resolve #wbtm-bus-popup within the clicked link's own holder and operate on that popup's .wbtm-popup-content.
- AJAX success: scope the _popup_tab / _content activation to that popup content.
- Close: fade out the popup closest to the actual click target.
- Tab switching: scope the active/show toggles to the popup content the tab belongs to.

This wrapper (.wbtm_search_result_holder) exists in both search_result.php and search_result_flix.php, so the fix covers the global search results page in both layout styles, for outbound and return buses alike. The handler is enqueued on all frontend pages via frontend_enqueue(), so no template changes are required.

Note: the duplicated id="wbtm-bus-popup" is still invalid HTML; a future follow-up could render that popup markup once outside both lists. This change resolves the reported symptom without touching the templates.