### PR TITLE
Add frontend "View" button to modern bus list + fix seat plan label typo

### DIFF
--- a/admin/WBTM_Bus_List.php
+++ b/admin/WBTM_Bus_List.php
@@ -179,11 +179,12 @@
 						'is_nonac'     => $is_nonac,
 						'type'         => $is_ac ? 'AC' : ( $is_nonac ? 'Non AC' : '' ),
 						'bus_type'     => $seat_conf === 'wbtm_seat_plan'
-							? esc_html__( 'Seal Plan', 'bus-ticket-booking-with-seat-reservation' )
-							: esc_html__( 'Without Seal Plan', 'bus-ticket-booking-with-seat-reservation' ),
+							? esc_html__( 'Seat Plan', 'bus-ticket-booking-with-seat-reservation' )
+							: esc_html__( 'Without Seat Plan', 'bus-ticket-booking-with-seat-reservation' ),
 						'status'       => $post->post_status,
 						'thumb'        => get_the_post_thumbnail_url( $pid, 'medium_large' ),
 						'author'       => get_the_author_meta( 'display_name', $post->post_author ),
+						'view_link'    => get_permalink( $pid ),
 						'edit_link'    => get_edit_post_link( $pid, 'raw' ),
 						'trash_link'   => get_delete_post_link( $pid ),
 						'restore_link' => wp_nonce_url( admin_url( sprintf( 'post.php?post=%d&action=untrash', $pid ) ), 'untrash-post_' . $pid ),
@@ -384,6 +385,11 @@
 													<svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><polyline points="3 6 5 6 21 6"/><path d="M19 6l-1 14a2 2 0 01-2 2H8a2 2 0 01-2-2L5 6m3 0V4a2 2 0 012-2h4a2 2 0 012 2v2"/></svg>
 												</a>
 											<?php else : ?>
+												<?php if ( $b['view_link'] ) : ?>
+												<a class="wbtm-act-btn view" href="<?php echo esc_url( $b['view_link'] ); ?>" target="_blank" rel="noopener" title="<?php esc_attr_e( 'View on frontend', 'bus-ticket-booking-with-seat-reservation' ); ?>">
+													<svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/><circle cx="12" cy="12" r="3"/></svg>
+												</a>
+												<?php endif; ?>
 												<a class="wbtm-act-btn edit" href="<?php echo esc_url( $b['edit_link'] ); ?>" title="<?php esc_attr_e( 'Edit', 'bus-ticket-booking-with-seat-reservation' ); ?>">
 													<svg width="14" height="14" fill="none" stroke="currentColor" stroke-width="2" viewBox="0 0 24 24"><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7"/><path d="M18.5 2.5a2.12 2.12 0 013 3L12 15l-4 1 1-4 9.5-9.5z"/></svg>
 												</a>
@@ -438,6 +444,7 @@
 												<a class="wbtm-table-edit" href="<?php echo esc_url( $b['restore_link'] ); ?>"><?php esc_html_e( 'Restore', 'bus-ticket-booking-with-seat-reservation' ); ?></a>
 												<a class="wbtm-table-del" href="<?php echo esc_url( $b['delete_link'] ); ?>" onclick="return confirm('<?php echo esc_js( __( 'Permanently delete this bus? This cannot be undone.', 'bus-ticket-booking-with-seat-reservation' ) ); ?>');"><?php esc_html_e( 'Delete', 'bus-ticket-booking-with-seat-reservation' ); ?></a>
 											<?php else : ?>
+												<?php if ( $b['view_link'] ) : ?><a class="wbtm-table-view" href="<?php echo esc_url( $b['view_link'] ); ?>" target="_blank" rel="noopener"><?php esc_html_e( 'View', 'bus-ticket-booking-with-seat-reservation' ); ?></a><?php endif; ?>
 												<a class="wbtm-table-edit" href="<?php echo esc_url( $b['edit_link'] ); ?>"><?php esc_html_e( 'Edit', 'bus-ticket-booking-with-seat-reservation' ); ?></a>
 												<a class="wbtm-table-del" href="<?php echo esc_url( $b['trash_link'] ); ?>" onclick="return confirm('<?php echo esc_js( __( 'Move this bus to Trash?', 'bus-ticket-booking-with-seat-reservation' ) ); ?>');"><?php esc_html_e( 'Trash', 'bus-ticket-booking-with-seat-reservation' ); ?></a>
 											<?php endif; ?>

--- a/admin/WBTM_CPT.php
+++ b/admin/WBTM_CPT.php
@@ -134,7 +134,7 @@
 			}
 			public function custom_column_data($column, $post_id) {
 				$seat_plan = WBTM_Global_Function::get_post_info($post_id, 'wbtm_seat_type_conf');
-				$seat_plan_text = $seat_plan == 'wbtm_seat_plan' ? esc_html__('Seal Plan', 'bus-ticket-booking-with-seat-reservation') : esc_html__('Without Seal Plan', 'bus-ticket-booking-with-seat-reservation');
+				$seat_plan_text = $seat_plan == 'wbtm_seat_plan' ? esc_html__('Seat Plan', 'bus-ticket-booking-with-seat-reservation') : esc_html__('Without Seat Plan', 'bus-ticket-booking-with-seat-reservation');
 				switch ($column) {
 					case 'wbtm_bus_no':
 						echo wp_kses_post("<span class=''>" . WBTM_Global_Function::get_post_info($post_id, 'wbtm_bus_no') . "</span>");

--- a/assets/admin/wbtm_bus_list.css
+++ b/assets/admin/wbtm_bus_list.css
@@ -130,6 +130,8 @@
 .wbtm-act-btn.del:hover{background:var(--wbtm-red);color:#fff;}
 .wbtm-act-btn.restore{background:rgba(22,163,74,.95);color:#fff;}
 .wbtm-act-btn.restore:hover{background:var(--wbtm-green);color:#fff;}
+.wbtm-act-btn.view{background:rgba(37,99,235,.95);color:#fff;}
+.wbtm-act-btn.view:hover{background:var(--wbtm-blue);color:#fff;}
 .wbtm-bus-body{padding:16px;}
 .wbtm-bus-name{display:block;font-size:15px;font-weight:700;color:var(--wbtm-ink) !important;margin-bottom:10px;line-height:1.3;text-decoration:none;}
 .wbtm-bus-name:hover{color:var(--wbtm-red) !important;}
@@ -164,8 +166,10 @@
 .wbtm-t-badge.type{background:var(--wbtm-blue-soft);color:var(--wbtm-blue);}
 .wbtm-t-badge.ac{background:var(--wbtm-red-soft);color:var(--wbtm-red);}
 .wbtm-t-badge.nonac{background:#f1f0ff;color:#6d5acd;}
-.wbtm-table-edit,.wbtm-table-del{padding:4px 12px;border-radius:6px;border:1px solid var(--wbtm-border);background:var(--wbtm-white);font-size:11px;font-weight:600;cursor:pointer;text-decoration:none;color:var(--wbtm-ink2) !important;display:inline-block;}
+.wbtm-table-edit,.wbtm-table-del,.wbtm-table-view{padding:4px 12px;border-radius:6px;border:1px solid var(--wbtm-border);background:var(--wbtm-white);font-size:11px;font-weight:600;cursor:pointer;text-decoration:none;color:var(--wbtm-ink2) !important;display:inline-block;}
 .wbtm-table-edit:hover{border-color:var(--wbtm-blue);color:var(--wbtm-blue) !important;}
+.wbtm-table-view{margin-right:4px;}
+.wbtm-table-view:hover{border-color:var(--wbtm-blue);color:var(--wbtm-blue) !important;}
 .wbtm-table-del{margin-left:4px;}
 .wbtm-table-del:hover{border-color:var(--wbtm-red);color:var(--wbtm-red) !important;}
 


### PR DESCRIPTION
Bus list (modern grid/table design):
- Add a "View on frontend" action that opens the bus's public permalink in a new tab, shown alongside Edit/Delete on card hover and in the table view.
- Expose view_link (get_permalink) in the bus data array used by the template.
- Style the new .wbtm-act-btn.view (blue circular icon button matching the existing edit/delete actions) and the .wbtm-table-view link.
- The View action is only rendered for non-trashed buses and opens with target="_blank" rel="noopener".

Misc:
- Fix label typo in the classic bus list column: "Seal Plan" -> "Seat Plan" (admin/WBTM_CPT.php).