### PR TITLE
feat(admin): add responsive Bus List design with grid/table, filters ……& trash

### DIFF
--- a/admin/WBTM_Admin.php
+++ b/admin/WBTM_Admin.php
@@ -57,6 +57,7 @@
 
 				//=====================//
 				require_once WBTM_PLUGIN_DIR . '/admin/WBTM_Welcome.php';
+				require_once WBTM_PLUGIN_DIR . '/admin/WBTM_Bus_List.php';
 				require_once WBTM_PLUGIN_DIR . '/admin/WBTM_Status.php';
 				require_once WBTM_PLUGIN_DIR . '/admin/WBTM_Dummy_Import.php';
 				require_once WBTM_PLUGIN_DIR . '/admin/WBTM_Analytics_Dashboard.php';

--- a/admin/WBTM_Bus_List.php
+++ b/admin/WBTM_Bus_List.php
@@ -1,0 +1,465 @@
+<?php
+	/*
+   * @Author 		engr.sumonazma@gmail.com
+   * Copyright: 	mage-people.com
+   */
+	if ( ! defined( 'ABSPATH' ) ) {
+		die;
+	} // Cannot access pages directly.
+	if ( ! class_exists( 'WBTM_Bus_List' ) ) {
+		/**
+		 * New responsive card/table design for the Bus fleet list screen.
+		 *
+		 * Controlled by the global setting "New Bus List Design" (General Settings).
+		 * When enabled the default edit.php?post_type=wbtm_bus list is replaced by a
+		 * fully responsive grid/table view. When disabled the classic WordPress list
+		 * table is shown, so the toggle works in both directions without side effects.
+		 */
+		class WBTM_Bus_List {
+			const PAGE_SLUG = 'wbtm_bus_list';
+
+			public function __construct() {
+				add_filter( 'wbtm_filter_general_settings', [ $this, 'register_setting' ] );
+				add_action( 'admin_menu', [ $this, 'register_page' ] );
+				add_action( 'load-edit.php', [ $this, 'maybe_redirect_to_new_design' ] );
+				add_action( 'admin_enqueue_scripts', [ $this, 'enqueue_assets' ] );
+				add_filter( 'parent_file', [ $this, 'highlight_menu' ] );
+				add_filter( 'submenu_file', [ $this, 'highlight_submenu' ] );
+				add_filter( 'admin_title', [ $this, 'admin_title' ], 10, 2 );
+			}
+
+			/**
+			 * Set the browser tab title on the orphan list page (WordPress can't
+			 * resolve it automatically because the page has no parent menu entry).
+			 */
+			public function admin_title( $admin_title, $title ) {
+				if ( ( $_GET['page'] ?? '' ) !== self::PAGE_SLUG ) {
+					return $admin_title;
+				}
+				$is_trash = isset( $_GET['wbtm_status'] ) && sanitize_text_field( wp_unslash( $_GET['wbtm_status'] ) ) === 'trash';
+				$label    = WBTM_Functions::get_name() . ' ' . esc_html__( 'Lists', 'bus-ticket-booking-with-seat-reservation' );
+				if ( $is_trash ) {
+					$label = esc_html__( 'Trash', 'bus-ticket-booking-with-seat-reservation' ) . ' - ' . $label;
+				}
+
+				return $label . ' &lsaquo; ' . get_bloginfo( 'name' ) . ' &#8212; WordPress';
+			}
+
+			/**
+			 * Keep the Bus CPT top menu open while viewing the orphan page.
+			 */
+			public function highlight_menu( $parent_file ) {
+				global $pagenow;
+				if ( $pagenow === 'admin.php' && ( $_GET['page'] ?? '' ) === self::PAGE_SLUG ) {
+					return 'edit.php?post_type=wbtm_bus';
+				}
+
+				return $parent_file;
+			}
+
+			public function highlight_submenu( $submenu_file ) {
+				if ( ( $_GET['page'] ?? '' ) === self::PAGE_SLUG ) {
+					return 'edit.php?post_type=wbtm_bus';
+				}
+
+				return $submenu_file;
+			}
+
+			/**
+			 * Whether the new design is currently turned on.
+			 */
+			public static function is_enabled(): bool {
+				return WBTM_Global_Function::get_settings( 'wbtm_general_settings', 'new_bus_list_design', 'enable' ) === 'enable';
+			}
+
+			/**
+			 * Append the enable/disable toggle to the General settings tab.
+			 */
+			public function register_setting( $fields ) {
+				$fields[] = array(
+					'name'    => 'new_bus_list_design',
+					'label'   => esc_html__( 'New Bus List Design', 'bus-ticket-booking-with-seat-reservation' ),
+					'desc'    => esc_html__( 'Enable the new responsive card/table design for the bus list screen. Disable to use the classic WordPress list.', 'bus-ticket-booking-with-seat-reservation' ),
+					'type'    => 'select',
+					'default' => 'enable',
+					'options' => array(
+						'enable'  => esc_html__( 'Enable', 'bus-ticket-booking-with-seat-reservation' ),
+						'disable' => esc_html__( 'Disable', 'bus-ticket-booking-with-seat-reservation' ),
+					),
+				);
+
+				return $fields;
+			}
+
+			/**
+			 * Register the hidden admin page that renders the new design.
+			 */
+			public function register_page() {
+				add_submenu_page(
+					'', // Hidden: reachable via redirect / direct link only.
+					esc_html__( 'Bus Fleet', 'bus-ticket-booking-with-seat-reservation' ),
+					esc_html__( 'Bus Fleet', 'bus-ticket-booking-with-seat-reservation' ),
+					'edit_wbtm_buses',
+					self::PAGE_SLUG,
+					[ $this, 'render_page' ]
+				);
+			}
+
+			/**
+			 * Send the default CPT list to the new design when the setting is on.
+			 */
+			public function maybe_redirect_to_new_design() {
+				if ( ! self::is_enabled() ) {
+					return;
+				}
+				if ( ( $_SERVER['REQUEST_METHOD'] ?? 'GET' ) !== 'GET' ) {
+					return;
+				}
+				// phpcs:disable WordPress.Security.NonceVerification.Recommended
+				$post_type = isset( $_GET['post_type'] ) ? sanitize_text_field( wp_unslash( $_GET['post_type'] ) ) : '';
+				if ( $post_type !== 'wbtm_bus' ) {
+					return;
+				}
+				// Let the classic list handle Trash and explicit "classic" requests.
+				$status = isset( $_GET['post_status'] ) ? sanitize_text_field( wp_unslash( $_GET['post_status'] ) ) : '';
+				$view   = isset( $_GET['wbtm_view'] ) ? sanitize_text_field( wp_unslash( $_GET['wbtm_view'] ) ) : '';
+				// phpcs:enable WordPress.Security.NonceVerification.Recommended
+				if ( $status === 'trash' || $view === 'classic' ) {
+					return;
+				}
+				if ( ! current_user_can( 'edit_wbtm_buses' ) ) {
+					return;
+				}
+				wp_safe_redirect( admin_url( 'admin.php?page=' . self::PAGE_SLUG ) );
+				exit;
+			}
+
+			/**
+			 * Load the dedicated CSS/JS only on the new design screen.
+			 */
+			public function enqueue_assets( $hook ) {
+				if ( $hook !== 'admin_page_' . self::PAGE_SLUG ) {
+					return;
+				}
+				wp_enqueue_style(
+					'wbtm-bus-list-font',
+					'https://fonts.googleapis.com/css2?family=Plus+Jakarta+Sans:wght@400;500;600;700;800&display=swap',
+					array(),
+					null
+				);
+				wp_enqueue_style( 'wbtm_bus_list', WBTM_PLUGIN_URL . '/assets/admin/wbtm_bus_list.css', array(), time() );
+				wp_enqueue_script( 'wbtm_bus_list', WBTM_PLUGIN_URL . '/assets/admin/wbtm_bus_list.js', array( 'jquery' ), time(), true );
+			}
+
+			/**
+			 * Collect the fleet data once, shared by stats / grid / table.
+			 */
+			private function get_buses( $statuses = array( 'publish', 'draft', 'pending', 'private' ) ): array {
+				$query = new WP_Query( array(
+					'post_type'      => 'wbtm_bus',
+					'post_status'    => $statuses,
+					'posts_per_page' => -1,
+					'orderby'        => 'date',
+					'order'          => 'DESC',
+					'no_found_rows'  => true,
+				) );
+				$buses = array();
+				foreach ( $query->posts as $post ) {
+					$pid       = $post->ID;
+					$category  = WBTM_Global_Function::get_post_info( $pid, 'wbtm_bus_category' );
+					$seat_conf = WBTM_Global_Function::get_post_info( $pid, 'wbtm_seat_type_conf' );
+					$is_nonac  = $category && stripos( $category, 'non' ) !== false;
+					$is_ac     = $category && ! $is_nonac && stripos( $category, 'ac' ) !== false;
+					$buses[]   = array(
+						'id'           => $pid,
+						'title'        => get_the_title( $pid ) ?: esc_html__( '(no title)', 'bus-ticket-booking-with-seat-reservation' ),
+						'coach_no'     => WBTM_Global_Function::get_post_info( $pid, 'wbtm_bus_no' ),
+						'category'     => $category,
+						'is_ac'        => $is_ac,
+						'is_nonac'     => $is_nonac,
+						'type'         => $is_ac ? 'AC' : ( $is_nonac ? 'Non AC' : '' ),
+						'bus_type'     => $seat_conf === 'wbtm_seat_plan'
+							? esc_html__( 'Seal Plan', 'bus-ticket-booking-with-seat-reservation' )
+							: esc_html__( 'Without Seal Plan', 'bus-ticket-booking-with-seat-reservation' ),
+						'status'       => $post->post_status,
+						'thumb'        => get_the_post_thumbnail_url( $pid, 'medium_large' ),
+						'author'       => get_the_author_meta( 'display_name', $post->post_author ),
+						'edit_link'    => get_edit_post_link( $pid, 'raw' ),
+						'trash_link'   => get_delete_post_link( $pid ),
+						'restore_link' => wp_nonce_url( admin_url( sprintf( 'post.php?post=%d&action=untrash', $pid ) ), 'untrash-post_' . $pid ),
+						'delete_link'  => get_delete_post_link( $pid, '', true ),
+					);
+				}
+
+				return $buses;
+			}
+
+			private function initials( $name ): string {
+				$name  = trim( wp_strip_all_tags( (string) $name ) );
+				if ( $name === '' ) {
+					return '?';
+				}
+				$parts = preg_split( '/\s+/', $name );
+				$first = mb_substr( $parts[0], 0, 1 );
+				$last  = count( $parts ) > 1 ? mb_substr( end( $parts ), 0, 1 ) : '';
+
+				return mb_strtoupper( $first . $last );
+			}
+
+			private function status_label( $status ): string {
+				switch ( $status ) {
+					case 'publish':
+						return esc_html__( 'Published', 'bus-ticket-booking-with-seat-reservation' );
+					case 'draft':
+						return esc_html__( 'Draft', 'bus-ticket-booking-with-seat-reservation' );
+					case 'pending':
+						return esc_html__( 'Pending', 'bus-ticket-booking-with-seat-reservation' );
+					case 'private':
+						return esc_html__( 'Private', 'bus-ticket-booking-with-seat-reservation' );
+					default:
+						return esc_html( ucfirst( $status ) );
+				}
+			}
+
+			public function render_page() {
+				$name = WBTM_Functions::get_name();
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$is_trash = isset( $_GET['wbtm_status'] ) && sanitize_text_field( wp_unslash( $_GET['wbtm_status'] ) ) === 'trash';
+
+				// Active fleet always drives the stat cards & tab counts.
+				$active    = $this->get_buses();
+				$total     = count( $active );
+				$published = 0;
+				$draft     = 0;
+				$ac        = 0;
+				$nonac     = 0;
+				foreach ( $active as $b ) {
+					if ( $b['status'] === 'publish' ) {
+						$published++;
+					} elseif ( $b['status'] === 'draft' ) {
+						$draft++;
+					}
+					if ( $b['is_ac'] ) {
+						$ac++;
+					} elseif ( $b['is_nonac'] ) {
+						$nonac++;
+					}
+				}
+				$status_counts = wp_count_posts( 'wbtm_bus' );
+				$trash         = isset( $status_counts->trash ) ? (int) $status_counts->trash : 0;
+
+				// Grid shows trashed buses in trash view, active fleet otherwise.
+				$buses     = $is_trash ? $this->get_buses( array( 'trash' ) ) : $active;
+				$base_url  = admin_url( 'admin.php?page=' . self::PAGE_SLUG );
+				$trash_url = add_query_arg( 'wbtm_status', 'trash', $base_url );
+				$add_url   = admin_url( 'post-new.php?post_type=wbtm_bus' );
+				$classic   = admin_url( 'edit.php?post_type=wbtm_bus&wbtm_view=classic' );
+				?>
+				<div class="wrap wbtm-fleet-wrap">
+					<div class="wbtm-fleet">
+
+						<div class="wbtm-page-header">
+							<div class="wbtm-page-title"><?php echo esc_html( $name ); ?> <?php esc_html_e( 'Lists', 'bus-ticket-booking-with-seat-reservation' ); ?>
+								<span><?php echo esc_html( sprintf( _n( '%d bus', '%d buses', $total, 'bus-ticket-booking-with-seat-reservation' ), $total ) ); ?></span>
+							</div>
+							<div class="wbtm-header-actions">
+								<a class="wbtm-classic-link" href="<?php echo esc_url( $classic ); ?>">
+									<svg width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
+									<?php esc_html_e( 'Classic view', 'bus-ticket-booking-with-seat-reservation' ); ?>
+								</a>
+								<a class="wbtm-add-btn" href="<?php echo esc_url( $add_url ); ?>">
+									<svg width="16" height="16" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><line x1="12" y1="5" x2="12" y2="19"/><line x1="5" y1="12" x2="19" y2="12"/></svg>
+									<?php printf( esc_html__( 'Add New %s', 'bus-ticket-booking-with-seat-reservation' ), esc_html( $name ) ); ?>
+								</a>
+							</div>
+						</div>
+
+						<div class="wbtm-stats">
+							<div class="wbtm-stat-card">
+								<div class="wbtm-stat-icon red">
+									<svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="13" rx="2"/><path d="M3 11h18"/><circle cx="7" cy="18" r="1.5"/><circle cx="17" cy="18" r="1.5"/></svg>
+								</div>
+								<div><div class="wbtm-stat-num"><?php echo esc_html( $total ); ?></div><div class="wbtm-stat-label"><?php printf( esc_html__( 'Total %s', 'bus-ticket-booking-with-seat-reservation' ), esc_html( $name ) ); ?></div></div>
+							</div>
+							<div class="wbtm-stat-card">
+								<div class="wbtm-stat-icon green">
+									<svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2.5" viewBox="0 0 24 24"><path d="M20 6L9 17l-5-5"/></svg>
+								</div>
+								<div><div class="wbtm-stat-num"><?php echo esc_html( $published ); ?></div><div class="wbtm-stat-label"><?php esc_html_e( 'Published', 'bus-ticket-booking-with-seat-reservation' ); ?></div></div>
+							</div>
+							<div class="wbtm-stat-card">
+								<div class="wbtm-stat-icon blue">
+									<svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9.5 19a4.5 4.5 0 100-9H4"/><path d="M12.5 5a3 3 0 110 6H3"/><path d="M17 14a3 3 0 110 6h-2"/></svg>
+								</div>
+								<div><div class="wbtm-stat-num"><?php echo esc_html( $ac ); ?></div><div class="wbtm-stat-label"><?php esc_html_e( 'AC Coach', 'bus-ticket-booking-with-seat-reservation' ); ?></div></div>
+							</div>
+							<div class="wbtm-stat-card">
+								<div class="wbtm-stat-icon orange">
+									<svg width="20" height="20" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M9.59 4.59A2 2 0 1111 8H2"/><path d="M12.59 11.41A2 2 0 1114 15H2"/><path d="M19.59 6.41A2 2 0 1121 10H2"/></svg>
+								</div>
+								<div><div class="wbtm-stat-num"><?php echo esc_html( $nonac ); ?></div><div class="wbtm-stat-label"><?php esc_html_e( 'Non AC Coach', 'bus-ticket-booking-with-seat-reservation' ); ?></div></div>
+							</div>
+						</div>
+
+						<div class="wbtm-filters">
+							<div class="wbtm-tab-pills">
+								<?php if ( $is_trash ) : ?>
+									<a class="wbtm-tab-pill" href="<?php echo esc_url( $base_url ); ?>"><?php printf( esc_html__( 'All (%d)', 'bus-ticket-booking-with-seat-reservation' ), $total ); ?></a>
+									<a class="wbtm-tab-pill" href="<?php echo esc_url( $base_url ); ?>"><?php printf( esc_html__( 'Published (%d)', 'bus-ticket-booking-with-seat-reservation' ), $published ); ?></a>
+									<a class="wbtm-tab-pill" href="<?php echo esc_url( $base_url ); ?>"><?php printf( esc_html__( 'Draft (%d)', 'bus-ticket-booking-with-seat-reservation' ), $draft ); ?></a>
+									<span class="wbtm-tab-pill wbtm-tab-trash active">
+										<svg width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
+										<?php printf( esc_html__( 'Trash (%d)', 'bus-ticket-booking-with-seat-reservation' ), $trash ); ?>
+									</span>
+								<?php else : ?>
+									<button class="wbtm-tab-pill wbtm-filter-pill active" data-status=""><?php printf( esc_html__( 'All (%d)', 'bus-ticket-booking-with-seat-reservation' ), $total ); ?></button>
+									<button class="wbtm-tab-pill wbtm-filter-pill" data-status="publish"><?php printf( esc_html__( 'Published (%d)', 'bus-ticket-booking-with-seat-reservation' ), $published ); ?></button>
+									<button class="wbtm-tab-pill wbtm-filter-pill" data-status="draft"><?php printf( esc_html__( 'Draft (%d)', 'bus-ticket-booking-with-seat-reservation' ), $draft ); ?></button>
+									<a class="wbtm-tab-pill wbtm-tab-trash" href="<?php echo esc_url( $trash_url ); ?>" title="<?php esc_attr_e( 'View trashed buses', 'bus-ticket-booking-with-seat-reservation' ); ?>">
+										<svg width="13" height="13" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
+										<?php printf( esc_html__( 'Trash (%d)', 'bus-ticket-booking-with-seat-reservation' ), $trash ); ?>
+									</a>
+								<?php endif; ?>
+							</div>
+							<div class="wbtm-search-box">
+								<svg class="wbtm-search-icon" width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+								<input type="text" placeholder="<?php esc_attr_e( 'Search buses...', 'bus-ticket-booking-with-seat-reservation' ); ?>" id="wbtmSearchInput" autocomplete="off">
+								<button type="button" class="wbtm-search-clear" id="wbtmSearchClear" aria-label="<?php esc_attr_e( 'Clear search', 'bus-ticket-booking-with-seat-reservation' ); ?>">
+									<svg width="13" height="13" fill="none" stroke="currentColor" stroke-width="2.4" viewBox="0 0 24 24"><line x1="18" y1="6" x2="6" y2="18"/><line x1="6" y1="6" x2="18" y2="18"/></svg>
+								</button>
+							</div>
+							<select class="wbtm-filter-select" id="wbtmTypeFilter">
+								<option value=""><?php esc_html_e( 'All Types', 'bus-ticket-booking-with-seat-reservation' ); ?></option>
+								<option value="AC"><?php esc_html_e( 'AC', 'bus-ticket-booking-with-seat-reservation' ); ?></option>
+								<option value="Non AC"><?php esc_html_e( 'Non AC', 'bus-ticket-booking-with-seat-reservation' ); ?></option>
+							</select>
+							<div class="wbtm-view-toggle">
+								<button class="wbtm-vtog active" id="wbtmGridBtn" title="<?php esc_attr_e( 'Grid view', 'bus-ticket-booking-with-seat-reservation' ); ?>">
+									<svg width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><rect x="3" y="3" width="7" height="7" rx="1"/><rect x="14" y="3" width="7" height="7" rx="1"/><rect x="3" y="14" width="7" height="7" rx="1"/><rect x="14" y="14" width="7" height="7" rx="1"/></svg>
+								</button>
+								<button class="wbtm-vtog" id="wbtmListBtn" title="<?php esc_attr_e( 'List view', 'bus-ticket-booking-with-seat-reservation' ); ?>">
+									<svg width="15" height="15" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><line x1="3" y1="6" x2="21" y2="6"/><line x1="3" y1="12" x2="21" y2="12"/><line x1="3" y1="18" x2="21" y2="18"/></svg>
+								</button>
+							</div>
+						</div>
+
+						<?php if ( empty( $buses ) ) : ?>
+							<div class="wbtm-no-data">
+								<?php if ( $is_trash ) : ?>
+									<p><?php esc_html_e( 'Trash is empty.', 'bus-ticket-booking-with-seat-reservation' ); ?></p>
+									<a class="wbtm-classic-link" href="<?php echo esc_url( $base_url ); ?>"><?php esc_html_e( 'Back to list', 'bus-ticket-booking-with-seat-reservation' ); ?></a>
+								<?php else : ?>
+									<p><?php printf( esc_html__( 'No %s found yet.', 'bus-ticket-booking-with-seat-reservation' ), esc_html( strtolower( $name ) ) ); ?></p>
+									<a class="wbtm-add-btn" href="<?php echo esc_url( $add_url ); ?>"><?php printf( esc_html__( 'Add your first %s', 'bus-ticket-booking-with-seat-reservation' ), esc_html( $name ) ); ?></a>
+								<?php endif; ?>
+							</div>
+						<?php else : ?>
+
+						<div class="wbtm-bus-grid" id="wbtmBusGrid">
+							<?php foreach ( $buses as $b ) :
+								$type_badge_class = $b['is_ac'] ? 'ac' : 'nonac';
+								$type_badge_text  = $b['type'] ?: esc_html__( 'Coach', 'bus-ticket-booking-with-seat-reservation' );
+								?>
+								<div class="wbtm-bus-card" data-name="<?php echo esc_attr( strtolower( $b['title'] . ' ' . $b['coach_no'] ) ); ?>" data-type="<?php echo esc_attr( $b['type'] ); ?>" data-status="<?php echo esc_attr( $b['status'] ); ?>">
+									<div class="wbtm-bus-thumb">
+										<?php if ( $b['thumb'] ) : ?>
+											<img src="<?php echo esc_url( $b['thumb'] ); ?>" alt="<?php echo esc_attr( $b['title'] ); ?>">
+										<?php else : ?>
+											<div class="wbtm-thumb-placeholder">
+												<svg width="46" height="46" fill="none" stroke="currentColor" stroke-width="1.5" viewBox="0 0 24 24"><rect x="3" y="5" width="18" height="13" rx="2"/><path d="M3 11h18"/><circle cx="7" cy="18" r="1.5"/><circle cx="17" cy="18" r="1.5"/></svg>
+											</div>
+										<?php endif; ?>
+										<div class="wbtm-bus-thumb-overlay"></div>
+										<div class="wbtm-bus-thumb-badges">
+											<span class="wbtm-thumb-badge <?php echo esc_attr( $type_badge_class ); ?>"><?php echo esc_html( $type_badge_text ); ?></span>
+											<span class="wbtm-thumb-badge nonac"><?php echo esc_html( $b['bus_type'] ); ?></span>
+										</div>
+										<?php if ( $b['coach_no'] ) : ?><div class="wbtm-bus-coach-no"><?php echo esc_html( $b['coach_no'] ); ?></div><?php endif; ?>
+										<div class="wbtm-bus-actions-top">
+											<?php if ( $is_trash ) : ?>
+												<a class="wbtm-act-btn restore" href="<?php echo esc_url( $b['restore_link'] ); ?>" title="<?php esc_attr_e( 'Restore', 'bus-ticket-booking-with-seat-reservation' ); ?>">
+													<svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M3 12a9 9 0 109-9 9 9 0 00-7 3.3"/><polyline points="3 4 3 8 7 8"/></svg>
+												</a>
+												<a class="wbtm-act-btn del" href="<?php echo esc_url( $b['delete_link'] ); ?>" title="<?php esc_attr_e( 'Delete Permanently', 'bus-ticket-booking-with-seat-reservation' ); ?>" onclick="return confirm('<?php echo esc_js( __( 'Permanently delete this bus? This cannot be undone.', 'bus-ticket-booking-with-seat-reservation' ) ); ?>');">
+													<svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
+												</a>
+											<?php else : ?>
+												<a class="wbtm-act-btn edit" href="<?php echo esc_url( $b['edit_link'] ); ?>" title="<?php esc_attr_e( 'Edit', 'bus-ticket-booking-with-seat-reservation' ); ?>">
+													<svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.12 2.12 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
+												</a>
+												<a class="wbtm-act-btn del" href="<?php echo esc_url( $b['trash_link'] ); ?>" title="<?php esc_attr_e( 'Move to Trash', 'bus-ticket-booking-with-seat-reservation' ); ?>" onclick="return confirm('<?php echo esc_js( __( 'Move this bus to Trash?', 'bus-ticket-booking-with-seat-reservation' ) ); ?>');">
+													<svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
+												</a>
+											<?php endif; ?>
+										</div>
+									</div>
+									<div class="wbtm-bus-body">
+										<?php if ( $is_trash ) : ?>
+											<span class="wbtm-bus-name"><?php echo esc_html( $b['title'] ); ?></span>
+										<?php else : ?>
+											<a class="wbtm-bus-name" href="<?php echo esc_url( $b['edit_link'] ); ?>"><?php echo esc_html( $b['title'] ); ?></a>
+										<?php endif; ?>
+										<div class="wbtm-bus-meta">
+											<span class="wbtm-meta-pill type"><?php echo esc_html( $b['bus_type'] ); ?></span>
+											<?php if ( $b['type'] ) : ?>
+												<span class="wbtm-meta-pill <?php echo $b['is_ac'] ? 'coach' : 'nonac-pill'; ?>"><?php echo esc_html( $b['is_ac'] ? esc_html__( 'AC Coach', 'bus-ticket-booking-with-seat-reservation' ) : esc_html__( 'Non AC', 'bus-ticket-booking-with-seat-reservation' ) ); ?></span>
+											<?php endif; ?>
+										</div>
+										<div class="wbtm-bus-footer">
+											<div class="wbtm-bus-author"><span class="wbtm-author-avatar"><?php echo esc_html( $this->initials( $b['author'] ) ); ?></span> <?php echo esc_html( $b['author'] ); ?></div>
+											<span class="wbtm-status-dot status-<?php echo esc_attr( $b['status'] ); ?>"><?php echo esc_html( $this->status_label( $b['status'] ) ); ?></span>
+										</div>
+									</div>
+								</div>
+							<?php endforeach; ?>
+						</div>
+
+						<table class="wbtm-bus-table" id="wbtmBusTable">
+							<thead>
+								<tr>
+									<th><?php printf( esc_html__( '%s Name', 'bus-ticket-booking-with-seat-reservation' ), esc_html( $name ) ); ?></th>
+									<th><?php esc_html_e( 'Coach No', 'bus-ticket-booking-with-seat-reservation' ); ?></th>
+									<th><?php printf( esc_html__( '%s Type', 'bus-ticket-booking-with-seat-reservation' ), esc_html( $name ) ); ?></th>
+									<th><?php echo esc_html( WBTM_Translations::text_coach_type() ); ?></th>
+									<th><?php esc_html_e( 'Status', 'bus-ticket-booking-with-seat-reservation' ); ?></th>
+									<th><?php esc_html_e( 'Actions', 'bus-ticket-booking-with-seat-reservation' ); ?></th>
+								</tr>
+							</thead>
+							<tbody>
+								<?php foreach ( $buses as $b ) : ?>
+									<tr class="wbtm-row" data-name="<?php echo esc_attr( strtolower( $b['title'] . ' ' . $b['coach_no'] ) ); ?>" data-type="<?php echo esc_attr( $b['type'] ); ?>" data-status="<?php echo esc_attr( $b['status'] ); ?>">
+										<td data-label="<?php esc_attr_e( 'Name', 'bus-ticket-booking-with-seat-reservation' ); ?>"><?php if ( $is_trash ) : ?><?php echo esc_html( $b['title'] ); ?><?php else : ?><a href="<?php echo esc_url( $b['edit_link'] ); ?>"><?php echo esc_html( $b['title'] ); ?></a><?php endif; ?></td>
+										<td data-label="<?php esc_attr_e( 'Coach No', 'bus-ticket-booking-with-seat-reservation' ); ?>"><?php echo esc_html( $b['coach_no'] ?: '-' ); ?></td>
+										<td data-label="<?php esc_attr_e( 'Type', 'bus-ticket-booking-with-seat-reservation' ); ?>"><span class="wbtm-t-badge type"><?php echo esc_html( $b['bus_type'] ); ?></span></td>
+										<td data-label="<?php esc_attr_e( 'Coach', 'bus-ticket-booking-with-seat-reservation' ); ?>"><?php if ( $b['type'] ) : ?><span class="wbtm-t-badge <?php echo $b['is_ac'] ? 'ac' : 'nonac'; ?>"><?php echo esc_html( $b['type'] ); ?></span><?php else : ?>-<?php endif; ?></td>
+										<td data-label="<?php esc_attr_e( 'Status', 'bus-ticket-booking-with-seat-reservation' ); ?>"><span class="wbtm-status-dot status-<?php echo esc_attr( $b['status'] ); ?>"><?php echo esc_html( $this->status_label( $b['status'] ) ); ?></span></td>
+										<td data-label="<?php esc_attr_e( 'Actions', 'bus-ticket-booking-with-seat-reservation' ); ?>">
+											<?php if ( $is_trash ) : ?>
+												<a class="wbtm-table-edit" href="<?php echo esc_url( $b['restore_link'] ); ?>"><?php esc_html_e( 'Restore', 'bus-ticket-booking-with-seat-reservation' ); ?></a>
+												<a class="wbtm-table-del" href="<?php echo esc_url( $b['delete_link'] ); ?>" onclick="return confirm('<?php echo esc_js( __( 'Permanently delete this bus? This cannot be undone.', 'bus-ticket-booking-with-seat-reservation' ) ); ?>');"><?php esc_html_e( 'Delete', 'bus-ticket-booking-with-seat-reservation' ); ?></a>
+											<?php else : ?>
+												<a class="wbtm-table-edit" href="<?php echo esc_url( $b['edit_link'] ); ?>"><?php esc_html_e( 'Edit', 'bus-ticket-booking-with-seat-reservation' ); ?></a>
+												<a class="wbtm-table-del" href="<?php echo esc_url( $b['trash_link'] ); ?>" onclick="return confirm('<?php echo esc_js( __( 'Move this bus to Trash?', 'bus-ticket-booking-with-seat-reservation' ) ); ?>');"><?php esc_html_e( 'Trash', 'bus-ticket-booking-with-seat-reservation' ); ?></a>
+											<?php endif; ?>
+										</td>
+									</tr>
+								<?php endforeach; ?>
+							</tbody>
+						</table>
+
+						<div class="wbtm-empty" id="wbtmEmptyMsg"><?php esc_html_e( 'No buses found matching your search.', 'bus-ticket-booking-with-seat-reservation' ); ?></div>
+
+						<div class="wbtm-pagination" id="wbtmPagination">
+							<div class="wbtm-page-info" id="wbtmPageInfo"></div>
+							<div class="wbtm-page-btns" id="wbtmPageBtns"></div>
+						</div>
+
+						<?php endif; ?>
+					</div>
+				</div>
+				<?php
+			}
+		}
+
+		new WBTM_Bus_List();
+	}

--- a/assets/admin/wbtm_bus_list.css
+++ b/assets/admin/wbtm_bus_list.css
@@ -1,0 +1,208 @@
+/* ==========================================================================
+   WBTM Bus Fleet - new responsive list design
+   Scoped under .wbtm-fleet so it never leaks into the rest of wp-admin.
+   ========================================================================== */
+.wbtm-fleet-wrap{margin:0;}
+.wbtm-fleet *,.wbtm-fleet *::before,.wbtm-fleet *::after{box-sizing:border-box;}
+.wbtm-fleet{
+  --wbtm-bg:#f0f2f7;--wbtm-white:#fff;--wbtm-ink:#0f1523;--wbtm-ink2:#3a3f55;
+  --wbtm-muted:#8b93b0;--wbtm-border:#e4e7f0;--wbtm-red:#e63946;--wbtm-red-soft:#fdedef;
+  --wbtm-green:#16a34a;--wbtm-green-soft:#dcfce7;--wbtm-blue:#1d4ed8;--wbtm-blue-soft:#dbeafe;
+  --wbtm-orange:#ea580c;--wbtm-orange-soft:#ffedd5;
+  --wbtm-shadow:0 2px 16px rgba(15,21,35,.08);--wbtm-shadow-hover:0 8px 32px rgba(15,21,35,.14);
+  font-family:'Plus Jakarta Sans',-apple-system,BlinkMacSystemFont,'Segoe UI',sans-serif;
+  background:var(--wbtm-bg);color:var(--wbtm-ink);
+  margin:10px 20px 40px 0;padding:28px;border-radius:18px;
+}
+.wbtm-fleet a{box-shadow:none;}
+.wbtm-fleet a:focus{box-shadow:none;outline:none;}
+
+/* HEADER */
+.wbtm-page-header{display:flex;align-items:center;justify-content:space-between;gap:16px;margin-bottom:24px;flex-wrap:wrap;}
+.wbtm-page-title{font-size:25px;font-weight:800;color:var(--wbtm-ink);letter-spacing:-.02em;}
+.wbtm-page-title span{color:var(--wbtm-muted);font-weight:400;font-size:15px;margin-left:8px;}
+.wbtm-header-actions{display:flex;align-items:center;gap:10px;}
+.wbtm-classic-link{
+  display:inline-flex;align-items:center;gap:7px;
+  font-size:13px;font-weight:700;color:var(--wbtm-ink2) !important;text-decoration:none;
+  background:var(--wbtm-white);border:1px solid var(--wbtm-border);
+  padding:9px 16px;border-radius:10px;
+  transition:border-color .2s,color .2s,box-shadow .2s,transform .15s;
+}
+.wbtm-classic-link svg{color:var(--wbtm-muted);transition:color .2s;}
+.wbtm-classic-link:hover{color:var(--wbtm-red) !important;border-color:var(--wbtm-red);box-shadow:var(--wbtm-shadow);transform:translateY(-1px);}
+.wbtm-classic-link:hover svg{color:var(--wbtm-red);}
+.wbtm-add-btn{
+  display:inline-flex;align-items:center;gap:8px;background:var(--wbtm-red);color:#fff !important;
+  font-size:13px;font-weight:700;padding:10px 20px;border-radius:10px;border:none;cursor:pointer;
+  text-decoration:none;transition:background .2s,transform .15s;
+}
+.wbtm-add-btn:hover{background:#c62a35;color:#fff !important;transform:translateY(-1px);}
+
+/* STATS */
+.wbtm-stats{display:grid;grid-template-columns:repeat(4,1fr);gap:14px;margin-bottom:24px;}
+.wbtm-stat-card{background:var(--wbtm-white);border-radius:14px;padding:18px 20px;border:1px solid var(--wbtm-border);display:flex;align-items:center;gap:14px;transition:box-shadow .2s;}
+.wbtm-stat-card:hover{box-shadow:var(--wbtm-shadow);}
+.wbtm-stat-icon{width:44px;height:44px;border-radius:12px;display:flex;align-items:center;justify-content:center;flex-shrink:0;}
+.wbtm-stat-icon.red{background:var(--wbtm-red-soft);color:var(--wbtm-red);}
+.wbtm-stat-icon.green{background:var(--wbtm-green-soft);color:var(--wbtm-green);}
+.wbtm-stat-icon.blue{background:var(--wbtm-blue-soft);color:var(--wbtm-blue);}
+.wbtm-stat-icon.orange{background:var(--wbtm-orange-soft);color:var(--wbtm-orange);}
+.wbtm-stat-num{font-size:22px;font-weight:800;color:var(--wbtm-ink);line-height:1;}
+.wbtm-stat-label{font-size:11px;color:var(--wbtm-muted);margin-top:3px;font-weight:500;}
+
+/* FILTERS */
+.wbtm-filters{display:flex;align-items:center;gap:12px;margin-bottom:20px;flex-wrap:wrap;}
+.wbtm-tab-pills{display:flex;gap:6px;background:var(--wbtm-white);padding:5px;border-radius:10px;border:1px solid var(--wbtm-border);}
+.wbtm-tab-pill{display:inline-flex;align-items:center;gap:5px;padding:6px 14px;border-radius:7px;font-size:12px;font-weight:600;cursor:pointer;color:var(--wbtm-muted);transition:all .2s;border:none;background:none;font-family:inherit;text-decoration:none;line-height:1.5;}
+.wbtm-tab-pill.active{background:var(--wbtm-red);color:#fff;}
+.wbtm-tab-trash{color:var(--wbtm-muted) !important;}
+.wbtm-tab-trash svg{opacity:.8;}
+.wbtm-tab-trash:not(.active):hover{background:var(--wbtm-red-soft);color:var(--wbtm-red) !important;}
+.wbtm-tab-trash.active{background:var(--wbtm-red);color:#fff !important;}
+.wbtm-tab-trash.active svg{opacity:1;}
+.wbtm-search-box{display:flex;align-items:center;gap:8px;background:var(--wbtm-white);border:1px solid var(--wbtm-border);border-radius:10px;padding:6px 14px;flex:1;max-width:300px;min-width:180px;color:var(--wbtm-muted);transition:border-color .2s,box-shadow .2s;}
+.wbtm-search-box.is-focused{border-color:var(--wbtm-red);box-shadow:0 0 0 3px var(--wbtm-red-soft);}
+.wbtm-search-box .wbtm-search-icon{flex-shrink:0;transition:color .2s;}
+.wbtm-search-box.is-focused .wbtm-search-icon{color:var(--wbtm-red);}
+.wbtm-search-box input{border:none;outline:none;box-shadow:none;font-size:13px;font-family:inherit;color:var(--wbtm-ink);width:100%;background:transparent;margin:0;min-height:auto;padding:0;}
+.wbtm-search-box input:focus{outline:none;box-shadow:none;border:none;}
+.wbtm-search-clear{display:none;align-items:center;justify-content:center;flex-shrink:0;width:20px;height:20px;border:none;border-radius:50%;background:var(--wbtm-bg);color:var(--wbtm-muted);cursor:pointer;padding:0;transition:background .15s,color .15s;}
+.wbtm-search-clear:hover{background:var(--wbtm-red-soft);color:var(--wbtm-red);}
+.wbtm-search-box.has-value .wbtm-search-clear{display:inline-flex;}
+
+/* CUSTOM DROPDOWN */
+.wbtm-filter-select{display:none;}
+.wbtm-dropdown{position:relative;font-family:inherit;}
+.wbtm-dropdown-toggle{
+  display:inline-flex;align-items:center;gap:10px;min-width:148px;justify-content:space-between;
+  background:var(--wbtm-white);border:1px solid var(--wbtm-border);border-radius:10px;
+  padding:9px 14px;font-size:13px;font-weight:600;font-family:inherit;color:var(--wbtm-ink2);
+  cursor:pointer;transition:border-color .2s,box-shadow .2s;
+}
+.wbtm-dropdown-toggle:hover{border-color:#cfd5e6;}
+.wbtm-dropdown.open .wbtm-dropdown-toggle{border-color:var(--wbtm-red);box-shadow:0 0 0 3px var(--wbtm-red-soft);}
+.wbtm-dropdown-toggle .wbtm-caret{transition:transform .2s;color:var(--wbtm-muted);flex-shrink:0;}
+.wbtm-dropdown.open .wbtm-dropdown-toggle .wbtm-caret{transform:rotate(180deg);}
+.wbtm-dropdown-menu{
+  position:absolute;top:calc(100% + 6px);left:0;right:0;z-index:20;
+  background:var(--wbtm-white);border:1px solid var(--wbtm-border);border-radius:12px;
+  box-shadow:var(--wbtm-shadow-hover);padding:6px;
+  opacity:0;visibility:hidden;transform:translateY(-6px);transition:opacity .18s,transform .18s,visibility .18s;
+}
+.wbtm-dropdown.open .wbtm-dropdown-menu{opacity:1;visibility:visible;transform:translateY(0);}
+.wbtm-dropdown-option{
+  display:flex;align-items:center;justify-content:space-between;gap:8px;
+  padding:8px 12px;border-radius:8px;font-size:13px;font-weight:600;color:var(--wbtm-ink2);
+  cursor:pointer;transition:background .15s,color .15s;
+}
+.wbtm-dropdown-option:hover{background:var(--wbtm-bg);}
+.wbtm-dropdown-option.selected{background:var(--wbtm-red-soft);color:var(--wbtm-red);}
+.wbtm-dropdown-option .wbtm-check{opacity:0;transition:opacity .15s;}
+.wbtm-dropdown-option.selected .wbtm-check{opacity:1;}
+.wbtm-filter-select-legacy{background:var(--wbtm-white);border:1px solid var(--wbtm-border);border-radius:10px;padding:7px 14px;font-size:13px;font-family:inherit;color:var(--wbtm-ink2);outline:none;cursor:pointer;min-height:auto;line-height:1.6;}
+.wbtm-view-toggle{display:flex;gap:4px;background:var(--wbtm-white);padding:4px;border-radius:8px;border:1px solid var(--wbtm-border);margin-left:auto;}
+.wbtm-vtog{width:32px;height:32px;border:none;border-radius:6px;cursor:pointer;background:none;display:flex;align-items:center;justify-content:center;color:var(--wbtm-muted);transition:all .15s;}
+.wbtm-vtog.active{background:var(--wbtm-red);color:#fff;}
+
+/* GRID */
+.wbtm-bus-grid{display:grid;grid-template-columns:repeat(auto-fill,minmax(270px,1fr));gap:18px;}
+.wbtm-bus-card{background:var(--wbtm-white);border-radius:16px;border:1px solid var(--wbtm-border);overflow:hidden;transition:box-shadow .25s,transform .2s;animation:wbtmFadeUp .4s ease both;}
+.wbtm-bus-card:hover{box-shadow:var(--wbtm-shadow-hover);transform:translateY(-3px);}
+@keyframes wbtmFadeUp{from{opacity:0;transform:translateY(16px);}to{opacity:1;transform:translateY(0);}}
+.wbtm-bus-thumb{height:150px;position:relative;overflow:hidden;background:linear-gradient(135deg,#1a1a2e,#2d2d44);}
+.wbtm-bus-thumb img{width:100%;height:100%;object-fit:cover;display:block;transition:transform .4s;}
+.wbtm-bus-card:hover .wbtm-bus-thumb img{transform:scale(1.06);}
+.wbtm-thumb-placeholder{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;color:rgba(255,255,255,.35);}
+.wbtm-bus-thumb-overlay{position:absolute;inset:0;background:linear-gradient(to top,rgba(15,21,35,.7) 0%,transparent 55%);}
+.wbtm-bus-thumb-badges{position:absolute;top:12px;left:12px;display:flex;gap:6px;flex-wrap:wrap;max-width:80%;}
+.wbtm-thumb-badge{font-size:10px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;padding:3px 9px;border-radius:6px;backdrop-filter:blur(6px);}
+.wbtm-thumb-badge.ac{background:rgba(230,57,70,.85);color:#fff;}
+.wbtm-thumb-badge.nonac{background:rgba(30,30,60,.75);color:rgba(255,255,255,.9);}
+.wbtm-bus-coach-no{position:absolute;bottom:10px;left:12px;font-size:11px;font-weight:700;color:rgba(255,255,255,.9);letter-spacing:.04em;}
+.wbtm-bus-actions-top{position:absolute;top:10px;right:10px;display:flex;gap:6px;opacity:0;transition:opacity .2s;z-index:3;}
+.wbtm-bus-card:hover .wbtm-bus-actions-top,.wbtm-bus-card:focus-within .wbtm-bus-actions-top{opacity:1;}
+.wbtm-act-btn{width:32px;height:32px;border-radius:9px;border:none;cursor:pointer;display:flex;align-items:center;justify-content:center;backdrop-filter:blur(6px);transition:background .15s,transform .15s;text-decoration:none;box-shadow:0 2px 6px rgba(15,21,35,.25);}
+.wbtm-act-btn:hover{transform:translateY(-1px);}
+.wbtm-act-btn.edit{background:rgba(255,255,255,.92);color:var(--wbtm-ink);}
+.wbtm-act-btn.edit:hover{background:#fff;color:var(--wbtm-ink);}
+.wbtm-act-btn.del{background:rgba(230,57,70,.95);color:#fff;}
+.wbtm-act-btn.del:hover{background:var(--wbtm-red);color:#fff;}
+.wbtm-act-btn.restore{background:rgba(22,163,74,.95);color:#fff;}
+.wbtm-act-btn.restore:hover{background:var(--wbtm-green);color:#fff;}
+.wbtm-bus-body{padding:16px;}
+.wbtm-bus-name{display:block;font-size:15px;font-weight:700;color:var(--wbtm-ink) !important;margin-bottom:10px;line-height:1.3;text-decoration:none;}
+.wbtm-bus-name:hover{color:var(--wbtm-red) !important;}
+.wbtm-bus-meta{display:flex;flex-wrap:wrap;gap:8px;margin-bottom:12px;}
+.wbtm-meta-pill{display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:600;padding:4px 10px;border-radius:20px;}
+.wbtm-meta-pill.type{background:var(--wbtm-blue-soft);color:var(--wbtm-blue);}
+.wbtm-meta-pill.coach{background:var(--wbtm-red-soft);color:var(--wbtm-red);}
+.wbtm-meta-pill.nonac-pill{background:#f1f0ff;color:#6d5acd;}
+.wbtm-bus-footer{display:flex;align-items:center;justify-content:space-between;gap:8px;padding-top:12px;border-top:1px solid var(--wbtm-border);}
+.wbtm-bus-author{font-size:11px;color:var(--wbtm-muted);display:flex;align-items:center;gap:5px;overflow:hidden;}
+.wbtm-author-avatar{width:22px;height:22px;border-radius:50%;background:var(--wbtm-red);display:flex;align-items:center;justify-content:center;font-size:9px;font-weight:700;color:#fff;flex-shrink:0;}
+.wbtm-status-dot{display:inline-flex;align-items:center;gap:5px;font-size:11px;font-weight:600;white-space:nowrap;}
+.wbtm-status-dot::before{content:'';width:6px;height:6px;border-radius:50%;display:block;background:var(--wbtm-muted);}
+.wbtm-status-dot.status-publish{color:var(--wbtm-green);}
+.wbtm-status-dot.status-publish::before{background:var(--wbtm-green);}
+.wbtm-status-dot.status-draft{color:var(--wbtm-orange);}
+.wbtm-status-dot.status-draft::before{background:var(--wbtm-orange);}
+.wbtm-status-dot.status-pending{color:var(--wbtm-blue);}
+.wbtm-status-dot.status-pending::before{background:var(--wbtm-blue);}
+
+/* TABLE */
+.wbtm-bus-table{width:100%;border-collapse:separate;border-spacing:0 8px;display:none;}
+.wbtm-bus-table th{font-size:11px;font-weight:700;letter-spacing:.1em;text-transform:uppercase;color:var(--wbtm-muted);padding:0 16px 4px;text-align:left;}
+.wbtm-bus-table tr.wbtm-row{background:var(--wbtm-white);transition:box-shadow .2s,transform .15s;animation:wbtmFadeUp .35s ease both;}
+.wbtm-bus-table tr.wbtm-row:hover{box-shadow:var(--wbtm-shadow-hover);transform:translateY(-2px);}
+.wbtm-bus-table td{padding:14px 16px;font-size:13px;color:var(--wbtm-ink2);border-top:1px solid var(--wbtm-border);border-bottom:1px solid var(--wbtm-border);vertical-align:middle;}
+.wbtm-bus-table td:first-child{border-left:1px solid var(--wbtm-border);border-radius:12px 0 0 12px;font-weight:700;}
+.wbtm-bus-table td:first-child a{color:var(--wbtm-ink) !important;text-decoration:none;}
+.wbtm-bus-table td:first-child a:hover{color:var(--wbtm-red) !important;}
+.wbtm-bus-table td:last-child{border-right:1px solid var(--wbtm-border);border-radius:0 12px 12px 0;}
+.wbtm-t-badge{display:inline-flex;align-items:center;padding:3px 10px;border-radius:6px;font-size:11px;font-weight:600;}
+.wbtm-t-badge.type{background:var(--wbtm-blue-soft);color:var(--wbtm-blue);}
+.wbtm-t-badge.ac{background:var(--wbtm-red-soft);color:var(--wbtm-red);}
+.wbtm-t-badge.nonac{background:#f1f0ff;color:#6d5acd;}
+.wbtm-table-edit,.wbtm-table-del{padding:4px 12px;border-radius:6px;border:1px solid var(--wbtm-border);background:var(--wbtm-white);font-size:11px;font-weight:600;cursor:pointer;text-decoration:none;color:var(--wbtm-ink2) !important;display:inline-block;}
+.wbtm-table-edit:hover{border-color:var(--wbtm-blue);color:var(--wbtm-blue) !important;}
+.wbtm-table-del{margin-left:4px;}
+.wbtm-table-del:hover{border-color:var(--wbtm-red);color:var(--wbtm-red) !important;}
+
+/* PAGINATION */
+.wbtm-pagination{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-top:24px;flex-wrap:wrap;}
+.wbtm-page-info{font-size:13px;color:var(--wbtm-muted);}
+.wbtm-page-btns{display:flex;gap:6px;flex-wrap:wrap;}
+.wbtm-page-btn{min-width:34px;height:34px;padding:0 8px;border-radius:8px;border:1px solid var(--wbtm-border);background:var(--wbtm-white);font-size:13px;font-weight:600;color:var(--wbtm-ink2);cursor:pointer;display:flex;align-items:center;justify-content:center;transition:all .15s;font-family:inherit;}
+.wbtm-page-btn:hover:not(:disabled),.wbtm-page-btn.active{background:var(--wbtm-red);color:#fff;border-color:var(--wbtm-red);}
+.wbtm-page-btn:disabled{opacity:.4;cursor:not-allowed;}
+
+.wbtm-empty{display:none;text-align:center;padding:60px 20px;color:var(--wbtm-muted);font-size:14px;font-weight:500;}
+.wbtm-no-data{text-align:center;padding:60px 20px;color:var(--wbtm-muted);}
+.wbtm-no-data p{font-size:15px;margin-bottom:18px;}
+
+/* RESPONSIVE */
+@media (max-width:1200px){.wbtm-stats{grid-template-columns:repeat(2,1fr);}}
+@media (max-width:782px){
+  .wbtm-fleet{margin:10px 0 30px 0;padding:18px;border-radius:14px;}
+  .wbtm-page-header{align-items:flex-start;}
+  .wbtm-view-toggle{margin-left:0;}
+  .wbtm-search-box{max-width:none;flex:1 1 100%;order:5;}
+  .wbtm-bus-grid{grid-template-columns:1fr;}
+  /* Stacked / card-style table on small screens */
+  .wbtm-bus-table thead{display:none;}
+  .wbtm-bus-table,.wbtm-bus-table tbody,.wbtm-bus-table tr.wbtm-row,.wbtm-bus-table td{display:block;width:100%;}
+  .wbtm-bus-table tr.wbtm-row{background:var(--wbtm-white);border:1px solid var(--wbtm-border);border-radius:12px;margin-bottom:12px;padding:6px 0;}
+  .wbtm-bus-table td{border:none !important;border-radius:0 !important;padding:8px 16px;display:flex;justify-content:space-between;align-items:center;gap:12px;text-align:right;}
+  .wbtm-bus-table td::before{content:attr(data-label);font-size:11px;font-weight:700;letter-spacing:.06em;text-transform:uppercase;color:var(--wbtm-muted);text-align:left;}
+}
+@media (max-width:480px){
+  .wbtm-stats{grid-template-columns:1fr;}
+  .wbtm-tab-pills{width:100%;justify-content:space-between;}
+}
+
+/* Card actions: hidden by default, revealed on card hover/focus. */
+.wbtm-fleet .wbtm-bus-actions-top{opacity:0;}
+.wbtm-fleet .wbtm-bus-card:hover .wbtm-bus-actions-top,.wbtm-fleet .wbtm-bus-card:focus-within .wbtm-bus-actions-top{opacity:1;}
+.wbtm-fleet .wbtm-act-btn.restore{background:rgba(22,163,74,.95);color:#fff;}
+.wbtm-fleet .wbtm-act-btn.restore:hover{background:var(--wbtm-green);color:#fff;}

--- a/assets/admin/wbtm_bus_list.js
+++ b/assets/admin/wbtm_bus_list.js
@@ -1,0 +1,267 @@
+/* ==========================================================================
+   WBTM Bus Fleet - new list design interactions
+   View toggle, search, type filter, status tabs, client-side pagination.
+   ========================================================================== */
+(function () {
+	'use strict';
+
+	document.addEventListener('DOMContentLoaded', function () {
+		var fleet = document.querySelector('.wbtm-fleet');
+		if (!fleet) {
+			return;
+		}
+
+		var grid       = document.getElementById('wbtmBusGrid');
+		var table      = document.getElementById('wbtmBusTable');
+		var gridBtn    = document.getElementById('wbtmGridBtn');
+		var listBtn    = document.getElementById('wbtmListBtn');
+		var searchEl   = document.getElementById('wbtmSearchInput');
+		var searchBox  = searchEl ? searchEl.closest('.wbtm-search-box') : null;
+		var clearBtn   = document.getElementById('wbtmSearchClear');
+		var typeEl     = document.getElementById('wbtmTypeFilter');
+		var emptyMsg   = document.getElementById('wbtmEmptyMsg');
+		var pageInfo   = document.getElementById('wbtmPageInfo');
+		var pageBtns   = document.getElementById('wbtmPageBtns');
+		// Only the in-page client filter pills; Trash / navigation pills are real links.
+		var tabs       = Array.prototype.slice.call(document.querySelectorAll('.wbtm-filter-pill'));
+
+		// No buses on the page (empty state) - nothing to wire up.
+		if (!grid) {
+			return;
+		}
+
+		var PER_PAGE   = 12;
+		var STORE_KEY  = 'wbtmBusListView';
+		var cards      = Array.prototype.slice.call(grid.querySelectorAll('.wbtm-bus-card'));
+		var rows       = table ? Array.prototype.slice.call(table.querySelectorAll('tr.wbtm-row')) : [];
+
+		var state = {
+			view: 'grid',
+			search: '',
+			type: '',
+			status: '',
+			page: 1
+		};
+
+		/* ---- View toggle (persisted) ---------------------------------- */
+		function applyView() {
+			var isGrid = state.view === 'grid';
+			grid.style.display = isGrid ? 'grid' : 'none';
+			if (table) {
+				table.style.display = isGrid ? 'none' : 'table';
+			}
+			gridBtn.classList.toggle('active', isGrid);
+			listBtn.classList.toggle('active', !isGrid);
+		}
+
+		function setView(view) {
+			state.view = view;
+			try { window.localStorage.setItem(STORE_KEY, view); } catch (e) {}
+			applyView();
+			render();
+		}
+
+		try {
+			var saved = window.localStorage.getItem(STORE_KEY);
+			if (saved === 'list' || saved === 'grid') {
+				state.view = saved;
+			}
+		} catch (e) {}
+
+		gridBtn.addEventListener('click', function () { setView('grid'); });
+		listBtn.addEventListener('click', function () { setView('list'); });
+
+		/* ---- Matching --------------------------------------------------- */
+		function matches(el) {
+			var name   = (el.getAttribute('data-name') || '');
+			var type   = (el.getAttribute('data-type') || '');
+			var status = (el.getAttribute('data-status') || '');
+			if (state.search && name.indexOf(state.search) === -1) { return false; }
+			if (state.type && type !== state.type) { return false; }
+			if (state.status && status !== state.status) { return false; }
+			return true;
+		}
+
+		/* ---- Render with pagination ------------------------------------ */
+		function render() {
+			var items   = state.view === 'list' ? rows : cards;
+			var matched = items.filter(matches);
+			var total   = matched.length;
+			var pages    = Math.max(1, Math.ceil(total / PER_PAGE));
+			if (state.page > pages) { state.page = pages; }
+			var start = (state.page - 1) * PER_PAGE;
+			var end   = start + PER_PAGE;
+
+			// Hide everything, then show the current page slice of matched items.
+			items.forEach(function (el) { el.style.display = 'none'; });
+			matched.forEach(function (el, i) {
+				if (i >= start && i < end) {
+					el.style.display = '';
+				}
+			});
+
+			if (emptyMsg) { emptyMsg.style.display = total === 0 ? 'block' : 'none'; }
+
+			renderPageInfo(total, start, end);
+			renderPageButtons(pages);
+		}
+
+		function renderPageInfo(total, start, end) {
+			if (!pageInfo) { return; }
+			if (total === 0) {
+				pageInfo.textContent = '0 buses';
+				return;
+			}
+			var from = start + 1;
+			var to   = Math.min(end, total);
+			pageInfo.textContent = 'Showing ' + from + '-' + to + ' of ' + total + ' buses';
+		}
+
+		function makeBtn(label, page, opts) {
+			opts = opts || {};
+			var btn = document.createElement('button');
+			btn.className = 'wbtm-page-btn' + (opts.active ? ' active' : '');
+			btn.innerHTML = label;
+			if (opts.disabled) {
+				btn.disabled = true;
+			} else {
+				btn.addEventListener('click', function () {
+					state.page = page;
+					render();
+					fleet.scrollIntoView({ behavior: 'smooth', block: 'start' });
+				});
+			}
+			return btn;
+		}
+
+		function renderPageButtons(pages) {
+			if (!pageBtns) { return; }
+			pageBtns.innerHTML = '';
+			if (pages <= 1) { return; }
+			pageBtns.appendChild(makeBtn('&#8249;', state.page - 1, { disabled: state.page === 1 }));
+			for (var p = 1; p <= pages; p++) {
+				pageBtns.appendChild(makeBtn(String(p), p, { active: p === state.page }));
+			}
+			pageBtns.appendChild(makeBtn('&#8250;', state.page + 1, { disabled: state.page === pages }));
+		}
+
+		/* ---- Filters ---------------------------------------------------- */
+		function resetAndRender() {
+			state.page = 1;
+			render();
+		}
+
+		/* ---- Live search ------------------------------------------------ */
+		if (searchEl) {
+			var onSearch = function () {
+				state.search = searchEl.value.toLowerCase().trim();
+				if (searchBox) {
+					searchBox.classList.toggle('has-value', searchEl.value.length > 0);
+				}
+				resetAndRender();
+			};
+			searchEl.addEventListener('input', onSearch);
+			searchEl.addEventListener('search', onSearch); // native clear (×) on some browsers
+			if (searchBox) {
+				searchEl.addEventListener('focus', function () { searchBox.classList.add('is-focused'); });
+				searchEl.addEventListener('blur', function () { searchBox.classList.remove('is-focused'); });
+			}
+			if (clearBtn) {
+				clearBtn.addEventListener('click', function () {
+					searchEl.value = '';
+					searchEl.focus();
+					onSearch();
+				});
+			}
+		}
+
+		/* ---- Custom styled dropdown (type filter) ---------------------- */
+		function buildDropdown(select) {
+			var options = Array.prototype.slice.call(select.options);
+
+			var wrap = document.createElement('div');
+			wrap.className = 'wbtm-dropdown';
+
+			var toggle = document.createElement('button');
+			toggle.type = 'button';
+			toggle.className = 'wbtm-dropdown-toggle';
+			toggle.setAttribute('aria-haspopup', 'listbox');
+			toggle.setAttribute('aria-expanded', 'false');
+
+			var label = document.createElement('span');
+			label.className = 'wbtm-dropdown-label';
+			label.textContent = options[select.selectedIndex] ? options[select.selectedIndex].text : '';
+
+			var caret = document.createElement('span');
+			caret.className = 'wbtm-caret';
+			caret.innerHTML = '<svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.2" viewBox="0 0 24 24"><polyline points="6 9 12 15 18 9"/></svg>';
+
+			toggle.appendChild(label);
+			toggle.appendChild(caret);
+
+			var menu = document.createElement('div');
+			menu.className = 'wbtm-dropdown-menu';
+			menu.setAttribute('role', 'listbox');
+
+			var check = '<span class="wbtm-check"><svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2.6" viewBox="0 0 24 24"><polyline points="20 6 9 17 4 12"/></svg></span>';
+
+			options.forEach(function (opt) {
+				var item = document.createElement('div');
+				item.className = 'wbtm-dropdown-option' + (opt.value === select.value ? ' selected' : '');
+				item.setAttribute('role', 'option');
+				item.setAttribute('data-value', opt.value);
+				item.innerHTML = '<span>' + opt.text + '</span>' + check;
+				item.addEventListener('click', function () {
+					select.value = opt.value;
+					label.textContent = opt.text;
+					menu.querySelectorAll('.wbtm-dropdown-option').forEach(function (o) { o.classList.remove('selected'); });
+					item.classList.add('selected');
+					closeMenu();
+					state.type = opt.value;
+					resetAndRender();
+				});
+				menu.appendChild(item);
+			});
+
+			function openMenu() {
+				wrap.classList.add('open');
+				toggle.setAttribute('aria-expanded', 'true');
+			}
+			function closeMenu() {
+				wrap.classList.remove('open');
+				toggle.setAttribute('aria-expanded', 'false');
+			}
+
+			toggle.addEventListener('click', function (e) {
+				e.stopPropagation();
+				wrap.classList.contains('open') ? closeMenu() : openMenu();
+			});
+			document.addEventListener('click', function (e) {
+				if (!wrap.contains(e.target)) { closeMenu(); }
+			});
+			document.addEventListener('keydown', function (e) {
+				if (e.key === 'Escape') { closeMenu(); }
+			});
+
+			wrap.appendChild(toggle);
+			wrap.appendChild(menu);
+			select.parentNode.insertBefore(wrap, select.nextSibling);
+		}
+
+		if (typeEl) {
+			buildDropdown(typeEl);
+		}
+		tabs.forEach(function (tab) {
+			tab.addEventListener('click', function () {
+				tabs.forEach(function (t) { t.classList.remove('active'); });
+				this.classList.add('active');
+				state.status = this.getAttribute('data-status') || '';
+				resetAndRender();
+			});
+		});
+
+		/* ---- Init ------------------------------------------------------- */
+		applyView();
+		render();
+	});
+})();


### PR DESCRIPTION


Introduce a modern, fully responsive admin screen for the bus fleet (wbtm_bus), gated behind a new global setting so it can be toggled on/off without affecting the classic WordPress list.

New global setting
- "New Bus List Design" (Enable/Disable, default Enable) added to the General settings tab via the wbtm_filter_general_settings filter.
- When enabled, edit.php?post_type=wbtm_bus redirects to the new screen.
- When disabled, the classic WP list table is shown (no redirect), so the toggle works cleanly in both directions.

New design screen (admin/WBTM_Bus_List.php)
- Registered as a hidden submenu page rendered with full admin chrome; parent_file/submenu_file filters keep the Bus menu highlighted.
- admin_title filter sets the browser tab title ("Bus Lists", or "Trash - Bus Lists") since orphan pages can't resolve it automatically.
- Stat cards: Total / Published / AC Coach / Non AC Coach, computed from wbtm_bus_category and post status.
- Card grid + table views populated from real post data: title, wbtm_bus_no, seat-plan type, category, featured image (gradient fallback), author initials and status badge.
- Edit and Move-to-Trash actions per item (nonce-protected, confirm).
- "Classic view" link (wbtm_view=classic) bypasses the redirect.

Trash management in the new design
- Trash tab shows trashed buses inside the same styled layout instead of bouncing to the old list.
- Per-item Restore and Delete Permanently actions (nonce-protected).
- Counts always reflect the active fleet; trashed titles are non-editable.

Separate assets
- assets/admin/wbtm_bus_list.css: scoped under .wbtm-fleet, responsive (4->2->1 stat columns, single-column grid, table collapses to stacked cards on mobile). Card action buttons reveal on hover/focus.
- assets/admin/wbtm_bus_list.js: persisted grid/list toggle, live search (title + coach no) with clear button, custom styled type dropdown, status tabs and client-side pagination (12/page).

Both assets are enqueued only on this screen.