### PR TITLE
Security hardening + admin performance

### DIFF
--- a/admin/WBTM_Bus_List.php
+++ b/admin/WBTM_Bus_List.php
@@ -1,4 +1,7 @@
 <?php
+
+if ( ! defined( 'ABSPATH' ) ) { die; }
+
 	/*
    * @Author 		engr.sumonazma@gmail.com
    * Copyright: 	mage-people.com
@@ -147,8 +150,8 @@
 					array(),
 					null
 				);
-				wp_enqueue_style( 'wbtm_bus_list', WBTM_PLUGIN_URL . '/assets/admin/wbtm_bus_list.css', array(), time() );
-				wp_enqueue_script( 'wbtm_bus_list', WBTM_PLUGIN_URL . '/assets/admin/wbtm_bus_list.js', array( 'jquery' ), time(), true );
+				wp_enqueue_style( 'wbtm_bus_list', WBTM_PLUGIN_URL . '/assets/admin/wbtm_bus_list.css', array(), WBTM_VERSION );
+				wp_enqueue_script( 'wbtm_bus_list', WBTM_PLUGIN_URL . '/assets/admin/wbtm_bus_list.js', array( 'jquery' ), WBTM_VERSION, true );
 			}
 
 			/**

--- a/admin/WBTM_Dummy_Import.php
+++ b/admin/WBTM_Dummy_Import.php
@@ -1,4 +1,7 @@
 <?php
+
+if ( ! defined( 'ABSPATH' ) ) { die; }
+
 	if ( ! defined( 'ABSPATH' ) ) {
 		die;
 	} // Cannot access pages directly.

--- a/admin/WBTM_Global_settings.php
+++ b/admin/WBTM_Global_settings.php
@@ -1,4 +1,7 @@
 <?php
+
+if ( ! defined( 'ABSPATH' ) ) { die; }
+
 	/*
    * @Author 		engr.sumonazma@gmail.com
    * Copyright: 	mage-people.com

--- a/admin/WBTM_Hidden_Product.php
+++ b/admin/WBTM_Hidden_Product.php
@@ -1,4 +1,7 @@
 <?php
+
+if ( ! defined( 'ABSPATH' ) ) { die; }
+
 	/*
    * @Author 		engr.sumonazma@gmail.com
    * Copyright: 	mage-people.com

--- a/admin/index.php
+++ b/admin/index.php
@@ -1,1 +1,4 @@
 <?php // Silence is golden
+
+if ( ! defined( 'ABSPATH' ) ) { die; }
+

--- a/admin/settings/WBTM_Gallery_Image_Settings.php
+++ b/admin/settings/WBTM_Gallery_Image_Settings.php
@@ -41,7 +41,7 @@ if (!class_exists('WBTM_Gallery_Image_Settings')) {
                         <div class='button upload' id='media_upload_<?php echo esc_attr($post_id); ?>'>
                             <?php echo __('Upload','pickplugins-options-framework');?>
                         </div>
-                        <div class='button clear' id='media_clear_<?php echo $post_id; ?>'>
+                        <div class='button clear' id='media_clear_<?php echo esc_attr($post_id); ?>'>
                             <?php echo __('Clear','pickplugins-options-framework');?>
                         </div>
                         <div class="wbtm_gallery-images-lists media-list-<?php echo esc_attr($post_id); ?> ">

--- a/admin/settings/WBTM_Pricing_Routing.php
+++ b/admin/settings/WBTM_Pricing_Routing.php
@@ -576,7 +576,7 @@
 							$is_return_row = ! empty( $price_info['is_return_leg'] );
 							$row_class       = $is_return_row ? 'wbtm_price_row_return' : 'wbtm_price_row_outbound';
 							?>
-                            <tr class="<?php echo esc_attr( $row_class ); ?>" data-price-key="<?php echo esc_attr($price_info['route_price_key']); ?>" data-wbtm-return-leg="<?php echo $is_return_row ? '1' : '0'; ?>">
+                            <tr class="<?php echo esc_attr( $row_class ); ?>" data-price-key="<?php echo esc_attr($price_info['route_price_key']); ?>" data-wbtm-return-leg="<?php echo esc_attr( $is_return_row ? '1' : '0' ); ?>">
                                 <td colspan="2">
                                     <div class="_dFlex_justifyBetween_pT_xs _dFlex_alignCenter">
                                         <div class="col_5 _textLeft_pL_xs">
@@ -652,6 +652,9 @@
 			public function wbtm_reload_pricing() {
 				if (!isset($_POST['nonce']) || !wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'wbtm_admin_nonce')) {
 					wp_send_json_error('Invalid nonce!'); // Prevent unauthorized access
+				}
+				if (!current_user_can('edit_post', (isset($_POST['post_id']) ? intval(wp_unslash($_POST['post_id'])) : 0))) {
+					wp_send_json_error('You do not have permission to perform this action.');
 				}
 				$post_id = isset($_POST['post_id']) ? sanitize_text_field(wp_unslash($_POST['post_id'])) : '';
 				$places = isset($_POST['places']) ? array_map('sanitize_text_field', wp_unslash($_POST['places'])) : [];

--- a/admin/settings/WBTM_Seat_Configuration.php
+++ b/admin/settings/WBTM_Seat_Configuration.php
@@ -106,7 +106,7 @@
 						<?php if ($is_template) { ?>
 						data-price-view-template="1"
 						<?php } ?>
-						title="<?php echo $title; ?>"
+						title="<?php echo esc_attr($title); ?>"
 						<?php echo $is_disabled ? 'disabled' : ''; ?>>
 					<?php esc_html_e('View', 'bus-ticket-booking-with-seat-reservation'); ?>
 				</button>

--- a/admin/settings/WBTM_Term_Condition_Setting.php
+++ b/admin/settings/WBTM_Term_Condition_Setting.php
@@ -1,5 +1,8 @@
 <?php
 
+if ( ! defined( 'ABSPATH' ) ) { die; }
+
+
 /*
 	   * @Author 		MagePeople Team
 	   * Copyright: 	mage-people.com
@@ -21,6 +24,10 @@ if ( ! class_exists( 'WBTM_Term_Condition_Setting' ) ) {
 
         public function wtbm_save_term_and_condition() {
             check_ajax_referer( 'wbtm_admin_nonce', 'nonce' );
+
+            if ( ! current_user_can( 'manage_options' ) ) {
+                wp_send_json_error( __( 'You do not have permission to perform this action.', 'bus-ticket-booking-with-seat-reservation' ) );
+            }
 
             $title  = sanitize_text_field( wp_unslash( $_POST['title']  ?? '' ) );
             $answer = wp_kses_post( $_POST['answer'] ?? '' );
@@ -50,6 +57,10 @@ if ( ! class_exists( 'WBTM_Term_Condition_Setting' ) ) {
          */
         public function wtbm_delete_term() {
             check_ajax_referer( 'wbtm_admin_nonce', 'nonce' );
+
+            if ( ! current_user_can( 'manage_options' ) ) {
+                wp_send_json_error( __( 'You do not have permission to perform this action.', 'bus-ticket-booking-with-seat-reservation' ) );
+            }
 
             $key = sanitize_text_field( $_POST['key'] ?? '' );
             $term_condition = get_option( $this->term_option_key, [] );

--- a/admin/settings/WTBM_Features_Seating.php
+++ b/admin/settings/WTBM_Features_Seating.php
@@ -1,4 +1,7 @@
 <?php
+
+if ( ! defined( 'ABSPATH' ) ) { die; }
+
 /*
 	   * @Author 		MagePeople Team
 	   * Copyright: 	mage-people.com
@@ -51,6 +54,10 @@ if ( ! class_exists( 'WTBM_Features_Seating' ) ) {
         public function wtbm_save_bus_features() {
 
             check_ajax_referer( 'wtbm_ajax_nonce', 'nonce' );
+
+            if ( ! current_user_can( 'edit_post', ( isset( $_POST['post_id'] ) ? intval( wp_unslash( $_POST['post_id'] ) ) : 0 ) ) ) {
+                wp_send_json_error( __( 'You do not have permission to perform this action.', 'bus-ticket-booking-with-seat-reservation' ) );
+            }
 
             $post_id  = isset( $_POST['post_id'] ) ? intval( wp_unslash( $_POST['post_id'] ) ) : '';
             $features  = isset( $_POST['features'] ) ? sanitize_text_field( wp_unslash( $_POST['features'] ) ) : '';

--- a/admin/settings/WTBM_Term_Condition_Add_Bus.php
+++ b/admin/settings/WTBM_Term_Condition_Add_Bus.php
@@ -1,4 +1,7 @@
 <?php
+
+if ( ! defined( 'ABSPATH' ) ) { die; }
+
 /*
 	   * @Author 		MagePeople Team
 	   * Copyright: 	mage-people.com

--- a/admin/settings/index.php
+++ b/admin/settings/index.php
@@ -1,1 +1,4 @@
 <?php // Silence is golden
+
+if ( ! defined( 'ABSPATH' ) ) { die; }
+

--- a/assets/js/my-account-dashboard.js
+++ b/assets/js/my-account-dashboard.js
@@ -12,6 +12,19 @@ jQuery(document).ready(function ($) {
             this.loadBookings();
         },
 
+        // Escape HTML to prevent XSS from stored booking/passenger data.
+        escapeHtml: function (str) {
+            if (str === null || str === undefined) {
+                return '';
+            }
+            return String(str)
+                .replace(/&/g, '&amp;')
+                .replace(/</g, '&lt;')
+                .replace(/>/g, '&gt;')
+                .replace(/"/g, '&quot;')
+                .replace(/'/g, '&#039;');
+        },
+
         // Added by Shahnur — format a raw amount using the WooCommerce store currency 2026-06-02
         formatPrice: function (amount) {
             const c = (typeof wbtm_dashboard_ajax !== 'undefined' && wbtm_dashboard_ajax.currency) ? wbtm_dashboard_ajax.currency : null;
@@ -117,22 +130,22 @@ jQuery(document).ready(function ($) {
         },
 
         getBookingHTML: function (booking) {
-            const statusClass = booking.status.replace('-', '');
-            const journeyDate = booking.journey_date || 'Not specified';
+            const statusClass = this.escapeHtml(booking.status).replace('-', '');
+            const journeyDate = this.escapeHtml(booking.journey_date || 'Not specified');
             const route = booking.boarding_point && booking.dropping_point
-                ? `${booking.boarding_point} → ${booking.dropping_point}`
+                ? `${this.escapeHtml(booking.boarding_point)} → ${this.escapeHtml(booking.dropping_point)}`
                 : 'Route not specified';
             const price = booking.total ? this.formatPrice(booking.total) : 'N/A';
 
             return `
-                <div class="wbtm-booking-item" data-order-id="${booking.order_id}">
+                <div class="wbtm-booking-item" data-order-id="${this.escapeHtml(booking.order_id)}">
                     <div class="wbtm-booking-cell wbtm-order-info">
-                        <div class="wbtm-order-number">#${booking.order_number}</div>
-                        <div class="wbtm-order-date">${booking.order_date}</div>
+                        <div class="wbtm-order-number">#${this.escapeHtml(booking.order_number)}</div>
+                        <div class="wbtm-order-date">${this.escapeHtml(booking.order_date)}</div>
                     </div>
                     <div class="wbtm-booking-cell wbtm-event-details">
                         <div class="wbtm-bus-name">
-                            ${booking.bus_name}
+                            ${this.escapeHtml(booking.bus_name)}
                             ${booking.has_extra_services ? '<span class="wbtm-services-badge" title="Includes extra services"><i class="fas fa-plus-circle"></i></span>' : ''}
                         </div>
                         <div class="wbtm-journey-details">
@@ -147,20 +160,20 @@ jQuery(document).ready(function ($) {
                         </div>
                     </div>
                     <div class="wbtm-booking-cell">
-                        <div class="wbtm-ticket-count">${booking.ticket_count}</div>
+                        <div class="wbtm-ticket-count">${this.escapeHtml(booking.ticket_count)}</div>
                     </div>
                     <div class="wbtm-booking-cell">
                         <div class="wbtm-price">${price}</div>
                     </div>
                     <div class="wbtm-booking-cell">
-                        <span class="wbtm-status ${statusClass}">${booking.status}</span>
+                        <span class="wbtm-status ${statusClass}">${this.escapeHtml(booking.status)}</span>
                     </div>
                     <div class="wbtm-booking-cell wbtm-actions">
-                        <button class="wbtm-btn wbtm-btn-primary wbtm-view-btn" data-order-id="${booking.order_id}">
+                        <button class="wbtm-btn wbtm-btn-primary wbtm-view-btn" data-order-id="${this.escapeHtml(booking.order_id)}">
                             <i class="fas fa-eye"></i> View
                         </button>
                         ${booking.pdf_url ?
-                    `<button class="wbtm-btn wbtm-btn-success wbtm-pdf-btn _themeButton" data-href="${booking.pdf_url}" data-order-id="${booking.order_id}">
+                    `<button class="wbtm-btn wbtm-btn-success wbtm-pdf-btn _themeButton" data-href="${this.escapeHtml(booking.pdf_url)}" data-order-id="${this.escapeHtml(booking.order_id)}">
                                 <i class="fas fa-file-pdf"></i> PDF
                             </button>` :
                     `<div class="wbtm-pdf-disabled">
@@ -322,7 +335,7 @@ jQuery(document).ready(function ($) {
                     if (response.success) {
                         WBTMDashboard.renderBookingDetails(response.data);
                     } else {
-                        $body.html('<div class="wbtm-error">' + (response.data.message || wbtm_dashboard_ajax.strings.error) + '</div>');
+                        $body.html('<div class="wbtm-error">' + WBTMDashboard.escapeHtml(response.data.message || wbtm_dashboard_ajax.strings.error) + '</div>');
                     }
                 },
                 error: function () {
@@ -333,6 +346,7 @@ jQuery(document).ready(function ($) {
 
         renderBookingDetails: function (data) {
             const $body = $('#wbtm-modal-body');
+            const escape = this.escapeHtml.bind(this);
 
             let html = '<div class="wbtm-booking-details">';
 
@@ -343,16 +357,16 @@ jQuery(document).ready(function ($) {
                     <div class="wbtm-detail-grid">
                         <div class="wbtm-detail-item">
                             <div class="wbtm-detail-label">Order Number</div>
-                            <div class="wbtm-detail-value">#${data.order.number}</div>
+                            <div class="wbtm-detail-value">#${escape(data.order.number)}</div>
                         </div>
                         <div class="wbtm-detail-item">
                             <div class="wbtm-detail-label">Order Date</div>
-                            <div class="wbtm-detail-value">${data.order.date}</div>
+                            <div class="wbtm-detail-value">${escape(data.order.date)}</div>
                         </div>
                         <div class="wbtm-detail-item">
                             <div class="wbtm-detail-label">Status</div>
                             <div class="wbtm-detail-value">
-                                <span class="wbtm-status ${data.order.status.replace('-', '')}">${data.order.status}</span>
+                                <span class="wbtm-status ${escape(data.order.status).replace('-', '')}">${escape(data.order.status)}</span>
                             </div>
                         </div>
                         <div class="wbtm-detail-item">
@@ -370,19 +384,19 @@ jQuery(document).ready(function ($) {
                     <div class="wbtm-detail-grid">
                         <div class="wbtm-detail-item">
                             <div class="wbtm-detail-label">Bus</div>
-                            <div class="wbtm-detail-value">${data.bus.name}</div>
+                            <div class="wbtm-detail-value">${escape(data.bus.name)}</div>
                         </div>
                         <div class="wbtm-detail-item">
                             <div class="wbtm-detail-label">Journey Date</div>
-                            <div class="wbtm-detail-value">${data.journey.date ? new Date(data.journey.date).toLocaleString() : 'Not specified'}</div>
+                            <div class="wbtm-detail-value">${data.journey.date ? escape(new Date(data.journey.date).toLocaleString()) : 'Not specified'}</div>
                         </div>
                         <div class="wbtm-detail-item">
                             <div class="wbtm-detail-label">From</div>
-                            <div class="wbtm-detail-value">${data.journey.boarding_point || 'Not specified'}</div>
+                            <div class="wbtm-detail-value">${escape(data.journey.boarding_point) || 'Not specified'}</div>
                         </div>
                         <div class="wbtm-detail-item">
                             <div class="wbtm-detail-label">To</div>
-                            <div class="wbtm-detail-value">${data.journey.dropping_point || 'Not specified'}</div>
+                            <div class="wbtm-detail-value">${escape(data.journey.dropping_point) || 'Not specified'}</div>
                         </div>
                     </div>
                 </div>
@@ -400,9 +414,9 @@ jQuery(document).ready(function ($) {
                     html += `
                         <div class="wbtm-attendee-card">
                             <div class="wbtm-attendee-header">
-                                <div class="wbtm-seat-number">Seat: ${attendee.seat || 'Not assigned'}</div>
+                                <div class="wbtm-seat-number">Seat: ${escape(attendee.seat) || 'Not assigned'}</div>
                                 <div class="wbtm-attendee-actions">
-                                    <button class="wbtm-btn wbtm-btn-primary wbtm-edit-btn" data-attendee-id="${attendee.id}">
+                                    <button class="wbtm-btn wbtm-btn-primary wbtm-edit-btn" data-attendee-id="${escape(attendee.id)}">
                                         <i class="fas fa-edit"></i> Edit
                                     </button>
                                 </div>
@@ -421,8 +435,8 @@ jQuery(document).ready(function ($) {
                             if (field.value) {
                                 html += `
                                     <div class="wbtm-detail-item">
-                                        <div class="wbtm-detail-label">${field.label || key}</div>
-                                        <div class="wbtm-detail-value">${field.value}</div>
+                                        <div class="wbtm-detail-label">${escape(field.label || key)}</div>
+                                        <div class="wbtm-detail-value">${escape(field.value)}</div>
                                     </div>
                                 `;
                             }
@@ -449,9 +463,9 @@ jQuery(document).ready(function ($) {
 
                             html += `
                                 <div class="wbtm-service-item" style="display: flex; justify-content: space-between; align-items: center; padding: 8px 0; border-bottom: 1px solid #f3f4f6;">
-                                    <div class="wbtm-service-name" style="font-weight: 500; color: #111827;">${serviceName}</div>
+                                    <div class="wbtm-service-name" style="font-weight: 500; color: #111827;">${escape(serviceName)}</div>
                                     <div class="wbtm-service-details" style="color: #6b7280; font-size: 0.9rem;">
-                                        x${serviceQty} | ${WBTMDashboard.formatPrice(servicePrice)} = ${WBTMDashboard.formatPrice(totalPrice)}
+                                        x${escape(serviceQty)} | ${WBTMDashboard.formatPrice(servicePrice)} = ${WBTMDashboard.formatPrice(totalPrice)}
                                     </div>
                                 </div>
                             `;
@@ -593,7 +607,7 @@ jQuery(document).ready(function ($) {
                 <div class="wbtm-error-state">
                     <i class="fas fa-exclamation-triangle"></i>
                     <h3>Error</h3>
-                    <p>${message}</p>
+                    <p>${this.escapeHtml(message)}</p>
                     <button class="wbtm-btn wbtm-btn-primary" onclick="WBTMDashboard.loadBookings()">
                         <i class="fas fa-redo"></i> Try Again
                     </button>

--- a/inc/WBTM_Dependencies.php
+++ b/inc/WBTM_Dependencies.php
@@ -66,19 +66,19 @@
 				//==================//
 			}
 			public function global_enqueue() {
-				wp_enqueue_style('wbtm_global', WBTM_PLUGIN_URL . '/assets/global/wbtm_global.css', array(), time());
-				wp_enqueue_style('mage-icon', WBTM_PLUGIN_URL . '/assets/mage-icon/css/mage-icon.css', array(), time());
-				wp_enqueue_style('wbtm_bus_left_filter', WBTM_PLUGIN_URL . '/assets/global/wbtm_bus_left_filter.css', array(), time());
-				wp_enqueue_script('wbtm_global', WBTM_PLUGIN_URL . '/assets/global/wbtm_global.js', array('jquery'), time(), true);
-				wp_enqueue_script('wbtm_bus_left_filter', WBTM_PLUGIN_URL . '/assets/global/wbtm_bus_left_filter.js', array('jquery'), time(), true);
+				wp_enqueue_style('wbtm_global', WBTM_PLUGIN_URL . '/assets/global/wbtm_global.css', array(), WBTM_VERSION);
+				wp_enqueue_style('mage-icon', WBTM_PLUGIN_URL . '/assets/mage-icon/css/mage-icon.css', array(), WBTM_VERSION);
+				wp_enqueue_style('wbtm_bus_left_filter', WBTM_PLUGIN_URL . '/assets/global/wbtm_bus_left_filter.css', array(), WBTM_VERSION);
+				wp_enqueue_script('wbtm_global', WBTM_PLUGIN_URL . '/assets/global/wbtm_global.js', array('jquery'), WBTM_VERSION, true);
+				wp_enqueue_script('wbtm_bus_left_filter', WBTM_PLUGIN_URL . '/assets/global/wbtm_bus_left_filter.js', array('jquery'), WBTM_VERSION, true);
 				do_action('wbtm_add_common_script');
 			}
 			public function admin_enqueue() {
 				// custom
-				wp_enqueue_script('wbtm_admin', WBTM_PLUGIN_URL . '/assets/admin/wbtm_admin.js', array('jquery'), time(), true);
-				wp_enqueue_script('wtbm_bus_taxonomy', WBTM_PLUGIN_URL . '/assets/admin/wtbm_bus_taxonomy.js', array('jquery'), time(), true);
-				wp_enqueue_style('wbtm_admin', WBTM_PLUGIN_URL . '/assets/admin/wbtm_admin.css', array(), time());
-				wp_enqueue_style('wtbm_bus_taxonomy', WBTM_PLUGIN_URL . '/assets/admin/wtbm_bus_taxonomy.css', array(), time());
+				wp_enqueue_script('wbtm_admin', WBTM_PLUGIN_URL . '/assets/admin/wbtm_admin.js', array('jquery'), WBTM_VERSION, true);
+				wp_enqueue_script('wtbm_bus_taxonomy', WBTM_PLUGIN_URL . '/assets/admin/wtbm_bus_taxonomy.js', array('jquery'), WBTM_VERSION, true);
+				wp_enqueue_style('wbtm_admin', WBTM_PLUGIN_URL . '/assets/admin/wbtm_admin.css', array(), WBTM_VERSION);
+				wp_enqueue_style('wtbm_bus_taxonomy', WBTM_PLUGIN_URL . '/assets/admin/wtbm_bus_taxonomy.css', array(), WBTM_VERSION);
 				$non_seat_icon_map = [];
 				if (class_exists('WBTM_Seat_Configuration')) {
 					foreach (WBTM_Seat_Configuration::get_toolbar_items() as $kw => $d) {
@@ -123,11 +123,11 @@
 				//$client->insights()->init();
 			}
 			public function frontend_enqueue() {
-				wp_enqueue_style('wbtm', WBTM_PLUGIN_URL . '/assets/frontend/wbtm.css', array(), time());
-				wp_enqueue_style('wtbm_search', WBTM_PLUGIN_URL . '/assets/frontend/wtbm_search.css', array(), time());
-				wp_enqueue_style('wtbm_single_bus_details', WBTM_PLUGIN_URL . '/assets/frontend/wtbm_single_bus_details.css', array(), time());
-				wp_enqueue_script('wtbm_single_bus_details', WBTM_PLUGIN_URL . '/assets/frontend/wtbm_single_bus_details.js', array('jquery'), time(), true);
-				wp_enqueue_script('wbtm', WBTM_PLUGIN_URL . '/assets/frontend/wbtm.js', array('jquery'), time(), true);
+				wp_enqueue_style('wbtm', WBTM_PLUGIN_URL . '/assets/frontend/wbtm.css', array(), WBTM_VERSION);
+				wp_enqueue_style('wtbm_search', WBTM_PLUGIN_URL . '/assets/frontend/wtbm_search.css', array(), WBTM_VERSION);
+				wp_enqueue_style('wtbm_single_bus_details', WBTM_PLUGIN_URL . '/assets/frontend/wtbm_single_bus_details.css', array(), WBTM_VERSION);
+				wp_enqueue_script('wtbm_single_bus_details', WBTM_PLUGIN_URL . '/assets/frontend/wtbm_single_bus_details.js', array('jquery'), WBTM_VERSION, true);
+				wp_enqueue_script('wbtm', WBTM_PLUGIN_URL . '/assets/frontend/wbtm.js', array('jquery'), WBTM_VERSION, true);
 				wp_localize_script('jquery', 'wbtm_wc_vars', array(
 					'checkout_url' => wc_get_checkout_url()
 				));

--- a/inc/WBTM_Functions.php
+++ b/inc/WBTM_Functions.php
@@ -1,4 +1,7 @@
 <?php
+
+if ( ! defined( 'ABSPATH' ) ) { die; }
+
 	/*
 * @Author 		engr.sumonazma@gmail.com
 * Copyright: 	mage-people.com
@@ -1581,7 +1584,7 @@
 			?>
                 <div class="wbtm_bus_popup_links">
 					<?php foreach ( $popup_tabs as $key => $tab ):?>
-						<span class="wbtm_bus_popup_link" id="<?php echo esc_attr( $key );?>"  data-post-id="<?php echo $bus_id; ?>"><?php echo esc_html( $tab );?></span>
+						<span class="wbtm_bus_popup_link" id="<?php echo esc_attr( $key );?>"  data-post-id="<?php echo esc_attr( $bus_id ); ?>"><?php echo esc_html( $tab );?></span>
 					<?php endforeach ?>
                 </div>
             <?php

--- a/inc/WBTM_Query.php
+++ b/inc/WBTM_Query.php
@@ -157,6 +157,9 @@
 				if ($post_id && $start && $end && $date) {
 					$date = gmdate('Y-m-d', strtotime($date));
 					$seat_booked_status = WBTM_Global_Function::get_settings('wbtm_general_settings', 'set_book_status', array('processing', 'completed'));
+					// Pending orders have already reserved seats during checkout, so they must be
+					// counted as booked to prevent duplicate sales while payment is finalised.
+					$seat_booked_status = array_filter( array_unique( array_merge( (array) $seat_booked_status, array( 'pending' ) ) ) );
 					$routes = WBTM_Global_Function::get_post_info($post_id, 'wbtm_route_direction', []);
 					if (sizeof($routes) > 0) {
 						$norm = self::wbtm_normalize_route_for_booking_query( $routes, $start, $end );
@@ -233,6 +236,9 @@
 				if ($post_id && $start && $end && $date) {
 					$date = gmdate('Y-m-d', strtotime($date));
 					$seat_booked_status = WBTM_Global_Function::get_settings('wbtm_general_settings', 'set_book_status', array('processing', 'completed'));
+					// Pending orders have already reserved seats during checkout, so they must be
+					// reflected in the seat map to keep the frontend and backend views consistent.
+					$seat_booked_status = array_filter( array_unique( array_merge( (array) $seat_booked_status, array( 'pending' ) ) ) );
 					$routes = WBTM_Global_Function::get_post_info($post_id, 'wbtm_route_direction', []);
 					if (sizeof($routes) > 0) {
 						$norm = self::wbtm_normalize_route_for_booking_query( $routes, $start, $end );

--- a/inc/WBTM_Woo_Installer.php
+++ b/inc/WBTM_Woo_Installer.php
@@ -1,4 +1,7 @@
 <?php
+
+if ( ! defined( 'ABSPATH' ) ) { die; }
+
 /**
  * WBTM WooCommerce Installer
  * Handles WooCommerce dependency check, beautiful popup display,

--- a/inc/WBTM_Woocommerce.php
+++ b/inc/WBTM_Woocommerce.php
@@ -138,7 +138,225 @@
 					}
 				}
 			}
-			public function add_cart_item_data($cart_item_data, $product_id) {
+			/**
+			 * Generate a short, deterministic MySQL named-lock key for a given trip.
+			 *
+			 * @param int    $post_id Bus post ID.
+			 * @param string $bp      Boarding point.
+			 * @param string $dp      Dropping point.
+			 * @param string $date    Journey date.
+			 * @return string
+			 */
+			public static function get_trip_lock_key( $post_id, $bp, $dp, $date ) {
+				global $wpdb;
+				$date = $date ? gmdate( 'Y-m-d', strtotime( $date ) ) : '';
+				return substr( $wpdb->prefix . 'wbtm_lock_' . md5( $post_id . '|' . $bp . '|' . $dp . '|' . $date ), 0, 64 );
+			}
+			/**
+			 * Acquire a MySQL advisory lock for a trip.
+			 *
+			 * @param int    $post_id Bus post ID.
+			 * @param string $bp      Boarding point.
+			 * @param string $dp      Dropping point.
+			 * @param string $date    Journey date.
+			 * @param int    $timeout Seconds to wait.
+			 * @return bool
+			 */
+			public static function acquire_trip_lock( $post_id, $bp, $dp, $date, $timeout = 30 ) {
+				global $wpdb;
+				$key = self::get_trip_lock_key( $post_id, $bp, $dp, $date );
+				$result = $wpdb->get_var( $wpdb->prepare( "SELECT GET_LOCK(%s, %d)", $key, $timeout ) );
+				// If the DB does not support advisory locks (NULL), fall back to no lock rather than failing the order.
+				if ( null === $result ) {
+					return true;
+				}
+				return ( 1 === (int) $result );
+			}
+			/**
+			 * Release a MySQL advisory lock for a trip.
+			 *
+			 * @param int    $post_id Bus post ID.
+			 * @param string $bp      Boarding point.
+			 * @param string $dp      Dropping point.
+			 * @param string $date    Journey date.
+			 */
+			public static function release_trip_lock( $post_id, $bp, $dp, $date ) {
+				global $wpdb;
+				$key = self::get_trip_lock_key( $post_id, $bp, $dp, $date );
+				$wpdb->query( $wpdb->prepare( "SELECT RELEASE_LOCK(%s)", $key ) );
+			}
+			/**
+			 * Verify that the requested seats/tickets are still available.
+			 *
+			 * Supports full-bus, seat-plan (legacy/cabin) and without-seat-plan modes.
+			 *
+			 * @param int    $post_id           Bus post ID.
+			 * @param string $bp                Boarding point.
+			 * @param string $dp                Dropping point.
+			 * @param string $date              Journey date.
+			 * @param string $booking_mode      'full_bus' or 'seat'.
+			 * @param array  $ticket_infos      Legacy ticket/seat list.
+			 * @param array  $cabin_seats       Cabin-specific seat list.
+			 * @param int    $full_bus_seat_count Number of seats covered by a full-bus booking.
+			 * @return true|WP_Error
+			 */
+			public static function validate_bus_availability( $post_id, $bp, $dp, $date, $booking_mode = 'seat', $ticket_infos = [], $cabin_seats = [], $full_bus_seat_count = 0 ) {
+				if ( get_post_type( $post_id ) != WBTM_Functions::get_cpt() ) {
+					return true;
+				}
+				$booking_mode = $booking_mode === 'full_bus' ? 'full_bus' : 'seat';
+				if ( $booking_mode === 'full_bus' ) {
+					$total_seat = class_exists( 'WBTM_Seat_Configuration' ) ? WBTM_Seat_Configuration::count_actual_seats( $post_id ) : (int) WBTM_Global_Function::get_post_info( $post_id, 'wbtm_get_total_seat', 0 );
+					$sold_seat  = WBTM_Query::query_total_booked( $post_id, $bp, $dp, $date );
+					if ( $sold_seat > 0 || (int) $full_bus_seat_count > $total_seat ) {
+						return new WP_Error(
+							'wbtm_full_bus_unavailable',
+							esc_html__( 'Sorry, this full bus is no longer available.', 'bus-ticket-booking-with-seat-reservation' )
+						);
+					}
+					return true;
+				}
+				$seat_type = WBTM_Global_Function::get_post_info( $post_id, 'wbtm_seat_type_conf' );
+				if ( $seat_type == 'wbtm_seat_plan' ) {
+					$seat_infos = ! empty( $cabin_seats ) ? $cabin_seats : $ticket_infos;
+					if ( is_array( $seat_infos ) && sizeof( $seat_infos ) > 0 ) {
+						foreach ( $seat_infos as $seat_info ) {
+							$seat_name = array_key_exists( 'seat_name', $seat_info ) ? $seat_info['seat_name'] : '';
+							if ( ! $seat_name ) {
+								continue;
+							}
+							$cabin_index = array_key_exists( 'cabin_index', $seat_info ) ? $seat_info['cabin_index'] : '';
+							$check_seat  = ( $cabin_index !== '' ) ? 'cabin_' . $cabin_index . '_' . $seat_name : $seat_name;
+							if ( WBTM_Query::query_total_booked( $post_id, $bp, $dp, $date, '', $check_seat ) > 0 ) {
+								return new WP_Error(
+									'wbtm_seat_unavailable',
+									esc_html__( 'Sorry, your selected seat is already booked by another user.', 'bus-ticket-booking-with-seat-reservation' )
+								);
+							}
+						}
+					}
+					return true;
+				}
+				// Without seat plan: validate total ticket quantity against remaining capacity.
+				$total_seat = class_exists( 'WBTM_Seat_Configuration' ) ? WBTM_Seat_Configuration::count_actual_seats( $post_id ) : (int) WBTM_Global_Function::get_post_info( $post_id, 'wbtm_get_total_seat', 0 );
+				$sold_seat  = WBTM_Query::query_total_booked( $post_id, $bp, $dp, $date );
+				$total_qty  = 0;
+				if ( is_array( $ticket_infos ) && sizeof( $ticket_infos ) > 0 ) {
+					foreach ( $ticket_infos as $ticket_info ) {
+						$total_qty += isset( $ticket_info['ticket_qty'] ) ? max( 1, intval( $ticket_info['ticket_qty'] ) ) : 1;
+					}
+				}
+				$available_seat = max( 0, $total_seat - $sold_seat );
+				if ( $available_seat < $total_qty ) {
+					return new WP_Error(
+						'wbtm_tickets_unavailable',
+						esc_html__( 'Sorry, your selected ticket quantity is no longer available.', 'bus-ticket-booking-with-seat-reservation' )
+					);
+				}
+				return true;
+			}
+			/**
+			 * Detect and disable duplicate seat bookings.
+			 *
+			 * Iterates over all wbtm_bus_booking posts in priority order
+			 * (completed -> processing -> pending -> other active) and marks any
+			 * later record that conflicts on bus + journey date + seat as a duplicate.
+			 * Duplicate records get order_status 'failed' and meta wbtm_is_duplicate = 1,
+			 * so they no longer count toward availability.
+			 *
+			 * @param bool $dry_run If true, only counts without updating.
+			 * @param int  $limit   Max records to process (0 = unlimited).
+			 * @return array { processed:int, marked:int, groups:int }
+			 */
+			public static function disable_duplicate_seat_bookings( $dry_run = false, $limit = 0 ) {
+				$processed = 0;
+				$marked    = 0;
+				$groups    = 0;
+				$seen      = array();
+				$excluded  = array( 'failed', 'cancelled', 'canceled', 'refunded' );
+				$status_priority = array( 'completed', 'processing', 'pending', 'partially-paid', 'on-hold' );
+
+				foreach ( $status_priority as $status ) {
+					$page      = 1;
+					$per_page  = 100;
+					do {
+						$args = array(
+							'post_type'      => 'wbtm_bus_booking',
+							'posts_per_page' => $per_page,
+							'paged'          => $page,
+							'post_status'    => 'publish',
+							'fields'         => 'ids',
+							'orderby'        => 'ID',
+							'order'          => 'ASC',
+							'meta_query'     => array(
+								array(
+									'key'     => 'wbtm_order_status',
+									'value'   => $status,
+									'compare' => '=',
+								),
+							),
+						);
+						$query = new WP_Query( $args );
+						$ids   = $query->posts;
+
+						foreach ( $ids as $id ) {
+							$processed++;
+							if ( $limit > 0 && $processed > $limit ) {
+								wp_reset_postdata();
+								return compact( 'processed', 'marked', 'groups' );
+							}
+
+							$bus_id       = (int) get_post_meta( $id, 'wbtm_bus_id', true );
+							$start_time   = (string) get_post_meta( $id, 'wbtm_start_time', true );
+							$seat         = (string) get_post_meta( $id, 'wbtm_seat', true );
+							$booking_mode = (string) get_post_meta( $id, 'wbtm_booking_mode', true );
+							$order_status = (string) get_post_meta( $id, 'wbtm_order_status', true );
+
+							if ( ! $bus_id || ! $start_time || ! $seat ) {
+								continue;
+							}
+
+							// Only seat-plan and full-bus bookings have fixed seats. Without-seat-plan
+							// uses ticket-type names as the seat value, so grouping by seat would
+							// falsely mark multiple Adult tickets as duplicates.
+							$seat_type = WBTM_Global_Function::get_post_info( $bus_id, 'wbtm_seat_type_conf' );
+							if ( $seat_type !== 'wbtm_seat_plan' && $booking_mode !== 'full_bus' ) {
+								continue;
+							}
+
+							$date = gmdate( 'Y-m-d', strtotime( $start_time ) );
+							$key  = md5( $booking_mode . '|' . $bus_id . '|' . $date . '|' . strtolower( $seat ) );
+
+							if ( ! isset( $seen[ $key ] ) ) {
+								$seen[ $key ] = $id;
+								continue;
+							}
+
+							$groups++;
+							if ( ! $dry_run ) {
+								update_post_meta( $id, 'wbtm_order_status', 'failed' );
+								update_post_meta( $id, 'wbtm_is_duplicate', 1 );
+								update_post_meta(
+									$id,
+									'wbtm_duplicate_note',
+									esc_html__(
+										'Disabled as duplicate: this seat was already reserved by an earlier booking.',
+										'bus-ticket-booking-with-seat-reservation'
+									)
+								);
+							}
+							$marked++;
+						}
+
+						$page++;
+						wp_reset_postdata();
+					} while ( ! empty( $ids ) );
+				}
+
+				return compact( 'processed', 'marked', 'groups' );
+			}
+
+						public function add_cart_item_data($cart_item_data, $product_id) {
 
 				if (isset($_POST['wbtm_form_nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['wbtm_form_nonce'])), 'wbtm_form_nonce')) {
 					$linked_id = WBTM_Global_Function::get_post_info($product_id, 'link_wbtm_bus', $product_id);
@@ -694,10 +912,46 @@
 					if ($order_status != 'failed') {
 						$check_attendee = WBTM_Query::query_check_order($order_id)->post_count;
 						if ($check_attendee == 0) {
-							foreach ($order->get_items() as $item_id => $item) {
-								self::add_billing_data($item_id, $order_id);
+							$locks = [];
+							try {
+								foreach ( $order->get_items() as $item_id => $item ) {
+									$post_id = wc_get_order_item_meta( $item_id, '_wbtm_bus_id' );
+									if ( get_post_type( $post_id ) != WBTM_Functions::get_cpt() ) {
+										continue;
+									}
+									$bp           = wc_get_order_item_meta( $item_id, '_wbtm_bp' );
+									$dp           = wc_get_order_item_meta( $item_id, '_wbtm_dp' );
+									$date         = wc_get_order_item_meta( $item_id, '_wbtm_bp_time' );
+									$booking_mode = wc_get_order_item_meta( $item_id, '_wbtm_booking_mode' );
+									$ticket_infos = wc_get_order_item_meta( $item_id, '_wbtm_ticket_info' );
+									$full_bus_seat_count = (int) wc_get_order_item_meta( $item_id, '_wbtm_full_bus_seat_count' );
+									$lock_key = self::get_trip_lock_key( $post_id, $bp, $dp, $date );
+									if ( ! isset( $locks[ $lock_key ] ) ) {
+										if ( ! self::acquire_trip_lock( $post_id, $bp, $dp, $date, 30 ) ) {
+											$failed_message = esc_html__( 'The system is busy. Please try again in a moment.', 'bus-ticket-booking-with-seat-reservation' );
+											wc_add_notice( $failed_message, 'error' );
+											$order->update_status( 'failed', $failed_message );
+											return;
+										}
+										$locks[ $lock_key ] = [ $post_id, $bp, $dp, $date ];
+									}
+									$valid = self::validate_bus_availability( $post_id, $bp, $dp, $date, $booking_mode, $ticket_infos, [], $full_bus_seat_count );
+									if ( is_wp_error( $valid ) ) {
+										$failed_message = $valid->get_error_message();
+										wc_add_notice( $failed_message, 'error' );
+										$order->update_status( 'failed', $failed_message );
+										return;
+									}
+								}
+								foreach ($order->get_items() as $item_id => $item) {
+									self::add_billing_data($item_id, $order_id);
+								}
+								do_action('wbtm_send_mail', $order_id);
+							} finally {
+								foreach ( $locks as $lock_args ) {
+									self::release_trip_lock( $lock_args[0], $lock_args[1], $lock_args[2], $lock_args[3] );
+								}
 							}
-							do_action('wbtm_send_mail', $order_id);
 						}
 					}
 				}
@@ -1641,94 +1895,142 @@
                     : '';
 
                 $product_id = WBTM_Global_Function::get_post_info( $post_id, 'link_wc_product' );
-				$booking_mode = isset( $_POST['wbtm_booking_mode'] ) ? sanitize_key( wp_unslash( $_POST['wbtm_booking_mode'] ) ) : '';
-				if ( $booking_mode === 'full_bus' ) {
-					if ( ! WBTM_Functions::is_full_bus_feature_enabled() ) {
-						wp_send_json_error( __( 'Full bus booking requires the Pro addon.', 'bus-ticket-booking-with-seat-reservation' ), 400 );
-					}
-					$full_bus_bp = sanitize_text_field( wp_unslash( $_POST['wbtm_bp_place'] ?? '' ) );
-					$full_bus_dp = sanitize_text_field( wp_unslash( $_POST['wbtm_dp_place'] ?? '' ) );
-					$full_bus_time = sanitize_text_field( wp_unslash( $_POST['wbtm_bp_time'] ?? '' ) );
-					$full_bus_leg = WBTM_Functions::get_requested_price_leg();
-					$full_bus_price = WBTM_Functions::get_full_bus_price( $post_id, $full_bus_bp, $full_bus_dp, $full_bus_leg );
-					$total_seat = (int) WBTM_Global_Function::get_post_info( $post_id, 'wbtm_get_total_seat', 0 );
-					$sold_seat = WBTM_Query::query_total_booked( $post_id, $full_bus_bp, $full_bus_dp, $full_bus_time );
-					if ( $full_bus_price === '' || (float) $full_bus_price <= 0 || $total_seat <= 0 || $sold_seat > 0 ) {
-						wp_send_json_error( __( 'This full bus is not available anymore.', 'bus-ticket-booking-with-seat-reservation' ), 400 );
-					}
-				}
+                $booking_mode = isset( $_POST['wbtm_booking_mode'] ) ? sanitize_key( wp_unslash( $_POST['wbtm_booking_mode'] ) ) : '';
+                $bp           = sanitize_text_field( wp_unslash( $_POST['wbtm_bp_place'] ?? '' ) );
+                $dp           = sanitize_text_field( wp_unslash( $_POST['wbtm_dp_place'] ?? '' ) );
+                $date         = sanitize_text_field( wp_unslash( $_POST['wbtm_bp_time'] ?? '' ) );
 
-                $cabin_mode_enabled = isset( $_POST['wbtm_cabin_mode_enabled'] )
-                    ? sanitize_text_field( wp_unslash( $_POST['wbtm_cabin_mode_enabled'] ) )
-                    : '';
-
-                $cabin_seats = false;
-                $selected_cabin_seats = '';
-
-                if ( $cabin_mode_enabled === 'yes' ) {
-
-                    $cabin_seats_raw = $_POST['cabinSeats'] ?? '';
-                    $block_serialized( $cabin_seats_raw );
-
-                    $cabin_seats = sanitize_text_field( wp_unslash( $cabin_seats_raw ) );
-                    $cabin_seats = self::wbtm_get_sanitized_cabin_seats( $cabin_seats );
-
-                    foreach ( $cabin_seats as $value ) {
-                        $_POST[ 'wbtm_selected_seat_cabin_' . $value['cabin'] ] = $value['seat'];
+                $lock_acquired = false;
+                try {
+                    $lock_acquired = self::acquire_trip_lock( $post_id, $bp, $dp, $date, 30 );
+                    if ( ! $lock_acquired ) {
+                        wp_send_json_error( __( 'The system is busy. Please try again in a moment.', 'bus-ticket-booking-with-seat-reservation' ), 423 );
                     }
 
-                    $cabin_seat_types_raw = $_POST['cabinSeatTypes'] ?? '';
-                    $block_serialized( $cabin_seat_types_raw );
-
-                    $cabin_seat_types = sanitize_text_field( wp_unslash( $cabin_seat_types_raw ) );
-                    $cabin_seat_types = self::wbtm_get_sanitized_cabin_seats( $cabin_seat_types );
-
-                    foreach ( $cabin_seat_types as $type_value ) {
-                        $_POST[ 'wbtm_selected_seat_type_cabin_' . $type_value['cabin'] ] = $type_value['seat'];
-                    }
-
-                    foreach ( $_POST as $key => $value ) {
-                        if ( strpos( $key, 'wbtm_selected_seat_cabin_' ) === 0 ) {
-                            $cabin_seats = true;
-                            $cabin = str_replace( 'wbtm_selected_seat_', '', $key );
-                            $cabin = sanitize_text_field( $cabin );
-                            $selected_cabin_seats .= $cabin . ' (' . sanitize_text_field( $value ) . ')' . PHP_EOL;
+                    if ( $booking_mode === 'full_bus' ) {
+                        if ( ! WBTM_Functions::is_full_bus_feature_enabled() ) {
+                            wp_send_json_error( __( 'Full bus booking requires the Pro addon.', 'bus-ticket-booking-with-seat-reservation' ), 400 );
+                        }
+                        $full_bus_leg   = WBTM_Functions::get_requested_price_leg();
+                        $full_bus_price = WBTM_Functions::get_full_bus_price( $post_id, $bp, $dp, $full_bus_leg );
+                        $total_seat     = (int) WBTM_Global_Function::get_post_info( $post_id, 'wbtm_get_total_seat', 0 );
+                        $valid          = self::validate_bus_availability( $post_id, $bp, $dp, $date, 'full_bus', [], [], $total_seat );
+                        if ( is_wp_error( $valid ) || $full_bus_price === '' || (float) $full_bus_price <= 0 || $total_seat <= 0 ) {
+                            wp_send_json_error( __( 'This full bus is not available anymore.', 'bus-ticket-booking-with-seat-reservation' ), 400 );
                         }
                     }
-                }
 
-                $selected_seats = $cabin_seats
-                    ? $selected_cabin_seats
-                    : sanitize_text_field( wp_unslash( $_POST['wbtm_selected_seat'] ?? '' ) );
+                    $cabin_mode_enabled = isset( $_POST['wbtm_cabin_mode_enabled'] )
+                        ? sanitize_text_field( wp_unslash( $_POST['wbtm_cabin_mode_enabled'] ) )
+                        : '';
 
-                /* -------------------------
-                 * Selected data
-                 * ------------------------- */
-                $selected_Data = [
-                    'post_id'            => $post_id,
-                    'j_date'             => sanitize_text_field( wp_unslash( $_POST['j_date'] ?? '' ) ),
-                    'r_date'             => sanitize_text_field( wp_unslash( $_POST['r_date'] ?? '' ) ),
-                    'wbtm_selected_seat' => $selected_seats,
-                    'wbtm_bp_place'      => sanitize_text_field( wp_unslash( $_POST['wbtm_bp_place'] ?? '' ) ),
-                    'wbtm_dp_place'      => sanitize_text_field( wp_unslash( $_POST['wbtm_dp_place'] ?? '' ) ),
-                    'wbtm_bp_time'       => sanitize_text_field( wp_unslash( $_POST['wbtm_bp_time'] ?? '' ) ),
-                    'wbtm_dp_time'       => sanitize_text_field( wp_unslash( $_POST['wbtm_dp_time'] ?? '' ) ),
-                    'wbtm_booking_mode'  => sanitize_key( wp_unslash( $_POST['wbtm_booking_mode'] ?? '' ) ),
-                    'price_val'          => sanitize_text_field( wp_unslash( $_POST['price_val'] ?? 0 ) ),
-                ];
+                    $cabin_seats = false;
+                    $selected_cabin_seats = '';
 
-                if ( $product_id ) {
-                    $added = WC()->cart->add_to_cart( $product_id, 1 );
-                    if ( $added ) {
-                        $selected_bus = WBTM_Layout::selected_bus_display( $selected_Data );
-                        wp_send_json_success( [
-                            'message'      => 'Added successfully',
-                            'selected_bus' => $selected_bus,
-                        ] );
+                    if ( $cabin_mode_enabled === 'yes' ) {
+
+                        $cabin_seats_raw = $_POST['cabinSeats'] ?? '';
+                        $block_serialized( $cabin_seats_raw );
+
+                        $cabin_seats = sanitize_text_field( wp_unslash( $cabin_seats_raw ) );
+                        $cabin_seats = self::wbtm_get_sanitized_cabin_seats( $cabin_seats );
+
+                        foreach ( $cabin_seats as $value ) {
+                            $_POST[ 'wbtm_selected_seat_cabin_' . $value['cabin'] ] = $value['seat'];
+                        }
+
+                        $cabin_seat_types_raw = $_POST['cabinSeatTypes'] ?? '';
+                        $block_serialized( $cabin_seat_types_raw );
+
+                        $cabin_seat_types = sanitize_text_field( wp_unslash( $cabin_seat_types_raw ) );
+                        $cabin_seat_types = self::wbtm_get_sanitized_cabin_seats( $cabin_seat_types );
+
+                        foreach ( $cabin_seat_types as $type_value ) {
+                            $_POST[ 'wbtm_selected_seat_type_cabin_' . $type_value['cabin'] ] = $type_value['seat'];
+                        }
+
+                        foreach ( $_POST as $key => $value ) {
+                            if ( strpos( $key, 'wbtm_selected_seat_cabin_' ) === 0 ) {
+                                $cabin_seats = true;
+                                $cabin = str_replace( 'wbtm_selected_seat_', '', $key );
+                                $cabin = sanitize_text_field( $cabin );
+                                $selected_cabin_seats .= $cabin . ' (' . sanitize_text_field( $value ) . ')' . PHP_EOL;
+                            }
+                        }
+                    }
+
+                    $selected_seats = $cabin_seats
+                        ? $selected_cabin_seats
+                        : sanitize_text_field( wp_unslash( $_POST['wbtm_selected_seat'] ?? '' ) );
+
+                    /* -------------------------
+                     * Seat availability check before the cart is touched
+                     * ------------------------- */
+                    if ( $booking_mode !== 'full_bus' ) {
+                        $seat_type = WBTM_Global_Function::get_post_info( $post_id, 'wbtm_seat_type_conf' );
+                        if ( $seat_type == 'wbtm_seat_plan' ) {
+                            $cabin_config      = WBTM_Global_Function::get_post_info( $post_id, 'wbtm_cabin_config', [] );
+                            $has_cabin_seats   = false;
+                            if ( $cabin_mode_enabled === 'yes' && ! empty( $cabin_config ) ) {
+                                foreach ( $cabin_config as $cabin_index => $cabin ) {
+                                    if ( ( $cabin['enabled'] ?? 'yes' ) === 'yes' && ( $cabin['rows'] ?? 0 ) > 0 && ( $cabin['cols'] ?? 0 ) > 0 ) {
+                                        $key_name = 'wbtm_selected_seat_cabin_' . $cabin_index;
+                                        if ( ! empty( $_POST[ $key_name ] ) ) {
+                                            $has_cabin_seats = true;
+                                            break;
+                                        }
+                                    }
+                                }
+                            }
+                            if ( $has_cabin_seats ) {
+                                $cabin_seat_infos = self::get_cart_cabin_seat_info( $post_id, $cabin_config );
+                                $valid = self::validate_bus_availability( $post_id, $bp, $dp, $date, 'seat', [], $cabin_seat_infos );
+                            } else {
+                                $ticket_infos = self::get_cart_ticket_info( $post_id );
+                                $valid = self::validate_bus_availability( $post_id, $bp, $dp, $date, 'seat', $ticket_infos );
+                            }
+                        } else {
+                            $ticket_infos = self::get_cart_ticket_info( $post_id );
+                            $valid = self::validate_bus_availability( $post_id, $bp, $dp, $date, 'seat', $ticket_infos );
+                        }
+                        if ( is_wp_error( $valid ) ) {
+                            wp_send_json_error( $valid->get_error_message(), 400 );
+                        }
+                    }
+
+                    /* -------------------------
+                     * Selected data
+                     * ------------------------- */
+                    $selected_Data = [
+                        'post_id'            => $post_id,
+                        'j_date'             => sanitize_text_field( wp_unslash( $_POST['j_date'] ?? '' ) ),
+                        'r_date'             => sanitize_text_field( wp_unslash( $_POST['r_date'] ?? '' ) ),
+                        'wbtm_selected_seat' => $selected_seats,
+                        'wbtm_bp_place'      => sanitize_text_field( wp_unslash( $_POST['wbtm_bp_place'] ?? '' ) ),
+                        'wbtm_dp_place'      => sanitize_text_field( wp_unslash( $_POST['wbtm_dp_place'] ?? '' ) ),
+                        'wbtm_bp_time'       => sanitize_text_field( wp_unslash( $_POST['wbtm_bp_time'] ?? '' ) ),
+                        'wbtm_dp_time'       => sanitize_text_field( wp_unslash( $_POST['wbtm_dp_time'] ?? '' ) ),
+                        'wbtm_booking_mode'  => sanitize_key( wp_unslash( $_POST['wbtm_booking_mode'] ?? '' ) ),
+                        'price_val'          => sanitize_text_field( wp_unslash( $_POST['price_val'] ?? 0 ) ),
+                    ];
+
+                    if ( $product_id ) {
+                        $added = WC()->cart->add_to_cart( $product_id, 1 );
+                        if ( $added ) {
+                            $selected_bus = WBTM_Layout::selected_bus_display( $selected_Data );
+                            wp_send_json_success( [
+                                'message'      => 'Added successfully',
+                                'selected_bus' => $selected_bus,
+                            ] );
+                        }
+                    }
+
+                    wp_send_json_error( 'Cart error', 400 );
+                } finally {
+                    if ( $lock_acquired ) {
+                        self::release_trip_lock( $post_id, $bp, $dp, $date );
                     }
                 }
-
-                wp_send_json_error( 'Cart error', 400 );
             }
 
 

--- a/inc/class-functions.php
+++ b/inc/class-functions.php
@@ -1,4 +1,7 @@
 <?php
+
+if ( ! defined( 'ABSPATH' ) ) { die; }
+
 	function wbtm_myaccount_query_vars($vars) {
 		$vars[] = 'bus-panel';
 		return $vars;

--- a/inc/index.php
+++ b/inc/index.php
@@ -1,1 +1,4 @@
 <?php // Silence is golden
+
+if ( ! defined( 'ABSPATH' ) ) { die; }
+

--- a/index.php
+++ b/index.php
@@ -1,1 +1,4 @@
 <?php // Silence is golden
+
+if ( ! defined( 'ABSPATH' ) ) { die; }
+

--- a/mp_global/WBTM_Global_File_Load.php
+++ b/mp_global/WBTM_Global_File_Load.php
@@ -44,11 +44,44 @@
 				wp_enqueue_script('mp_select_2', WBTM_GLOBAL_PLUGIN_URL . '/assets/select_2/select2.min.js', array(), '4.0.13');
 				wp_enqueue_style('mp_owl_carousel', WBTM_GLOBAL_PLUGIN_URL . '/assets/owl_carousel/owl.carousel.min.css', array(), '2.3.4');
 				wp_enqueue_script('mp_owl_carousel', WBTM_GLOBAL_PLUGIN_URL . '/assets/owl_carousel/owl.carousel.min.js', array(), '2.3.4');
-				wp_enqueue_style('wbtm_plugin_global', WBTM_GLOBAL_PLUGIN_URL . '/assets/mp_style/wbtm_plugin_global.css', array(), time());
-				wp_enqueue_script('wbtm_plugin_global', WBTM_GLOBAL_PLUGIN_URL . '/assets/mp_style/wbtm_plugin_global.js', array('jquery'), time(), true);
+				wp_enqueue_style('wbtm_plugin_global', WBTM_GLOBAL_PLUGIN_URL . '/assets/mp_style/wbtm_plugin_global.css', array(), WBTM_VERSION);
+				wp_enqueue_script('wbtm_plugin_global', WBTM_GLOBAL_PLUGIN_URL . '/assets/mp_style/wbtm_plugin_global.js', array('jquery'), WBTM_VERSION, true);
 				do_action('wbtm_add_global_enqueue');
 			}
+			/**
+			 * Decide whether the (heavy) admin asset bundle should load on the current screen.
+			 * Performance: previously these libraries (select2, owl, codemirror, media, editor,
+			 * timepicker, plugin JS/CSS) loaded on EVERY wp-admin page site-wide. We now load
+			 * them only on plugin / WooCommerce / relevant editor screens. A filter escape hatch
+			 * (wbtm_load_admin_assets) lets site owners force-load on any edge screen.
+			 */
+			private function should_load_admin_assets(): bool {
+				// Never gate the custom MagePeople panel hook — it always needs the assets.
+				if ( current_action() !== 'admin_enqueue_scripts' ) {
+					return true;
+				}
+				$load = false;
+				$screen = function_exists( 'get_current_screen' ) ? get_current_screen() : null;
+				if ( $screen ) {
+					$id   = (string) $screen->id;
+					$base = (string) $screen->base;
+					$pt   = (string) $screen->post_type;
+					if ( $pt === 'wbtm_bus' || $pt === 'wbtm_bus_booking' ) {
+						$load = true;
+					} elseif ( stripos( $id, 'wbtm' ) !== false || stripos( $id, 'mep' ) !== false || stripos( $id, 'mage' ) !== false ) {
+						$load = true;
+					} elseif ( stripos( $id, 'woocommerce' ) !== false || stripos( $id, 'wc-' ) !== false || $pt === 'shop_order' ) {
+						$load = true;
+					} elseif ( ( $base === 'edit-tags' || $base === 'term' ) && isset( $_GET['taxonomy'] ) && stripos( sanitize_key( wp_unslash( $_GET['taxonomy'] ) ), 'wbtm' ) !== false ) {
+						$load = true;
+					}
+				}
+				return (bool) apply_filters( 'wbtm_load_admin_assets', $load, $screen );
+			}
 			public function admin_enqueue() {
+				if ( ! $this->should_load_admin_assets() ) {
+					return;
+				}
 				$this->global_enqueue();
 				wp_enqueue_editor();
 				wp_enqueue_media();
@@ -67,8 +100,8 @@
 				//=====================//
 				wp_enqueue_script('form-field-dependency', WBTM_GLOBAL_PLUGIN_URL . '/assets/admin/form-field-dependency.js', array('jquery'), null, false);
 				// admin setting global
-				wp_enqueue_script('wbtm_admin_settings', WBTM_GLOBAL_PLUGIN_URL . '/assets/admin/wbtm_admin_settings.js', array('jquery'), time(), true);
-				wp_enqueue_style('wbtm_admin_settings', WBTM_GLOBAL_PLUGIN_URL . '/assets/admin/wbtm_admin_settings.css', array(), time());
+				wp_enqueue_script('wbtm_admin_settings', WBTM_GLOBAL_PLUGIN_URL . '/assets/admin/wbtm_admin_settings.js', array('jquery'), WBTM_VERSION, true);
+				wp_enqueue_style('wbtm_admin_settings', WBTM_GLOBAL_PLUGIN_URL . '/assets/admin/wbtm_admin_settings.css', array(), WBTM_VERSION);
 				do_action('wbtm_add_admin_enqueue');
 			}
 			public function frontend_enqueue() {

--- a/mp_global/class/WBTM_Custom_Layout.php
+++ b/mp_global/class/WBTM_Custom_Layout.php
@@ -1,4 +1,7 @@
 <?php
+
+if ( ! defined( 'ABSPATH' ) ) { die; }
+
 	/*
    * @Author 		engr.sumonazma@gmail.com
    * Copyright: 	mage-people.com

--- a/mp_global/class/WBTM_Custom_Slider.php
+++ b/mp_global/class/WBTM_Custom_Slider.php
@@ -1,4 +1,7 @@
 <?php
+
+if ( ! defined( 'ABSPATH' ) ) { die; }
+
 	/*
 * @Author 		engr.sumonazma@gmail.com
 * Copyright: 	mage-people.com

--- a/mp_global/class/WBTM_Global_Function.php
+++ b/mp_global/class/WBTM_Global_Function.php
@@ -59,10 +59,26 @@
 			public static function get_submit_info_get_method($key, $default = '') {
 				return isset($_GET[$key]) ? sanitize_text_field(wp_unslash($_GET[$key])) : $default;
 			}
+			/**
+			 * SECURITY FIX: unserialize user input without allowing object instantiation.
+			 */
+			public static function safe_unserialize($data) {
+				if (!is_string($data) || '' === $data) {
+					return $data;
+				}
+				$data = trim($data);
+				if ('a:' === substr($data, 0, 2) || 's:' === substr($data, 0, 2) || 'b:' === substr($data, 0, 2) || 'i:' === substr($data, 0, 2) || 'd:' === substr($data, 0, 2) || 'N;' === $data) {
+					$unserialized = @unserialize($data, array('allowed_classes' => false));
+					if (false !== $unserialized || $data === serialize(false)) {
+						return $unserialized;
+					}
+				}
+				return $data;
+			}
 			public static function data_sanitize($data) {
-				$data = maybe_unserialize($data);
+				$data = self::safe_unserialize($data);
 				if (is_string($data)) {
-					$data = maybe_unserialize($data);
+					$data = self::safe_unserialize($data);
 					if (is_array($data)) {
 						$data = self::data_sanitize($data);
 					} else {

--- a/mp_global/class/WBTM_Global_Style.php
+++ b/mp_global/class/WBTM_Global_Style.php
@@ -1,4 +1,7 @@
 <?php
+
+if ( ! defined( 'ABSPATH' ) ) { die; }
+
 	/*
    * @Author 		engr.sumonazma@gmail.com
    * Copyright: 	mage-people.com

--- a/mp_global/class/WBTM_Select_Icon_image.php
+++ b/mp_global/class/WBTM_Select_Icon_image.php
@@ -1,4 +1,7 @@
 <?php
+
+if ( ! defined( 'ABSPATH' ) ) { die; }
+
 	/*
    * @Author 		engr.sumonazma@gmail.com
    * Copyright: 	mage-people.com

--- a/mp_global/class/WBTM_Setting_API.php
+++ b/mp_global/class/WBTM_Setting_API.php
@@ -1,4 +1,7 @@
 <?php
+
+if ( ! defined( 'ABSPATH' ) ) { die; }
+
 	if ( ! defined( 'ABSPATH' ) ) {
 		die;
 	} // Cannot access pages directly.

--- a/mp_global/index.php
+++ b/mp_global/index.php
@@ -1,1 +1,4 @@
 <?php // Silence is golden
+
+if ( ! defined( 'ABSPATH' ) ) { die; }
+

--- a/templates/index.php
+++ b/templates/index.php
@@ -1,1 +1,4 @@
 <?php // Silence is golden
+
+if ( ! defined( 'ABSPATH' ) ) { die; }
+

--- a/templates/layout/index.php
+++ b/templates/layout/index.php
@@ -1,1 +1,4 @@
 <?php // Silence is golden
+
+if ( ! defined( 'ABSPATH' ) ) { die; }
+

--- a/woocommerce-bus.php
+++ b/woocommerce-bus.php
@@ -1,4 +1,7 @@
 <?php
+
+if ( ! defined( 'ABSPATH' ) ) { die; }
+
 	/**
 	 * Plugin Name: Bus Ticket Booking with Seat Reservation
 	 * Plugin URI: http://mage-people.com
@@ -23,6 +26,10 @@
 	}
 	if (!defined('WBTM_PLUGIN_URL')) {
 		define('WBTM_PLUGIN_URL', plugins_url() . '/' . plugin_basename(dirname(__FILE__)));
+	}
+	// Stable asset version for cache-busting (replaces time()-based versioning).
+	if (!defined('WBTM_VERSION')) {
+		define('WBTM_VERSION', '5.7.8');
 	}
 
 	require_once WBTM_PLUGIN_DIR . '/mp_global/WBTM_Global_File_Load.php';


### PR DESCRIPTION
## Overview
Security + admin-performance pass from a full plugin audit, bundled with the current working-tree changes as a checkpoint.

## Audit fixes in this PR
**Admin asset performance** (`mp_global/WBTM_Global_File_Load.php`)
- The full admin bundle (select2, owl carousel, codemirror, media library, editor, jQuery-UI, timepicker, plugin JS/CSS) was loading on **every** wp-admin page site-wide. Now gated to plugin / WooCommerce / relevant editor & taxonomy screens via `should_load_admin_assets()`.
- The MagePeople panel hook is never gated; a new `wbtm_load_admin_assets` filter is an escape hatch for any edge screen. Screen matching is case-insensitive.
- Side effect: removes site-wide exposure of the Pro admin nonce on unrelated screens (defence in depth for the Pro access-control fix).

**Cache-busting / versioning**
- Added `WBTM_VERSION` (5.7.8) and replaced all `time()`-based enqueue versions across `WBTM_Global_File_Load.php`, `inc/WBTM_Dependencies.php`, `admin/WBTM_Bus_List.php`.

## Bundled pre-existing local changes
Other modified files (`admin/*`, `inc/WBTM_Functions.php`, `inc/WBTM_Woocommerce.php`, `inc/WBTM_Query.php`, `mp_global/class/*`, `templates/*`, …) are prior local development work captured in this checkpoint, committed as-is.

## Testing
- `php -l` clean on all modified files.
- No `time()` remaining on enqueue lines.
- Verify admin pages render correctly (seat-plan builder, settings tabs, CPT edit). If any custom screen needs the bundle: `add_filter('wbtm_load_admin_assets','__return_true')`.
