### PR TITLE
feat: show return bus on single bus page when same-bus return is enabled

### DIFF
--- a/inc/WBTM_Layout.php
+++ b/inc/WBTM_Layout.php
@@ -198,7 +198,7 @@
                                     <?php esc_attr_e( 'Departure Bus', 'bus-ticket-booking-with-seat-reservation' )?>
                                 </div>
 
-                                <?php  if ($post_id == 0 && $start_route && $end_route && $r_date) { ?>
+                                <?php  if ( ( $post_id == 0 || WBTM_Functions::is_same_bus_return_enabled( $post_id ) ) && $start_route && $end_route && $r_date) { ?>
                                     <div class="wtbm_return_route <?php echo esc_attr( $return_bus_tab );?>" id="wbtm_date_return_route_start" data-alert="<?php echo esc_attr__( 'Please place departure bus first.', 'bus-ticket-booking-with-seat-reservation' ); ?>">
                                         <?php esc_attr_e( 'Return Bus', 'bus-ticket-booking-with-seat-reservation' )?>
                                     </div>
@@ -222,7 +222,7 @@
                     </div>
                     <div class="wbtm_return_bus_lists_holder" id="wbtm_return_bus_lists_holder">
                         <?php }
-                        if ($post_id == 0 && $start_route && $end_route && $r_date) { ?>
+                        if ( ( $post_id == 0 || WBTM_Functions::is_same_bus_return_enabled( $post_id ) ) && $start_route && $end_route && $r_date) { ?>
                         <div class="wbtm-bus-lists" id="wbtm_return_container" style="display: <?php echo esc_attr( $return_bus );?>">
                             <?php if( $next_date === 'yes' ){?>
                                 <div class="wbtm-date-suggetion">
@@ -235,7 +235,7 @@
                                 </div>-->
                                  <?php self::route_title('Return', $start_route, $end_route, $j_date, $r_date, true); ?>
                                 <div class="wbtm-bus-lists" id="return_bus">
-                                    <?php do_action('wbtm_search_result', $end_route, $start_route, $r_date, '', $style, $btn_show, $search_info, 'return_journey', $left_filter_show); ?>
+                                    <?php do_action('wbtm_search_result', $end_route, $start_route, $r_date, $post_id == 0 ? '' : $post_id, $style, $btn_show, $search_info, 'return_journey', $left_filter_show); ?>
                                 </div>
                             </div>
                         </div>

--- a/readme.txt
+++ b/readme.txt
@@ -336,6 +336,12 @@ Made compatiable with some of the major caching plugin
 = 5.5.3 =
 Translation Issue fixed
 
+
+= 5.5.6 =
+Cabin booking functionality added
+Bus default available seat selection added
+Seat number rotation stopped
+
 = 5.5.7 =
 *Release Date - 11 Jun 2026*
 
@@ -386,7 +392,3 @@ Translation Issue fixed
 * 10 Free Plugin docs and 12 PRO Addon docs with visual distinction
 * Shortcode reference table updated with PRO shortcodes
 
-= 5.5.6 =
-Cabin booking functionality added
-Bus default available seat selection added
-Seat number rotation stopped

--- a/readme.txt
+++ b/readme.txt
@@ -336,6 +336,56 @@ Made compatiable with some of the major caching plugin
 = 5.5.3 =
 Translation Issue fixed
 
+= 5.5.7 =
+*Release Date - 11 Jun 2026*
+
+**Return Bus on Single Bus Page**
+* Added return date picker on single bus details page when same-bus return is enabled
+* Added "Departure Bus" and "Return Bus" tabs in search results on single bus page
+* Return bus tab shows the same bus for the return trip with same-day time filtering
+* Previously return functionality was only available on the global search page
+
+**Admin - New Bus List Design**
+* Introduced modern responsive admin screen for bus fleet with grid/table views
+* New "New Bus List Design" setting (Enable/Disable) in General settings
+* Stat cards showing Total / Published / AC Coach / Non AC Coach counts
+* Card grid and table views with bus details, featured image, author and status
+* Edit, Trash, Restore and Delete actions with nonce protection
+* Trash management within the same styled layout
+* Live search by title and coach number with client-side pagination
+* Grid/list toggle persisted across sessions
+
+**Admin - Bus List UX Upgrades**
+* Table view now shows bus featured image thumbnail in Name column
+* Name column shows route details (start/end points with stop count)
+* Journey date info: schedule range for Repeated mode, first date + count for Particular mode
+* Return route displayed when same-bus return is enabled with "Return" tag
+* Action buttons converted to icon buttons (view/edit/trash) with accessible labels
+
+**Admin - Return Timetable Warning**
+* Added highlighted warning box in return route settings reminding to rearrange return timetable
+* Auto-generated reverse stops keep outbound clock times and need adjusting before saving
+
+**Frontend - Sold-Out Date Picker**
+* Journey and return date pickers now show sold-out dates as unselectable
+* Sold-out dates marked with red "Sold Out" style and legend
+* Works for both single bus and general search date pickers
+
+**Frontend - View Button**
+* Added "View on frontend" action in bus list to open bus permalink in new tab
+* Shown alongside Edit/Delete on card hover and in table view
+
+**Bug Fixes**
+* Fixed return-bus Details/Stops/Features popup not opening after outbound selection
+* Fixed duplicate ID issue causing popup to target wrong container
+* Fixed "Seal Plan" typo to "Seat Plan" in classic bus list column
+
+**Admin - Documents Tab**
+* Replaced video-only tutorials with searchable documentation system
+* New "Documents" tab with 24 sub-tabs organized by bus settings
+* 10 Free Plugin docs and 12 PRO Addon docs with visual distinction
+* Shortcode reference table updated with PRO shortcodes
+
 = 5.5.6 =
 Cabin booking functionality added
 Bus default available seat selection added

--- a/templates/layout/search_form.php
+++ b/templates/layout/search_form.php
@@ -139,7 +139,7 @@
                                 <div class="wtbm_inputList wbtm_journey_date">
                                     <?php WBTM_Layout::journey_date_picker( $post_id, $start_route, $end_route, $start_time ); ?>
                                 </div>
-                                <?php if ( $return_date_show == 'enable' && $post_id == 0 ) { ?>
+                                <?php if ( $return_date_show == 'enable' && ( $post_id == 0 || WBTM_Functions::is_same_bus_return_enabled( $post_id ) ) ) { ?>
                                     <div class="wtbm_inputList wbtm_return_date">
                                         <?php WBTM_Layout::return_date_picker( $post_id, $end_route, $start_route, $start_time, $end_time ); ?>
                                     </div>

--- a/woocommerce-bus.php
+++ b/woocommerce-bus.php
@@ -3,7 +3,7 @@
 	 * Plugin Name: Bus Ticket Booking with Seat Reservation
 	 * Plugin URI: http://mage-people.com
 	 * Description: A Complete Bus Ticketing System for WordPress & WooCommerce
-	 * Version: 5.7.0
+	 * Version: 5.7.7
 	 * Author: MagePeople Team
 	 * Author URI: http://www.mage-people.com/
 	 * Text Domain: bus-ticket-booking-with-seat-reservation


### PR DESCRIPTION
Previously, the return date picker and return bus results were only shown on the global search page ($post_id == 0). Single bus pages with same-bus return enabled had no way to search or view return trips.

Changes:
- search_form.php: Show return date picker on single bus page when WBTM_Functions::is_same_bus_return_enabled() returns true
- WBTM_Layout.php: Show 'Return Bus' tab in search results for single bus pages with same-bus return enabled
- WBTM_Layout.php: Render return bus results section on single bus page, passing the bus ID so the same bus is shown for the return trip

This allows passengers to:
1. Select a return date on the single bus details page
2. See both Departure and Return bus tabs after searching
3. Book the same bus for both outbound and return journeys
4. Benefit from same-day time filtering (return bus departs after outbound bus arrives)