### PR TITLE
feat: bidirectional stop search, editable return route & correct jour…

### DIFF
--- a/assets/frontend/wbtm.css
+++ b/assets/frontend/wbtm.css
@@ -2085,3 +2085,90 @@ div.wbtm_bus_list_area div.wbtm_seat_plan_upper div.seat_in_cart .seat_visual {
     overflow-x: hidden;
   }
 }
+
+/* Editable Return Route (Pro): style the return From/To selectors to match the
+   plugin's main search inputs (boxed input with an inline marker icon), and show
+   the locked "From" (fixed to the outbound destination) as read-only. */
+.wbtm_return_route_selectors {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-end;
+  gap: 10px;
+  width: 100%;
+  margin: 12px 0 10px;
+  padding: 12px 14px;
+  background-color: var(--wbtm_color_white, #ffffff);
+  border: 1px solid var(--wbtm_color_border, #e5e7eb);
+  border-radius: 10px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.04);
+  box-sizing: border-box;
+}
+.wbtm_return_route_selectors .wtbm_inputList {
+  position: relative;
+  flex: 1 1 calc(50% - 10px);
+  min-width: 180px;
+  margin: 0;
+}
+.wbtm_return_route_selectors .wtbm_fdColumn {
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+  gap: 4px;
+  font-size: var(--wbtm_fs_label, 14px);
+  color: #555;
+}
+.wbtm_return_route_selectors .marker {
+  position: relative;
+}
+.wbtm_return_route_selectors .marker > i.fa-map-marker-alt {
+  position: absolute;
+  top: 50%;
+  left: 12px;
+  transform: translateY(-50%);
+  color: #999;
+  font-size: 14px;
+  pointer-events: none;
+}
+.wbtm_return_route_selectors input.formControl {
+  width: 100%;
+  height: 44px;
+  padding: 0 14px 0 32px;
+  font-size: 16px;
+  color: #333;
+  background-color: var(--wbtm_color_white, #ffffff);
+  border: 1px solid #7d7979;
+  border-radius: 6px;
+  box-sizing: border-box;
+  outline: none;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+}
+.wbtm_return_route_selectors input.formControl:focus {
+  border-color: var(--wbtm_color_theme, #2271b1);
+  box-shadow: 0 0 0 2px rgba(34, 113, 177, 0.12);
+}
+/* Locked "From" — read-only, with a lock icon on the right. */
+.wbtm_return_route_selectors .wbtm_return_from_fixed input.formControl {
+  padding-right: 30px;
+  cursor: not-allowed;
+  background-color: #f4f5f7;
+  color: #555;
+  pointer-events: none;
+}
+.wbtm_return_route_selectors .wbtm_return_from_fixed .wbtm_return_from_lock {
+  position: absolute;
+  right: 12px;
+  top: 50%;
+  transform: translateY(-50%);
+  font-size: 12px;
+  color: #9aa0a6;
+  pointer-events: none;
+}
+/* Reuse the main search dropdown look for the editable "To" list. */
+.wbtm_return_route_selectors ul.wbtm_input_select_list {
+  width: 100%;
+}
+@media only screen and (max-width: 767px) {
+  .wbtm_return_route_selectors .wtbm_inputList {
+    flex: 1 1 100%;
+  }
+}

--- a/assets/global/wbtm_global.js
+++ b/assets/global/wbtm_global.js
@@ -874,6 +874,80 @@
 		});
 	}
 
+	/**
+	 * Editable Return Route (Pro): the return "From" is fixed to the outbound
+	 * destination (you return from where you arrived), so only the "To" is editable.
+	 * When the customer picks the return "To", reload the return bus list for the
+	 * fixed From -> chosen To.
+	 */
+	$(document).on('mp_change', '#wbtm_return_container .wbtm_return_dropping_point input.formControl', function () {
+		let container = $(this).closest('#wbtm_return_container');
+		wbtm_reload_return_bus_list(container);
+	});
+
+	function wbtm_reload_return_bus_list(container) {
+		let return_start = container.find('.wbtm_return_start_point input.formControl').val();
+		let return_end = container.find('.wbtm_return_dropping_point input.formControl').val();
+		if (!return_start || !return_end) {
+			return;
+		}
+		// Guard against selecting the same place for From and To.
+		if (return_start === return_end) {
+			let alertMsg = container.find('.wbtm_return_dropping_point').data('alert') || 'You select Wrong Route !';
+			wbtm_toast(alertMsg);
+			return;
+		}
+		let listContainer = container.find('.wbtm_return_bus_lists_container');
+		let leftFilter = container.data('left-filter');
+		try {
+			leftFilter = (typeof leftFilter === 'string') ? leftFilter : JSON.stringify(leftFilter || {});
+		} catch (e) {
+			leftFilter = '{}';
+		}
+		// On a same-day round trip, tell the server the outbound arrival time so it can
+		// roll the return forward to the next day when no same-day bus departs after it.
+		let outboundCard = $('#wbtm_seleced_start_bus .wbtm_selected_bus_card');
+		let floorTime = '';
+		if (outboundCard.length) {
+			let jd = wbtm_normalize_date_only(outboundCard.data('j-date'));
+			let rd = wbtm_normalize_date_only(container.data('r-date'));
+			if (jd && rd && jd === rd) {
+				floorTime = outboundCard.data('outbound-dp-time') || '';
+			}
+		}
+		$.ajax({
+			type: 'POST',
+			url: wbtm_ajax_url,
+			data: {
+				action: 'get_wbtm_return_bus_list',
+				post_id: container.data('post-id'),
+				return_start: return_start,
+				return_end: return_end,
+				j_date: container.data('j-date'),
+				r_date: container.data('r-date'),
+				style: container.data('style'),
+				btn_show: container.data('btn-show'),
+				left_filter_show: leftFilter,
+				floor_time: floorTime,
+				nonce: wbtm_nonce
+			},
+			beforeSend: function () {
+				wbtm_loader(listContainer);
+			},
+			success: function (data) {
+				listContainer.html(data).promise().done(function () {
+					wbtm_loaderRemove(listContainer);
+					// Re-apply same-day time filter against the selected outbound bus.
+					wbtm_filter_return_buses_by_outbound_time();
+				});
+			},
+			error: function (response) {
+				wbtm_loaderRemove(listContainer);
+				console.log(response);
+			}
+		});
+	}
+
 
 	$(document).on('click', '#wbtm_add_to_cart', function (e) {
 		e.preventDefault();
@@ -916,6 +990,13 @@
 
 		let burPosition = this_btn.closest('.wbtm-bus-lists').attr('id');
 		let numberOfBuses = $('#wbtm_return_container .wtbm_bus_counter').length;
+		// A round trip was requested whenever the return container is present (it only
+		// renders when a return date was chosen). We must show the Return tab in that
+		// case even if the default (exact-reverse) leg currently has no bus — e.g. a
+		// reverse-direction outbound whose mirror leg isn't bookable — so the customer
+		// can pick a valid return route (Editable Return Route) or "Checkout Without Return",
+		// instead of being silently redirected to checkout.
+		let returnRequested = $('#wbtm_return_container').length > 0;
 
 		let wbtm_cabin_mode_enabled = form.find(':input[name=wbtm_cabin_mode_enabled]').val();
 
@@ -981,6 +1062,8 @@
 			"price_val": encodeURIComponent(priceVal),
 			"wbtm_post_id": form.find(':input[name=wbtm_post_id]').val(),
 			"wbtm_price_leg": form.find(':input[name=wbtm_price_leg]').val() || "outbound",
+			// Journey role (which tab booked from), independent of the internal fare leg.
+			"wbtm_journey_type": (burPosition === 'return_bus') ? 'return' : 'departure',
 			"wbtm_start_point": form.find(':input[name=wbtm_start_point]').val(),
 			"wbtm_cabin_mode_enabled": wbtm_cabin_mode_enabled,
 			"wbtm_start_time": form.find(':input[name=wbtm_start_time]').val(),
@@ -1036,15 +1119,13 @@
 			},
 			complete: function () {
 				if (burPosition === 'start_bus') {
-					if (numberOfBuses > 0) {
+					if (returnRequested) {
 						wbtm_set_loading_button_state(this_btn, false);
-						// $('#wbtm_return_container').find('#wbtm_selected_bus_notification').slideDown('fast');
-						/*$("#start_bus").fadeOut();
-						$("#wbtm_return_container").fadeIn();
-
-						// $("#wbtm_date_return_route_start").fadeOut();
-						$("#wbtm_date_return_route_return").fadeIn();*/
-
+						// Show the Return tab so the customer can choose a return bus (or
+						// change the return route when Editable Return Route is on, or use
+						// "Checkout Without Return"). Previously this checked the return bus
+						// count and silently jumped to checkout when the default reverse leg
+						// had no bus — breaking round trips for reverse-direction searches.
 						wtbm_active_return_bus_tab_data();
 
 					} else {
@@ -1064,12 +1145,14 @@
 		let defaultHtml = this_btn.html();
 		let startDate = parent.find(':input[name=j_date]').val() || this_btn.attr('data-date') || '';
 		let returnDate = parent.find(':input[name=r_date]').val() || '';
+		let fullBusJourneyType = this_btn.closest('#return_bus').length ? 'return' : 'departure';
 		let requestData = {
 			"action": "wbtm_ajax_add_to_cart",
 			"wbtm_booking_mode": "full_bus",
 			"price_val": encodeURIComponent(this_btn.attr('data-price') || 0),
 			"wbtm_post_id": this_btn.attr('data-bus-id'),
 			"wbtm_price_leg": this_btn.attr('data-price-leg') || "outbound",
+			"wbtm_journey_type": fullBusJourneyType,
 			"wbtm_start_point": this_btn.attr('data-start-point'),
 			"wbtm_start_time": this_btn.attr('data-start-time'),
 			"wbtm_bp_place": this_btn.attr('data-bp-place'),

--- a/inc/WBTM_Functions.php
+++ b/inc/WBTM_Functions.php
@@ -61,16 +61,72 @@
 				if ( ! $start_route ) {
 					return self::single_bus_route_from_infos( $forward, '' );
 				}
-				$r = self::single_bus_route_from_infos( $forward, $start_route );
-				if ( sizeof( $r ) === 0 && self::is_same_bus_return_enabled( $post_id ) ) {
+				$forward_dests = self::single_bus_route_from_infos( $forward, $start_route );
+				$r             = $forward_dests;
+
+				if ( self::is_same_bus_return_enabled( $post_id ) ) {
+					// Destinations reachable on the return leg from this same boarding point.
+					$return_dests = [];
 					foreach ( self::get_same_bus_return_route_candidates( $post_id, $forward ) as $infos ) {
-						$r = self::single_bus_route_from_infos( $infos, $start_route );
-						if ( sizeof( $r ) > 0 ) {
+						$candidate = self::single_bus_route_from_infos( $infos, $start_route );
+						if ( sizeof( $candidate ) > 0 ) {
+							$return_dests = $candidate;
 							break;
 						}
 					}
+
+					/**
+					 * Bidirectional stop search (Pro feature).
+					 *
+					 * When TRUE, a passenger boarding at an intermediate stop can pick a
+					 * destination in EITHER direction, so the forward and return
+					 * destination lists are merged (e.g. from Nelspruit you can reach both
+					 * O.R. Tambo outbound and Marloth Park on the return leg).
+					 *
+					 * When FALSE (default / free), behaviour is unchanged: the return leg
+					 * is only used as a fallback for terminal stops that have no forward
+					 * destination (e.g. the final stop of the outbound route).
+					 *
+					 * @param bool   $enabled     Default false.
+					 * @param int    $post_id     Bus post ID.
+					 * @param string $start_route Selected boarding point.
+					 */
+					$bidirectional = (bool) apply_filters( 'wbtm_enable_bidirectional_route_search', false, $post_id, $start_route );
+
+					if ( $bidirectional ) {
+						// Offer every stop reachable later on EITHER physical leg (by position) so
+						// intermediate->intermediate trips work even when stops are boarding-only.
+						$merged = [];
+						foreach ( self::get_same_bus_physical_legs( $post_id, $forward ) as $leg ) {
+							$merged = self::merge_unique_routes( $merged, self::dests_after_by_position( $leg, $start_route ) );
+						}
+						$r = $merged;
+					} elseif ( sizeof( $forward_dests ) === 0 ) {
+						$r = $return_dests;
+					}
 				}
 				return $r;
+			}
+
+			/**
+			 * Merge two route-place lists, preserving order and removing
+			 * case-insensitive duplicates.
+			 *
+			 * @param array<int, string> $a
+			 * @param array<int, string> $b
+			 * @return array<int, string>
+			 */
+			private static function merge_unique_routes( $a, $b ) {
+				$out  = [];
+				$seen = [];
+				foreach ( array_merge( (array) $a, (array) $b ) as $place ) {
+					$key = strtolower( (string) $place );
+					if ( $place !== '' && $place !== null && ! isset( $seen[ $key ] ) ) {
+						$seen[ $key ] = true;
+						$out[]        = $place;
+					}
+				}
+				return $out;
 			}
 
 			/**
@@ -213,25 +269,8 @@
 				if ( ! $post_id || ! $start_route || ! $end_route ) {
 					return $fallback_leg;
 				}
-
-				$dir = WBTM_Global_Function::get_post_info( $post_id, 'wbtm_route_direction', [] );
-				if ( ! is_array( $dir ) || count( $dir ) < 2 ) {
-					return $fallback_leg;
-				}
-
-				$sp = self::route_place_index( $dir, $start_route );
-				$ep = self::route_place_index( $dir, $end_route );
-				if ( $sp === null || $ep === null || $sp === $ep ) {
-					return $fallback_leg;
-				}
-
-				// Fixed by Shahnur - 2026-04-23 02:50 PM (Asia/Dhaka)
-				// Use the searched stop direction to choose outbound vs return fare rows.
-				if ( $sp > $ep && self::is_same_bus_return_enabled( $post_id ) ) {
-					return 'return';
-				}
-
-				return 'outbound';
+				$resolved = self::resolve_od_leg( $post_id, $start_route, $end_route );
+				return $resolved['leg'] !== null ? $resolved['leg'] : $fallback_leg;
 			}
 
 			/**
@@ -241,30 +280,210 @@
 			 * @return array<int, array<string, mixed>>
 			 */
 			public static function resolve_route_infos_for_od_pair( $post_id, $start_route, $end_route, $forward_route_infos = null ) {
+				$resolved = self::resolve_od_leg( $post_id, $start_route, $end_route, $forward_route_infos );
+				return $resolved['route_infos'];
+			}
+
+			/**
+			 * Decide which leg (outbound vs return) and which route-row set serves an
+			 * origin/destination pair, choosing the leg that connects the two stops with
+			 * the SHORTEST forward (non day-wrapping) travel time.
+			 *
+			 * This is more robust than ordering stops via the stored `wbtm_route_direction`
+			 * list: on a bidirectional "same bus return" trip a pair such as Berlin -> Hamburg
+			 * exists on BOTH legs (outbound 07:00->08:00 and the reversed return 14:00->13:00+1d).
+			 * We always want the natural same-day leg, regardless of how the direction array
+			 * happens to be ordered.
+			 *
+			 * @param array<int, array<string, mixed>>|null $forward_route_infos
+			 * @return array{leg: string|null, route_infos: array<int, array<string, mixed>>}
+			 */
+			private static function resolve_od_leg( $post_id, $start_route, $end_route, $forward_route_infos = null ) {
 				if ( $forward_route_infos === null ) {
 					$forward_route_infos = WBTM_Global_Function::get_post_info( $post_id, 'wbtm_route_info', [] );
 				}
-				if ( ! is_array( $forward_route_infos ) || count( $forward_route_infos ) < 2 ) {
-					return is_array( $forward_route_infos ) ? $forward_route_infos : [];
+				if ( ! is_array( $forward_route_infos ) ) {
+					$forward_route_infos = [];
 				}
-				$dir = WBTM_Global_Function::get_post_info( $post_id, 'wbtm_route_direction', [] );
-				if ( ! is_array( $dir ) || count( $dir ) < 2 ) {
-					return $forward_route_infos;
+				$result = [ 'leg' => null, 'route_infos' => $forward_route_infos ];
+				if ( count( $forward_route_infos ) < 2 || ! $start_route || ! $end_route ) {
+					return $result;
 				}
-				$sp = self::route_place_index( $dir, $start_route );
-				$ep = self::route_place_index( $dir, $end_route );
-				if ( $sp === null || $ep === null || $sp === $ep ) {
-					return $forward_route_infos;
+
+				$same_bus_return = $post_id && self::is_same_bus_return_enabled( $post_id );
+
+				// Physical legs the bus actually runs (index 0 = outbound, 1 = return).
+				$candidates = $same_bus_return
+					? self::get_same_bus_physical_legs( $post_id, $forward_route_infos )
+					: [ $forward_route_infos ];
+
+				$ref_date = current_time( 'Y-m-d' );
+				$best_dur = null;
+				foreach ( $candidates as $index => $candidate_rows ) {
+					// Same-bus-return (bidirectional) buses connect any stop to a later stop on a
+					// leg regardless of bp/dp type; normal buses honour the configured types.
+					$supported = $same_bus_return
+						? self::route_infos_support_od_by_position( $candidate_rows, $start_route, $end_route )
+						: self::wbtm_route_infos_support_od_leg( $candidate_rows, $start_route, $end_route );
+					if ( ! $supported ) {
+						continue;
+					}
+					$times = self::od_leg_times_from_infos( $post_id, $candidate_rows, $start_route, $end_route, $ref_date );
+					if ( empty( $times ) ) {
+						continue;
+					}
+					$duration = strtotime( $times['dp_time'] ) - strtotime( $times['bp_time'] );
+					// Strict "<" so the outbound leg (checked first) wins ties.
+					if ( $best_dur === null || $duration < $best_dur ) {
+						$best_dur               = $duration;
+						$result['leg']         = $index === 0 ? 'outbound' : 'return';
+						$result['route_infos'] = $candidate_rows;
+					}
 				}
-				if ( $sp > $ep && self::is_same_bus_return_enabled( $post_id ) ) {
-					foreach ( self::get_same_bus_return_route_candidates( $post_id, $forward_route_infos ) as $candidate ) {
-						if ( self::wbtm_route_infos_support_od_leg( $candidate, $start_route, $end_route ) ) {
-							return $candidate;
+				return $result;
+			}
+
+			/**
+			 * The two physical legs a same-bus-return bus runs: [outbound, return].
+			 * The return leg is the custom return timetable when set, else the reversed outbound.
+			 *
+			 * @param array<int, array<string, mixed>> $forward_route_infos
+			 * @return array<int, array<int, array<string, mixed>>>
+			 */
+			private static function get_same_bus_physical_legs( $post_id, $forward_route_infos ) {
+				$legs   = [ $forward_route_infos ];
+				$custom = WBTM_Global_Function::get_post_info( $post_id, 'wbtm_return_route_info', [] );
+				if ( is_array( $custom ) && count( $custom ) > 1 ) {
+					$legs[] = $custom;
+				} else {
+					$legs[] = self::reverse_wbtm_route_infos( $forward_route_infos );
+				}
+				return $legs;
+			}
+
+			/**
+			 * Stops reachable after $start_route on a leg, by position (ignoring bp/dp type).
+			 *
+			 * @param array<int, array<string, mixed>> $route_infos
+			 * @return array<int, string>
+			 */
+			private static function dests_after_by_position( $route_infos, $start_route ) {
+				$out     = [];
+				$started = false;
+				if ( is_array( $route_infos ) ) {
+					foreach ( $route_infos as $row ) {
+						if ( ! is_array( $row ) || ! isset( $row['place'] ) || $row['place'] === '' ) {
+							continue;
+						}
+						if ( $started ) {
+							$out[] = $row['place'];
+						} elseif ( strtolower( (string) $row['place'] ) === strtolower( (string) $start_route ) ) {
+							$started = true;
 						}
 					}
-					return self::reverse_wbtm_route_infos( $forward_route_infos );
 				}
-				return $forward_route_infos;
+				return $out;
+			}
+
+			/**
+			 * Whether $end_route appears after $start_route on a leg, by position (type-agnostic).
+			 *
+			 * @param array<int, array<string, mixed>> $route_infos
+			 */
+			private static function route_infos_support_od_by_position( $route_infos, $start_route, $end_route ) {
+				if ( ! is_array( $route_infos ) || $start_route === '' || $end_route === '' ) {
+					return false;
+				}
+				$started = false;
+				foreach ( $route_infos as $row ) {
+					if ( ! is_array( $row ) || ! isset( $row['place'] ) ) {
+						continue;
+					}
+					$place = strtolower( (string) $row['place'] );
+					if ( ! $started && $place === strtolower( (string) $start_route ) ) {
+						$started = true;
+						continue;
+					}
+					if ( $started && $place === strtolower( (string) $end_route ) ) {
+						return true;
+					}
+				}
+				return false;
+			}
+
+			/**
+			 * Boarding/dropping datetimes for an OD pair within a specific set of route rows on a
+			 * given date, honouring day-wrapping. Same-bus-return buses match stops by position
+			 * (type-agnostic) so a boarding-only intermediate stop still yields times when used as
+			 * a drop point in the opposite direction.
+			 *
+			 * @param array<int, array<string, mixed>> $route_infos
+			 * @return array<string, string>
+			 */
+			private static function od_leg_times_from_infos( $post_id, $route_infos, $start_route, $end_route, $date ) {
+				if ( ! is_array( $route_infos ) || count( $route_infos ) < 2 || ! $start_route || ! $end_route || ! $date ) {
+					return [];
+				}
+				$ignore_types = $post_id && self::is_same_bus_return_enabled( $post_id );
+				$expanded = self::get_route_all_date_info( $post_id, [ gmdate( 'Y-m-d', strtotime( $date ) ) ], $route_infos );
+				foreach ( $expanded as $rows ) {
+					$bp_time = '';
+					foreach ( $rows as $info ) {
+						$is_bp = $ignore_types || $info['type'] === 'bp' || $info['type'] === 'both';
+						$is_dp = $ignore_types || $info['type'] === 'dp' || $info['type'] === 'both';
+						if ( ! $bp_time && $is_bp && strtolower( (string) $info['place'] ) === strtolower( (string) $start_route ) ) {
+							$bp_time = $info['time'];
+							continue;
+						}
+						if ( $bp_time && $is_dp && strtolower( (string) $info['place'] ) === strtolower( (string) $end_route ) ) {
+							return [ 'bp_time' => $bp_time, 'dp_time' => $info['time'] ];
+						}
+					}
+				}
+				return [];
+			}
+
+			/**
+			 * Public: boarding/dropping datetimes for an OD pair on a date, using the
+			 * automatically resolved leg (outbound vs return).
+			 *
+			 * @return array<string, string>
+			 */
+			public static function get_od_leg_datetimes( $post_id, $start_route, $end_route, $date ) {
+				if ( ! $post_id || ! $start_route || ! $end_route || ! $date ) {
+					return [];
+				}
+				$route_infos = self::resolve_route_infos_for_od_pair( $post_id, $start_route, $end_route );
+				return self::od_leg_times_from_infos( $post_id, $route_infos, $start_route, $end_route, $date );
+			}
+
+			/**
+			 * Earliest operational date on/after $r_date whose return bus departs at or after
+			 * $floor_ts (the outbound arrival). Lets a same-day round trip whose mirror leg only
+			 * runs earlier in the day roll forward to the next available day.
+			 *
+			 * @param int $floor_ts Unix timestamp the return boarding must be >=.
+			 * @return string Y-m-d
+			 */
+			public static function resolve_return_date_after( $post_id, $return_start, $return_end, $r_date, $floor_ts ) {
+				$base = $r_date ? gmdate( 'Y-m-d', strtotime( $r_date ) ) : '';
+				if ( ! $post_id || ! $return_start || ! $return_end || ! $base || ! $floor_ts ) {
+					return $base;
+				}
+				$dates = self::get_route_date( $post_id, $return_start );
+				$dates = array_unique( is_array( $dates ) ? $dates : [] );
+				usort( $dates, 'WBTM_Global_Function::sort_date' );
+				foreach ( $dates as $date ) {
+					$date = gmdate( 'Y-m-d', strtotime( $date ) );
+					if ( strtotime( $date ) < strtotime( $base ) ) {
+						continue;
+					}
+					$times = self::get_od_leg_datetimes( $post_id, $return_start, $return_end, $date );
+					if ( ! empty( $times ) && strtotime( $times['bp_time'] ) >= $floor_ts ) {
+						return $date;
+					}
+				}
+				return $base;
 			}
 
 			/**
@@ -501,12 +720,18 @@
 						}
 					}
 				}
-				if ( $price_leg === 'return' && sizeof( $ticket_infos ) === 0 && $try_reverse_return ) {
-					$reverse_return = self::get_ticket_info( $post_id, $end_route, $start_route, 'return', false );
-					if ( sizeof( $reverse_return ) > 0 ) {
-						return $reverse_return;
+				if ( sizeof( $ticket_infos ) === 0 && $try_reverse_return
+					&& ( $price_leg === 'return' || self::is_same_bus_return_enabled( $post_id ) ) ) {
+					// On a same-bus-return bus a city-pair is the same physical segment in both
+					// directions, so when this direction has no fare row configured, fall back to
+					// the mirror pair's fare (resolve_price_leg picks the right leg for it).
+					$reverse = self::get_ticket_info( $post_id, $end_route, $start_route, $price_leg, false );
+					if ( sizeof( $reverse ) > 0 ) {
+						return $reverse;
 					}
-					return self::get_ticket_info( $post_id, $start_route, $end_route, 'outbound', false );
+					if ( $price_leg !== 'outbound' ) {
+						return self::get_ticket_info( $post_id, $start_route, $end_route, 'outbound', false );
+					}
 				}
 				return $ticket_infos;
 			}
@@ -692,6 +917,9 @@
 				if ( $post_id > 0 && $date && $start_route && $end_route ) {
 					$all_dates        = WBTM_Functions::get_post_date( $post_id );
 					$resolved_leg     = self::resolve_route_infos_for_od_pair( $post_id, $start_route, $end_route );
+					// Same-bus-return buses connect stops by position, so a boarding-only intermediate
+					// stop can still serve as a drop point on the opposite-direction leg.
+					$ignore_types     = self::is_same_bus_return_enabled( $post_id );
 					$route_date_infos = WBTM_Functions::get_route_all_date_info( $post_id, $all_dates, $resolved_leg );
 					if ( sizeof( $route_date_infos ) > 0 ) {
 						$now_full = current_time( 'Y-m-d H:i' );
@@ -699,10 +927,10 @@
 							$bp_date = '';
 							if ( sizeof( $route_info ) > 0 ) {
 								foreach ( $route_info as $info ) {
-									if ( strtolower( (string) $start_route ) === strtolower( (string) $info['place'] ) && ( $info['type'] == 'bp' || $info['type'] == 'both' ) && strtotime( $date ) == strtotime( gmdate( 'Y-m-d', strtotime( $info['time'] ) ) ) ) {
+									if ( strtolower( (string) $start_route ) === strtolower( (string) $info['place'] ) && ( $ignore_types || $info['type'] == 'bp' || $info['type'] == 'both' ) && strtotime( $date ) == strtotime( gmdate( 'Y-m-d', strtotime( $info['time'] ) ) ) ) {
 										$bp_date = $info['time'];
 									}
-									if ( $bp_date && strtolower( (string) $end_route ) === strtolower( (string) $info['place'] ) && ( $info['type'] == 'dp' || $info['type'] == 'both' ) ) {
+									if ( $bp_date && strtolower( (string) $end_route ) === strtolower( (string) $info['place'] ) && ( $ignore_types || $info['type'] == 'dp' || $info['type'] == 'both' ) ) {
 										$slice_time = self::slice_buffer_time( $bp_date );
 										if ( strtotime( $now_full ) < strtotime( $slice_time ) ) {
 											$seat_type  = WBTM_Global_Function::get_post_info( $post_id, 'wbtm_seat_type_conf' );

--- a/inc/WBTM_Layout.php
+++ b/inc/WBTM_Layout.php
@@ -23,6 +23,9 @@
 				add_action('wp_ajax_get_wbtm_bus_list', [$this, 'get_wbtm_bus_list']);
 				add_action('wp_ajax_nopriv_get_wbtm_bus_list', [$this, 'get_wbtm_bus_list']);
 				/**************************/
+				add_action('wp_ajax_get_wbtm_return_bus_list', [$this, 'get_wbtm_return_bus_list']);
+				add_action('wp_ajax_nopriv_get_wbtm_return_bus_list', [$this, 'get_wbtm_return_bus_list']);
+				/**************************/
 				add_action('wp_ajax_get_wbtm_bus_details', [$this, 'get_wbtm_bus_details']);
 				add_action('wp_ajax_nopriv_get_wbtm_bus_details', [$this, 'get_wbtm_bus_details']);
 				/**************************/
@@ -83,6 +86,42 @@
 					$redirect_enabled = WBTM_Global_Function::get_settings('wbtm_general_settings', 'cart_empty_after_search', 'off');
 					if ($redirect_enabled === 'on' && WC()->cart->get_cart_contents_count() > 0) {
 						WC()->cart->empty_cart();
+					}
+					die();
+				}
+			}
+			/**
+			 * Re-render only the Return leg's title + bus list for a customer-chosen
+			 * return From/To (Pro: Editable Return Route).
+			 */
+			public function get_wbtm_return_bus_list() {
+				if ( isset( $_POST['nonce'] ) && wp_verify_nonce( sanitize_text_field( wp_unslash( $_POST['nonce'] ) ), 'wtbm_ajax_nonce' ) ) {
+					$post_id      = isset( $_POST['post_id'] ) ? sanitize_text_field( wp_unslash( $_POST['post_id'] ) ) : '';
+					$return_start = isset( $_POST['return_start'] ) ? sanitize_text_field( wp_unslash( $_POST['return_start'] ) ) : '';
+					$return_end   = isset( $_POST['return_end'] ) ? sanitize_text_field( wp_unslash( $_POST['return_end'] ) ) : '';
+					$j_date       = isset( $_POST['j_date'] ) ? sanitize_text_field( wp_unslash( $_POST['j_date'] ) ) : '';
+					$r_date       = isset( $_POST['r_date'] ) ? sanitize_text_field( wp_unslash( $_POST['r_date'] ) ) : '';
+					$style        = isset( $_POST['style'] ) ? sanitize_text_field( wp_unslash( $_POST['style'] ) ) : '';
+					$btn_show     = isset( $_POST['btn_show'] ) ? sanitize_text_field( wp_unslash( $_POST['btn_show'] ) ) : '';
+					$left_filter_show = isset( $_POST['left_filter_show'] )
+						? json_decode( sanitize_text_field( wp_unslash( $_POST['left_filter_show'] ) ), true )
+						: [];
+					if ( ! is_array( $left_filter_show ) ) {
+						$left_filter_show = [];
+					}
+					// Only honour this endpoint when the Pro feature is on.
+					if ( ! self::is_editable_return_enabled( $post_id ) ) {
+						die();
+					}
+					if ( $return_start && $return_end && $r_date ) {
+						$search_info = array(
+							'bus_start_route' => $return_start,
+							'bus_end_route'   => $return_end,
+							'j_date'          => $j_date,
+							'r_date'          => $r_date,
+						);
+						$floor_time = isset( $_POST['floor_time'] ) ? sanitize_text_field( wp_unslash( $_POST['floor_time'] ) ) : '';
+					self::render_return_bus_list_inner( $post_id, $return_start, $return_end, $j_date, $r_date, $style, $btn_show, $search_info, $left_filter_show, $floor_time );
 					}
 					die();
 				}
@@ -222,25 +261,115 @@
                     </div>
                     <div class="wbtm_return_bus_lists_holder" id="wbtm_return_bus_lists_holder">
                         <?php }
-                        if ( ( $post_id == 0 || WBTM_Functions::is_same_bus_return_enabled( $post_id ) ) && $start_route && $end_route && $r_date) { ?>
-                        <div class="wbtm-bus-lists" id="wbtm_return_container" style="display: <?php echo esc_attr( $return_bus );?>">
+                        if ( ( $post_id == 0 || WBTM_Functions::is_same_bus_return_enabled( $post_id ) ) && $start_route && $end_route && $r_date) {
+                            // Return leg defaults to the exact reverse of the outbound trip.
+                            $return_start = $end_route;
+                            $return_end   = $start_route;
+                            $editable_return = self::is_editable_return_enabled( $post_id );
+                            ?>
+                        <div class="wbtm-bus-lists" id="wbtm_return_container" style="display: <?php echo esc_attr( $return_bus );?>"
+                             data-post-id="<?php echo esc_attr( $post_id ); ?>"
+                             data-j-date="<?php echo esc_attr( $j_date ); ?>"
+                             data-r-date="<?php echo esc_attr( $r_date ); ?>"
+                             data-style="<?php echo esc_attr( $style ); ?>"
+                             data-btn-show="<?php echo esc_attr( $btn_show ); ?>"
+                             data-left-filter="<?php echo esc_attr( wp_json_encode( $left_filter_show ) ); ?>">
                             <?php if( $next_date === 'yes' ){?>
                                 <div class="wbtm-date-suggetion">
                                     <?php self::next_date_suggestion($post_id, $start_route, $end_route, $j_date, $r_date, true); ?>
                                 </div>
-                            <?php }?>
+                            <?php }
+                            if ( $editable_return ) {
+                                self::render_return_route_selectors( $post_id, $return_start, $return_end );
+                            }
+                            ?>
                              <div class="wbtm_return_bus_lists_container" >
-                                <!--<div class="wbtm-date-route_title" id="wbtm_date_return_route_return" style="display: none">
-                                    <?php /*self::route_title( 'Return', $start_route, $end_route, $j_date, $r_date, true); */?>
-                                </div>-->
-                                 <?php self::route_title('Return', $start_route, $end_route, $j_date, $r_date, true); ?>
-                                <div class="wbtm-bus-lists" id="return_bus">
-                                    <?php do_action('wbtm_search_result', $end_route, $start_route, $r_date, $post_id == 0 ? '' : $post_id, $style, $btn_show, $search_info, 'return_journey', $left_filter_show); ?>
-                                </div>
+                                 <?php self::render_return_bus_list_inner( $post_id, $return_start, $return_end, $j_date, $r_date, $style, $btn_show, $search_info, $left_filter_show ); ?>
                             </div>
                         </div>
                     </div>
 				    <?php }
+			}
+			/**
+			 * Whether the editable return-route feature (Pro) is enabled.
+			 *
+			 * @param int $post_id Bus post ID (0 for global search).
+			 */
+			public static function is_editable_return_enabled( $post_id = 0 ) {
+				return (bool) apply_filters( 'wbtm_enable_editable_return_route', false, $post_id );
+			}
+			/**
+			 * Render the title + bus list for the return leg.
+			 *
+			 * @param array<string, mixed> $search_info
+			 * @param array<string, mixed> $left_filter_show
+			 */
+			public static function render_return_bus_list_inner( $post_id, $return_start, $return_end, $j_date, $r_date, $style = '', $btn_show = '', $search_info = [], $left_filter_show = [], $floor_time = null ) {
+				$effective_r_date = $r_date;
+				// Same-bus-return round trips: the mirror leg must depart AFTER the outbound
+				// arrives. If the requested (same-day) return date has no such bus, roll forward
+				// to the next operational day that does.
+				if ( $post_id > 0 && WBTM_Functions::is_same_bus_return_enabled( $post_id ) && $j_date && $r_date
+					&& gmdate( 'Y-m-d', strtotime( $j_date ) ) === gmdate( 'Y-m-d', strtotime( $r_date ) ) ) {
+					$floor_ts = null;
+					if ( $floor_time ) {
+						$floor_ts = strtotime( $floor_time );
+					} else {
+						$out_start = isset( $search_info['bus_start_route'] ) ? $search_info['bus_start_route'] : '';
+						$out_end   = isset( $search_info['bus_end_route'] ) ? $search_info['bus_end_route'] : '';
+						if ( $out_start && $out_end ) {
+							$out_times = WBTM_Functions::get_od_leg_datetimes( $post_id, $out_start, $out_end, $j_date );
+							if ( ! empty( $out_times['dp_time'] ) ) {
+								$floor_ts = strtotime( $out_times['dp_time'] );
+							}
+						}
+					}
+					if ( $floor_ts ) {
+						$effective_r_date = WBTM_Functions::resolve_return_date_after( $post_id, $return_start, $return_end, $r_date, $floor_ts );
+					}
+				}
+				// Keep the return booking's date metadata aligned with what is displayed.
+				$search_info['r_date'] = $effective_r_date;
+				// route_title() with $return=true displays $end_route -> $start_route, so pass them
+				// reversed to render "$return_start -> $return_end" with return styling.
+				self::route_title( 'Return', $return_end, $return_start, $j_date, $effective_r_date, true );
+				?>
+                <div class="wbtm-bus-lists" id="return_bus">
+                    <?php do_action( 'wbtm_search_result', $return_start, $return_end, $effective_r_date, $post_id == 0 ? '' : $post_id, $style, $btn_show, $search_info, 'return_journey', $left_filter_show ); ?>
+                </div>
+				<?php
+			}
+			/**
+			 * Render editable From / To selectors for the return leg (Pro feature).
+			 * Reuses the same markup/behaviour as the main search From/To inputs.
+			 */
+			public static function render_return_route_selectors( $post_id, $return_start, $return_end ) {
+				$placeholder_text = WBTM_Translations::text_please_select();
+				?>
+                <div class="wbtm_return_route_selectors">
+                    <div class="wtbm_inputList wbtm_return_start_point wbtm_return_from_fixed">
+                        <label class="wtbm_fdColumn">
+                            <?php echo esc_html( WBTM_Translations::text_from() ); ?>
+                            <div class="marker">
+                                <i class="fas fa-map-marker-alt"></i>
+                                <!-- Return "From" is fixed to the outbound destination (you return from where you arrived); only "To" is editable. -->
+                                <input type="text" class="formControl" name="wbtm_return_start_route" value="<?php echo esc_attr( $return_start ); ?>" readonly="readonly" tabindex="-1" autocomplete="off"/>
+                                <i class="fas fa-lock wbtm_return_from_lock" aria-hidden="true"></i>
+                            </div>
+                        </label>
+                    </div>
+                    <div class="wtbm_inputList wbtm_input_select wbtm_return_dropping_point" data-alert="<?php echo esc_attr( WBTM_Translations::text_select_wrong_route() ); ?>">
+                        <label class="wtbm_fdColumn">
+                            <?php echo esc_html( WBTM_Translations::text_to() ); ?>
+                            <div class="marker">
+                                <i class="fas fa-map-marker-alt wtbm_icon_margin"></i>
+                                <input type="text" class="formControl" name="wbtm_return_end_route" value="<?php echo esc_attr( $return_end ); ?>" placeholder="<?php echo esc_attr( $placeholder_text ); ?>" autocomplete="off"/>
+                            </div>
+                        </label>
+                        <?php self::route_list( $post_id, $return_start ); ?>
+                    </div>
+                </div>
+				<?php
 			}
 			public static function wbtm_get_time_diff($start_time, $end_time) {
 				$start = new DateTime($start_time);
@@ -378,7 +507,8 @@
                 $end = $return ? $start_route : $end_route;
                 $date = $return ? $r_date : $j_date;
 
-                $day = date_i18n("l", strtotime($j_date));
+                // Weekday must match the leg's own date (the return leg may be rolled to a later day).
+                $day = date_i18n("l", strtotime($date));
                 $start_loc = strtoupper(substr($start, 0, 3));
                 $end_loc = strtoupper(substr($end, 0, 3));
 

--- a/inc/WBTM_Woocommerce.php
+++ b/inc/WBTM_Woocommerce.php
@@ -216,6 +216,11 @@
 						$cart_item_data['wbtm_dp_place'] = $dp;
 						$cart_item_data['wbtm_dp_time'] = isset($_POST['wbtm_dp_time']) ? sanitize_text_field(wp_unslash($_POST['wbtm_dp_time'])) : '';
 						$cart_item_data['wbtm_price_leg'] = WBTM_Functions::get_requested_price_leg();
+						// Journey role (departure vs return) is which tab the customer booked from.
+						// It is independent of the fare leg, which can be inverted on bidirectional
+						// same-bus-return routes (e.g. a "departure" trip that uses the return fares).
+						$journey_type_raw = isset( $_POST['wbtm_journey_type'] ) ? sanitize_text_field( wp_unslash( $_POST['wbtm_journey_type'] ) ) : '';
+						$cart_item_data['wbtm_journey_type'] = $journey_type_raw === 'return' ? 'return' : 'departure';
 						$cart_item_data['wbtm_booking_mode'] = $booking_mode === 'full_bus' ? 'full_bus' : 'seat';
 						$cart_item_data['wbtm_pickup_point'] = isset($_POST['wbtm_pickup_point']) ? sanitize_text_field(wp_unslash($_POST['wbtm_pickup_point'])) : '';
 						$cart_item_data['wbtm_drop_off_point'] = isset($_POST['wbtm_drop_off_point']) ? sanitize_text_field(wp_unslash($_POST['wbtm_drop_off_point'])) : '';
@@ -668,6 +673,8 @@
 					$item->add_meta_data('_wbtm_full_bus_seat_count', array_key_exists('wbtm_full_bus_seat_count', $values) ? (int) $values['wbtm_full_bus_seat_count'] : 0);
 					$price_leg = array_key_exists('wbtm_price_leg', $values) && $values['wbtm_price_leg'] === 'return' ? 'return' : 'outbound';
 					$item->add_meta_data('_wbtm_price_leg', $price_leg);
+					$journey_type = array_key_exists('wbtm_journey_type', $values) && $values['wbtm_journey_type'] === 'return' ? 'return' : 'departure';
+					$item->add_meta_data('_wbtm_journey_type', $journey_type);
 					$item->add_meta_data('_wbtm_start_point', $start_point);
 					$item->add_meta_data('_wbtm_start_time', $start_time);
 					$item->add_meta_data('_extra_services', $extra_service);
@@ -749,6 +756,8 @@
 					$ticket_infos = $ticket_infos ? WBTM_Global_Function::data_sanitize($ticket_infos) : [];
 					$order_price_leg = wc_get_order_item_meta($item_id, '_wbtm_price_leg', true);
 					$journey_leg     = ( $order_price_leg === 'return' ) ? 'return' : 'outbound';
+					$order_journey_type = wc_get_order_item_meta($item_id, '_wbtm_journey_type', true);
+					$journey_type_value = ( $order_journey_type === 'return' ) ? 'return' : 'departure';
 					/*************************/
 					if (sizeof($ticket_infos) > 0) {
 						$count = 0;
@@ -805,6 +814,7 @@
 								$data['wbtm_user_phone'] = $billing_phone;
 								$data['wbtm_user_address'] = $billing_address;
 								$data['wbtm_price_leg']    = $journey_leg;
+								$data['wbtm_journey_type'] = $journey_type_value;
 								$booking_data = apply_filters('wbtm_add_booking_data', $data, $post_id, $count);
 								self::add_cpt_data('wbtm_bus_booking', $billing_name, $booking_data);
 								$count++;
@@ -1181,7 +1191,42 @@
                 </div>
 				<?php
 			}
+			/**
+			 * Whether the cart currently holds an explicit return-leg ticket.
+			 */
+			public static function cart_has_return_leg() {
+				if ( ! function_exists( 'WC' ) || ! WC()->cart ) {
+					return false;
+				}
+				foreach ( WC()->cart->get_cart() as $ci ) {
+					if ( ( $ci['wbtm_journey_type'] ?? '' ) === 'return' ) {
+						return true;
+					}
+				}
+				return false;
+			}
+			/**
+			 * Journey badge (Outbound / Return) for a cart line on a round trip. Returns ''
+			 * for a one-way cart so single trips stay uncluttered. Mirrors the ticket/PDF badge.
+			 */
+			public static function cart_journey_badge_html( $cart_item ) {
+				$journey_type = $cart_item['wbtm_journey_type'] ?? '';
+				if ( $journey_type === 'return' ) {
+					$kind = 'return';
+				} elseif ( $journey_type === 'departure' && self::cart_has_return_leg() ) {
+					$kind = 'outbound';
+				} else {
+					return '';
+				}
+				$map = [
+					'return'   => [ esc_html__( 'Return', 'bus-ticket-booking-with-seat-reservation' ), '#2271b1' ],
+					'outbound' => [ esc_html__( 'Outbound', 'bus-ticket-booking-with-seat-reservation' ), '#2e7d32' ],
+				];
+				list( $label, $color ) = $map[ $kind ];
+				return '<span class="wbtm-journey-leg-badge wbtm-journey-leg-' . esc_attr( $kind ) . '" style="display:inline-block;margin:0 0 6px 0;background:' . esc_attr( $color ) . ';color:#fff;padding:3px 10px;border-radius:4px;font-size:11px;font-weight:600;letter-spacing:0.04em;text-transform:uppercase;line-height:1.3;">' . $label . '</span>';
+			}
 			public function show_cart_route_details($cart_item) {
+				echo wp_kses_post( self::cart_journey_badge_html( $cart_item ) );
 				$bp = array_key_exists('wbtm_bp_place', $cart_item) ? $cart_item['wbtm_bp_place'] : '';
 				$bp_time = array_key_exists('wbtm_bp_time', $cart_item) ? $cart_item['wbtm_bp_time'] : '';
 				$dp = array_key_exists('wbtm_dp_place', $cart_item) ? $cart_item['wbtm_dp_place'] : '';

--- a/readme.txt
+++ b/readme.txt
@@ -2,7 +2,7 @@
 Contributors: magepeopleteam, aamahin , hamidxazad
 Tags: bus ticket booking with seat reservation,bus ticket booking for wordpress, woocommerce seat reservation for wordpress woocommerce
 Requires at least: 4.5
-Stable tag: 5.5.7
+Stable tag: 5.7.8
 Tested up to: 6.9
 Requires PHP: 7.0
 License: GPLv2 or later
@@ -391,4 +391,24 @@ Seat number rotation stopped
 * New "Documents" tab with 24 sub-tabs organized by bus settings
 * 10 Free Plugin docs and 12 PRO Addon docs with visual distinction
 * Shortcode reference table updated with PRO shortcodes
+
+= 5.7.8 =
+*Release Date - 12 Jun 2026*
+
+**Bidirectional Stop Search & Editable Return Route (enabled via PRO toggles)**
+* Bidirectional stop search: on "same bus return" routes a passenger boarding at an intermediate stop can now choose a destination in EITHER direction (outbound or return). The "To" list merges every stop reachable on either physical leg.
+* Reworked origin/destination resolution to pick the natural same-day leg by stop position and real times, instead of relying on the stored route-direction order. Fixes the return leg showing reversed times with a wrong multi-hour duration (e.g. "23 H 0 M").
+* Boarding-only intermediate stops can now be used as a drop point in the opposite direction, so a return such as Paris -> Frankfurt uses the real outbound times (11:00 -> 12:30) instead of the reversed return.
+* Editable Return Route: the Return tab gets its own From / To selectors. The "From" is fixed (locked) to the outbound destination; only the "To" is editable, and the return bus list reloads for the chosen route.
+* Next-day return fallback: when a same-day round trip's return leg only departs before the outbound arrives, the return automatically rolls forward to the next available operational day.
+* Mirror-fare fallback: on same-bus-return routes a city-pair with no fare row configured for its direction now uses the reverse pair's fare instead of showing 0 / Free.
+
+**Journey Badge (Departure vs Return)**
+* The journey role (which tab a ticket was booked from) is now recorded separately from the internal fare leg, so the badge stays correct even when the fare leg is inverted on bidirectional routes.
+* Cart and checkout now show an "Outbound" / "Return" badge per leg on round trips.
+* The same role drives the PRO ticket PDF, passenger list and booking calendar so they no longer mislabel bidirectional or reverse-direction one-way trips.
+
+**Bug Fixes & UI**
+* Fixed the return route title weekday showing the outbound day instead of the return leg's own date.
+* Styled the editable Return From / To selectors to match the main search form (boxed inputs, inline marker icon, locked-field styling, responsive layout).
 

--- a/woocommerce-bus.php
+++ b/woocommerce-bus.php
@@ -3,7 +3,7 @@
 	 * Plugin Name: Bus Ticket Booking with Seat Reservation
 	 * Plugin URI: http://mage-people.com
 	 * Description: A Complete Bus Ticketing System for WordPress & WooCommerce
-	 * Version: 5.7.7
+	 * Version: 5.7.8
 	 * Author: MagePeople Team
 	 * Author URI: http://www.mage-people.com/
 	 * Text Domain: bus-ticket-booking-with-seat-reservation


### PR DESCRIPTION
…ney badge

Adds same-bus-return bidirectional search and a redesigned, editable return leg, fixes the inverted return times/badges, and bumps to 5.7.8.

Routing & time resolution (inc/WBTM_Functions.php)
- Resolve each origin/destination pair against the two physical legs (outbound + custom/return) by stop position and real times, choosing the natural same-day leg. Replaces the fragile wbtm_route_direction ordering that produced reversed return times with a wrong multi-hour duration (e.g. "23 H 0 M").
- Treat boarding-only intermediate stops as droppable in the opposite direction on same-bus-return routes, so e.g. a Paris -> Frankfurt return uses the real outbound times (11:00 -> 12:30) instead of the reversed return.
- get_bus_all_info() is now position-aware for same-bus-return buses.
- Bidirectional "To" list built from both physical legs by position.
- New helpers get_od_leg_datetimes() and resolve_return_date_after() for the next-day roll-forward when the return leg only departs before the outbound arrives.
- Mirror-fare fallback in get_ticket_info(): a city-pair with no fare row for its direction now uses the reverse pair's fare instead of showing 0 / Free.

Return leg UI (inc/WBTM_Layout.php, assets/global/wbtm_global.js, assets/frontend/wbtm.css)
- Editable Return Route: the "From" is fixed (locked) to the outbound destination and only the "To" is editable; the return list reloads by AJAX (get_wbtm_return_bus_list).
- Server-side next-day roll-forward applied when rendering the return list.
- Fixed route_title() weekday using the outbound date instead of the leg's date.
- Styled the return From/To selectors to match the main search form (boxed inputs, inline marker icon, locked-field styling, responsive).

Journey badge (inc/WBTM_Woocommerce.php, assets/global/wbtm_global.js)
- Record the journey role (which tab the booking came from) separately from the fare leg through cart item -> order line item -> attendee meta (wbtm_journey_type), since the fare leg is inverted on bidirectional routes.
- Show an Outbound / Return badge per leg in cart and checkout.

Docs: readme.txt changelog entry and version bump to 5.7.8.