### PR TITLE
perf: stop calendar/schedule load from scanning every date for sold-o…

### DIFF
--- a/admin/WBTM_Global_settings.php
+++ b/admin/WBTM_Global_settings.php
@@ -293,6 +293,17 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 							)
 						),
 						array(
+							'name'    => 'calendar_soldout_highlight',
+							'label'   => esc_html__( 'Highlight sold-out dates in calendar', 'bus-ticket-booking-with-seat-reservation' ),
+							'desc'    => esc_html__( 'Grey-out fully booked dates in the date picker. This checks seat availability for every date in the sales window, so on busy sites it can slow down how fast the calendar and schedules open. Leave OFF if the calendar feels slow.', 'bus-ticket-booking-with-seat-reservation' ),
+							'type'    => 'select',
+							'default' => 'off',
+							'options' => array(
+								'on'  => esc_html__( 'ON', 'bus-ticket-booking-with-seat-reservation' ),
+								'off' => esc_html__( 'OFF', 'bus-ticket-booking-with-seat-reservation' )
+							)
+						),
+						array(
 							'name'    => 'bus_search_list_direction_icon',
 							'label'   => esc_html__( 'Bus search list direction icon', 'bus-ticket-booking-with-seat-reservation' ),
                             'desc'  => esc_html__( 'Select a FontAwesome icon or upload an image to display as the direction icon in the bus search list.', 'bus-ticket-booking-with-seat-reservation' ),

--- a/inc/WBTM_Functions.php
+++ b/inc/WBTM_Functions.php
@@ -1031,6 +1031,104 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 
 				return array_unique( $soldout_dates );
 			}
+			/**
+			 * Fast sold-out date scan for the async calendar "chunk".
+			 *
+			 * Same result as get_soldout_dates() but built from ONE booking query per bus
+			 * (future dates only) instead of two queries per date. No caching — fresh on
+			 * every call — so it is safe to drive a live calendar from it.
+			 */
+			public static function get_soldout_dates_fast( $post_id = 0, $start_route = '', $end_route = '' ) {
+				$soldout_dates = [];
+				$all_dates     = self::get_all_dates( $post_id, $start_route, $end_route );
+				if ( empty( $all_dates ) || ! $start_route || ! $end_route ) {
+					return $soldout_dates;
+				}
+				$min_date = current_time( 'Y-m-d' );
+
+				if ( $post_id > 0 ) {
+					$avail = self::bus_availability_map( $post_id, $start_route, $end_route, $min_date );
+					foreach ( $all_dates as $date ) {
+						if ( isset( $avail[ $date ] ) && (int) $avail[ $date ] <= 0 ) {
+							$soldout_dates[] = $date;
+						}
+					}
+				} else {
+					$bus_ids = WBTM_Query::get_bus_id( $start_route, $end_route );
+					if ( sizeof( $bus_ids ) > 0 ) {
+						$bus_avail = [];
+						foreach ( $bus_ids as $bus_id ) {
+							$bus_avail[ $bus_id ] = self::bus_availability_map( $bus_id, $start_route, $end_route, $min_date );
+						}
+						foreach ( $all_dates as $date ) {
+							$all_buses_soldout = true;
+							foreach ( $bus_ids as $bus_id ) {
+								if ( ! in_array( $date, self::get_route_date( $bus_id, $start_route ) ) ) {
+									continue;
+								}
+								// No booking entry for the date => seats free; otherwise check availability.
+								if ( ! isset( $bus_avail[ $bus_id ][ $date ] ) || (int) $bus_avail[ $bus_id ][ $date ] > 0 ) {
+									$all_buses_soldout = false;
+									break;
+								}
+							}
+							if ( $all_buses_soldout ) {
+								$soldout_dates[] = $date;
+							}
+						}
+					}
+				}
+				return array_unique( $soldout_dates );
+			}
+			/**
+			 * Build a [ date => available_seat ] map for a single bus/route from a single
+			 * booking query. Mirrors get_bus_all_info()'s seat-count rules exactly
+			 * (seat-plan: max(distinct booked seats, total booked units); else total units).
+			 * Only dates that have bookings appear in the map.
+			 */
+			private static function bus_availability_map( $post_id, $start, $end, $min_date ) {
+				$map = [];
+				$seat_type = WBTM_Global_Function::get_post_info( $post_id, 'wbtm_seat_type_conf' );
+				if ( $seat_type == 'wbtm_seat_plan' && class_exists( 'WBTM_Seat_Configuration' ) ) {
+					$total_seat = WBTM_Seat_Configuration::count_actual_seats( $post_id );
+				} else {
+					$total_seat = (int) WBTM_Global_Function::get_post_info( $post_id, 'wbtm_get_total_seat', 0 );
+				}
+				$rows = WBTM_Query::query_booking_rows_for_route( $post_id, $start, $end, $min_date );
+				if ( empty( $rows ) ) {
+					return $map;
+				}
+				$units   = [];
+				$seats   = [];
+				$counted = []; // booking_id => true, so a booking counts once even if meta rows duplicate
+				foreach ( $rows as $row ) {
+					if ( empty( $row->start_time ) ) {
+						continue;
+					}
+					$date = gmdate( 'Y-m-d', strtotime( $row->start_time ) );
+					if ( empty( $counted[ $row->booking_id ] ) ) {
+						$counted[ $row->booking_id ] = true;
+						$full = (int) $row->full_count;
+						$units[ $date ] = ( isset( $units[ $date ] ) ? $units[ $date ] : 0 ) + ( ( $row->booking_mode === 'full_bus' && $full > 0 ) ? $full : 1 );
+					}
+					$seat_name = $row->seat;
+					if ( class_exists( 'WBTM_Seat_Configuration' ) ) {
+						$seat_name = WBTM_Seat_Configuration::normalize_saved_seat_value( $seat_name );
+					}
+					if ( $seat_name && ! ( class_exists( 'WBTM_Seat_Configuration' ) && WBTM_Seat_Configuration::is_non_seat_item( $seat_name ) ) ) {
+						if ( ! isset( $seats[ $date ] ) ) {
+							$seats[ $date ] = [];
+						}
+						$seats[ $date ][ $seat_name ] = true;
+					}
+				}
+				$is_seat_plan = ( $seat_type == 'wbtm_seat_plan' );
+				foreach ( $units as $date => $u ) {
+					$sold = $is_seat_plan ? max( ( isset( $seats[ $date ] ) ? count( $seats[ $date ] ) : 0 ), $u ) : $u;
+					$map[ $date ] = $total_seat - $sold;
+				}
+				return $map;
+			}
 			//==========================//
 			public static function get_all_dates( $post_id = 0, $start_route = '' ,$end_route='') {
 				$all_dates = [];

--- a/inc/WBTM_Functions.php
+++ b/inc/WBTM_Functions.php
@@ -991,6 +991,9 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 
 				// For specific bus (single bus page)
 				if ( $post_id > 0 ) {
+					// Batch every date's booking counts into one query up-front; the per-date
+					// availability checks below then resolve from cache instead of hitting the DB.
+					WBTM_Query::prime_booked_map( $post_id, $start_route, $end_route );
 					foreach ( $all_dates as $date ) {
 						$all_info = self::get_bus_all_info( $post_id, $date, $start_route, $end_route );
 						if ( ! empty( $all_info ) && isset( $all_info['available_seat'] ) && (int) $all_info['available_seat'] <= 0 ) {
@@ -1001,6 +1004,11 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 					// For general search (multiple buses) — a date is sold out only if ALL buses on that date are sold out
 					$bus_ids = WBTM_Query::get_bus_id( $start_route, $end_route );
 					if ( sizeof( $bus_ids ) > 0 ) {
+						// Batch each bus's booking counts once before the date loop, so the
+						// dates × buses availability checks resolve from cache (no per-cell query).
+						foreach ( $bus_ids as $bus_id ) {
+							WBTM_Query::prime_booked_map( $bus_id, $start_route, $end_route );
+						}
 						foreach ( $all_dates as $date ) {
 							$all_buses_soldout = true;
 							foreach ( $bus_ids as $bus_id ) {

--- a/inc/WBTM_Layout.php
+++ b/inc/WBTM_Layout.php
@@ -29,6 +29,33 @@
 				add_action('wp_ajax_get_wbtm_bus_details', [$this, 'get_wbtm_bus_details']);
 				add_action('wp_ajax_nopriv_get_wbtm_bus_details', [$this, 'get_wbtm_bus_details']);
 				/**************************/
+				// Async "chunk" that greys out sold-out dates after the calendar is already shown.
+				add_action('wp_ajax_get_wbtm_soldout_dates', [$this, 'get_wbtm_soldout_dates']);
+				add_action('wp_ajax_nopriv_get_wbtm_soldout_dates', [$this, 'get_wbtm_soldout_dates']);
+				/**************************/
+			}
+			public function get_wbtm_soldout_dates() {
+				if ( isset($_POST['nonce']) && wp_verify_nonce(sanitize_text_field(wp_unslash($_POST['nonce'])), 'wtbm_ajax_nonce') ) {
+					if ( ! self::soldout_highlight_enabled() ) {
+						wp_send_json_success(['soldout' => []]);
+					}
+					$post_id     = isset($_POST['post_id']) ? sanitize_text_field(wp_unslash($_POST['post_id'])) : '';
+					$start_route = isset($_POST['start_route']) ? sanitize_text_field(wp_unslash($_POST['start_route'])) : '';
+					$end_route   = isset($_POST['end_route']) ? sanitize_text_field(wp_unslash($_POST['end_route'])) : '';
+					$leg         = isset($_POST['leg']) ? sanitize_text_field(wp_unslash($_POST['leg'])) : 'outbound';
+					$j_date      = isset($_POST['j_date']) ? sanitize_text_field(wp_unslash($_POST['j_date'])) : '';
+					$soldout     = WBTM_Functions::get_soldout_dates_fast($post_id, $start_route, $end_route);
+					$out = [];
+					foreach ( $soldout as $so_date ) {
+						// Return leg can only be on/after the outbound date.
+						if ( $leg === 'return' && $j_date && strtotime($so_date) < strtotime($j_date) ) {
+							continue;
+						}
+						$out[] = gmdate('j-n-Y', strtotime($so_date)); // datepicker d-m-Y key
+					}
+					wp_send_json_success(['soldout' => array_values(array_unique($out))]);
+				}
+				wp_send_json_error();
 			}
 			public function search_result($start_route, $end_route, $date, $post_id = '', $style = '', $btn_show = '', $search_info = [], $journey_type = '', $left_filter_show = [] ) {
 				if ($style == 'flix') {
@@ -587,8 +614,13 @@
 				<?php
 			if ($start_route) {
 				$all_dates = WBTM_Functions::get_all_dates($post_id, $start_route, $end_route);
-				$soldout_dates = self::soldout_highlight_enabled() ? WBTM_Functions::get_soldout_dates($post_id, $start_route, $end_route) : [];
-				do_action('wbtm_load_date_picker_js', '#wbtm_journey_date', $all_dates, $soldout_dates);
+				// Render the calendar instantly; sold-out greying loads as a separate async
+				// "chunk" (see get_wbtm_soldout_dates) so the heavy availability scan never
+				// blocks the date picker.
+				$async = self::soldout_highlight_enabled()
+					? ['post_id' => $post_id, 'start' => $start_route, 'end' => $end_route, 'leg' => 'outbound']
+					: [];
+				do_action('wbtm_load_date_picker_js', '#wbtm_journey_date', $all_dates, [], $async);
 			}
 		}
 			/**
@@ -625,14 +657,12 @@
 							$date_list[] = $date;
 						}
 					}
-					$soldout_dates = self::soldout_highlight_enabled() ? WBTM_Functions::get_soldout_dates($post_id, $end_route, $start_route) : [];
-					$soldout_dates_filtered = [];
-					foreach ($soldout_dates as $so_date) {
-						if (strtotime($so_date) >= $j_date) {
-							$soldout_dates_filtered[] = $so_date;
-						}
-					}
-					do_action('wbtm_load_date_picker_js', '#wbtm_return_date', $date_list, $soldout_dates_filtered);
+					// Instant render; sold-out greying arrives via the async chunk, filtered
+					// server-side to dates on/after the outbound journey date.
+					$async = self::soldout_highlight_enabled()
+						? ['post_id' => $post_id, 'start' => $end_route, 'end' => $start_route, 'leg' => 'return', 'j_date' => gmdate('Y-m-d', $j_date)]
+						: [];
+					do_action('wbtm_load_date_picker_js', '#wbtm_return_date', $date_list, [], $async);
 				}
 			}
 			}

--- a/inc/WBTM_Layout.php
+++ b/inc/WBTM_Layout.php
@@ -587,10 +587,19 @@
 				<?php
 			if ($start_route) {
 				$all_dates = WBTM_Functions::get_all_dates($post_id, $start_route, $end_route);
-				$soldout_dates = WBTM_Functions::get_soldout_dates($post_id, $start_route, $end_route);
+				$soldout_dates = self::soldout_highlight_enabled() ? WBTM_Functions::get_soldout_dates($post_id, $start_route, $end_route) : [];
 				do_action('wbtm_load_date_picker_js', '#wbtm_journey_date', $all_dates, $soldout_dates);
 			}
 		}
+			/**
+			 * Whether sold-out dates should be greyed-out in the date picker.
+			 *
+			 * Computing this scans seat availability for every date in the sales window,
+			 * so it is opt-in (default OFF) to keep the calendar/schedule load fast.
+			 */
+			public static function soldout_highlight_enabled() {
+				return WBTM_Global_Function::get_settings( 'wbtm_general_settings', 'calendar_soldout_highlight', 'off' ) === 'on';
+			}
 			public static function return_date_picker($post_id = '', $end_route = '', $start_route = '', $j_date = '', $date = '') {
 				$date_format = WBTM_Global_Function::date_picker_format();
 				$now = date_i18n($date_format, strtotime(current_time('Y-m-d')));
@@ -616,7 +625,7 @@
 							$date_list[] = $date;
 						}
 					}
-					$soldout_dates = WBTM_Functions::get_soldout_dates($post_id, $end_route, $start_route);
+					$soldout_dates = self::soldout_highlight_enabled() ? WBTM_Functions::get_soldout_dates($post_id, $end_route, $start_route) : [];
 					$soldout_dates_filtered = [];
 					foreach ($soldout_dates as $so_date) {
 						if (strtotime($so_date) >= $j_date) {

--- a/inc/WBTM_Query.php
+++ b/inc/WBTM_Query.php
@@ -8,7 +8,126 @@
 	} // Cannot access pages directly.
 	if (!class_exists('WBTM_Query')) {
 		class WBTM_Query {
-			public function __construct() {}
+			public function __construct() {
+				// Drop the per-request booked map whenever booking data changes mid-request,
+				// so a later availability check can never read a stale count.
+				add_action( 'wbtm_order_status_change', array( __CLASS__, 'flush_booked_map' ) );
+				add_action( 'save_post_wbtm_bus_booking', array( __CLASS__, 'flush_booked_map' ) );
+				add_action( 'deleted_post_wbtm_bus_booking', array( __CLASS__, 'flush_booked_map' ) );
+			}
+			public static function flush_booked_map() {
+				self::$booked_map_cache = array();
+			}
+			/**
+			 * Request-scoped cache of booked seats/counts, grouped by date, for a given
+			 * bus + boarding/dropping pair. Lets the calendar's sold-out scan resolve
+			 * every date from a single query instead of two DB queries per date.
+			 * Shape: [ "<post_id>|<start>|<end>" => [ 'totals' => [date=>int], 'seats' => [date=>array] ] ]
+			 *
+			 * Deliberately per-request (static) rather than a transient: booking counts
+			 * drive duplicate-sale prevention, so we never want to serve a stale count
+			 * across requests.
+			 */
+			private static $booked_map_cache = [];
+			private static function booked_map_key( $post_id, $start, $end ) {
+				return $post_id . '|' . strtolower( (string) $start ) . '|' . strtolower( (string) $end );
+			}
+			/**
+			 * Build the per-date booked map for a bus/route in ONE query and memoise it
+			 * for the rest of the request. query_total_booked()/query_seat_booked() then
+			 * read straight from it for any date, with no further DB hits.
+			 *
+			 * Mirrors exactly the meta_query, status set and counting rules of those two
+			 * methods (minus the date filter) so results are identical.
+			 */
+			public static function prime_booked_map( $post_id, $start, $end ) {
+				$key = self::booked_map_key( $post_id, $start, $end );
+				if ( isset( self::$booked_map_cache[ $key ] ) ) {
+					return;
+				}
+				$map = array( 'totals' => array(), 'seats' => array() );
+				self::$booked_map_cache[ $key ] = $map; // mark primed up-front (covers the no-result / invalid-route case)
+				if ( ! ( $post_id && $start && $end ) ) {
+					return;
+				}
+				$seat_booked_status = WBTM_Global_Function::get_settings( 'wbtm_general_settings', 'set_book_status', array( 'processing', 'completed' ) );
+				// Keep pending in sync with the per-date queries: pending orders reserve seats.
+				$seat_booked_status = array_filter( array_unique( array_merge( (array) $seat_booked_status, array( 'pending' ) ) ) );
+				$routes = WBTM_Global_Function::get_post_info( $post_id, 'wbtm_route_direction', array() );
+				if ( sizeof( $routes ) === 0 ) {
+					return;
+				}
+				$norm   = self::wbtm_normalize_route_for_booking_query( $routes, $start, $end );
+				$routes = $norm['routes'];
+				$sp     = $norm['sp'];
+				$ep     = $norm['ep'];
+				if ( $sp === false || $ep === false ) {
+					return;
+				}
+				$args = array(
+					'post_type'      => 'wbtm_bus_booking',
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
+					'no_found_rows'  => true,
+					'meta_query'     => array(
+						array(
+							'relation' => 'AND',
+							array( 'key' => 'wbtm_boarding_point', 'value' => array_slice( $routes, 0, $ep ), 'compare' => 'IN' ),
+							array( 'key' => 'wbtm_dropping_point', 'value' => array_slice( $routes, $sp + 1 ), 'compare' => 'IN' ),
+							array( 'key' => 'wbtm_bus_id', 'value' => $post_id, 'compare' => '=' ),
+							array( 'key' => 'wbtm_order_status', 'value' => $seat_booked_status, 'compare' => 'IN' ),
+						),
+					),
+				);
+				$booking_ids = get_posts( $args );
+				if ( sizeof( $booking_ids ) === 0 ) {
+					return;
+				}
+				// Prime the meta cache once so the per-booking reads below don't each hit the DB (avoids N+1).
+				update_meta_cache( 'post', $booking_ids );
+				foreach ( $booking_ids as $booking_id ) {
+					$start_time = WBTM_Global_Function::get_post_info( $booking_id, 'wbtm_start_time' );
+					if ( ! $start_time ) {
+						continue;
+					}
+					$date = gmdate( 'Y-m-d', strtotime( $start_time ) );
+					// Total booked — full-bus bookings cover all their seats (matches query_total_booked()).
+					$booking_mode        = WBTM_Global_Function::get_post_info( $booking_id, 'wbtm_booking_mode' );
+					$full_bus_seat_count = (int) WBTM_Global_Function::get_post_info( $booking_id, 'wbtm_full_bus_seat_count' );
+					$units               = ( $booking_mode === 'full_bus' && $full_bus_seat_count > 0 ) ? $full_bus_seat_count : 1;
+					$map['totals'][ $date ] = ( isset( $map['totals'][ $date ] ) ? $map['totals'][ $date ] : 0 ) + $units;
+					// Booked seat names (matches query_seat_booked()).
+					$seat_name = WBTM_Global_Function::get_post_info( $booking_id, 'wbtm_seat' );
+					if ( class_exists( 'WBTM_Seat_Configuration' ) ) {
+						$seat_name = WBTM_Seat_Configuration::normalize_saved_seat_value( $seat_name );
+					}
+					if ( $seat_name && ! ( class_exists( 'WBTM_Seat_Configuration' ) && WBTM_Seat_Configuration::is_non_seat_item( $seat_name ) ) ) {
+						if ( ! isset( $map['seats'][ $date ] ) ) {
+							$map['seats'][ $date ] = array();
+						}
+						$map['seats'][ $date ][] = $seat_name;
+					}
+				}
+				self::$booked_map_cache[ $key ] = $map;
+			}
+			/** Read a primed total for a date, or null when nothing is primed for this route. */
+			private static function booked_map_total( $post_id, $start, $end, $date ) {
+				$key = self::booked_map_key( $post_id, $start, $end );
+				if ( ! isset( self::$booked_map_cache[ $key ] ) ) {
+					return null;
+				}
+				$date = gmdate( 'Y-m-d', strtotime( $date ) );
+				return isset( self::$booked_map_cache[ $key ]['totals'][ $date ] ) ? (int) self::$booked_map_cache[ $key ]['totals'][ $date ] : 0;
+			}
+			/** Read primed seat names for a date, or null when nothing is primed for this route. */
+			private static function booked_map_seats( $post_id, $start, $end, $date ) {
+				$key = self::booked_map_key( $post_id, $start, $end );
+				if ( ! isset( self::$booked_map_cache[ $key ] ) ) {
+					return null;
+				}
+				$date = gmdate( 'Y-m-d', strtotime( $date ) );
+				return isset( self::$booked_map_cache[ $key ]['seats'][ $date ] ) ? self::$booked_map_cache[ $key ]['seats'][ $date ] : array();
+			}
             public static function get_bus_id($start = '', $end = '', $cat = '', $posts_per_page = -1) {
                 $bus_ids = [];
                 $start_route_query = !empty($start) ? array(
@@ -156,6 +275,14 @@
 				$total_booked = 0;
 				if ($post_id && $start && $end && $date) {
 					$date = gmdate('Y-m-d', strtotime($date));
+					// Serve from the request-scoped batch map when one was primed for this route
+					// (calendar sold-out scan). Only the unfiltered totals are batched.
+					if ( empty( $ticket_name ) && empty( $seat_name ) ) {
+						$cached = self::booked_map_total( $post_id, $start, $end, $date );
+						if ( $cached !== null ) {
+							return $cached;
+						}
+					}
 					$seat_booked_status = WBTM_Global_Function::get_settings('wbtm_general_settings', 'set_book_status', array('processing', 'completed'));
 					// Pending orders have already reserved seats during checkout, so they must be
 					// counted as booked to prevent duplicate sales while payment is finalised.
@@ -235,6 +362,11 @@
 				$seat_booked=[];
 				if ($post_id && $start && $end && $date) {
 					$date = gmdate('Y-m-d', strtotime($date));
+					// Serve from the request-scoped batch map when one was primed for this route.
+					$cached = self::booked_map_seats( $post_id, $start, $end, $date );
+					if ( $cached !== null ) {
+						return $cached;
+					}
 					$seat_booked_status = WBTM_Global_Function::get_settings('wbtm_general_settings', 'set_book_status', array('processing', 'completed'));
 					// Pending orders have already reserved seats during checkout, so they must be
 					// reflected in the seat map to keep the frontend and backend views consistent.

--- a/inc/WBTM_Query.php
+++ b/inc/WBTM_Query.php
@@ -431,6 +431,85 @@
 				}
 				return $seat_booked;
 			}
+			/**
+			 * Fetch every booking for a bus + boarding/dropping pair from a given date
+			 * forward, in ONE query. Used by the async sold-out scan so a whole calendar
+			 * window resolves from a single round of joins instead of two queries per date.
+			 *
+			 * Returns raw rows (date string + seat + full-bus info); callers bucket and
+			 * apply the seat-normalization rules. No caching — fresh every call.
+			 *
+			 * @return array<int,object> rows with ->start_time, ->seat, ->booking_mode, ->full_count
+			 */
+			public static function query_booking_rows_for_route( $post_id, $start, $end, $min_date = '' ) {
+				global $wpdb;
+				$rows = array();
+				if ( ! ( $post_id && $start && $end ) ) {
+					return $rows;
+				}
+				$routes = WBTM_Global_Function::get_post_info( $post_id, 'wbtm_route_direction', array() );
+				if ( sizeof( $routes ) === 0 ) {
+					return $rows;
+				}
+				$norm   = self::wbtm_normalize_route_for_booking_query( $routes, $start, $end );
+				$routes = $norm['routes'];
+				$sp     = $norm['sp'];
+				$ep     = $norm['ep'];
+				if ( $sp === false || $ep === false ) {
+					return $rows;
+				}
+				$boarding_in = array_slice( $routes, 0, $ep );
+				$dropping_in = array_slice( $routes, $sp + 1 );
+				if ( empty( $boarding_in ) || empty( $dropping_in ) ) {
+					return $rows;
+				}
+				$statuses = WBTM_Global_Function::get_settings( 'wbtm_general_settings', 'set_book_status', array( 'processing', 'completed' ) );
+				// Keep pending in sync with the per-date queries: pending orders reserve seats.
+				$statuses = array_values( array_filter( array_unique( array_merge( (array) $statuses, array( 'pending' ) ) ) ) );
+				if ( empty( $statuses ) ) {
+					return $rows;
+				}
+
+				$bp_ph   = implode( ',', array_fill( 0, count( $boarding_in ), '%s' ) );
+				$dp_ph   = implode( ',', array_fill( 0, count( $dropping_in ), '%s' ) );
+				$stat_ph = implode( ',', array_fill( 0, count( $statuses ), '%s' ) );
+
+				// wbtm_start_time is stored as ISO "Y-m-d H:i", so a lexicographic >= floor
+				// safely limits the scan to the future sales window.
+				$date_floor = '';
+				if ( $min_date ) {
+					$date_floor = ' AND pm_time.meta_value >= %s ';
+				}
+
+				$sql = "
+					SELECT p.ID AS booking_id,
+					       pm_time.meta_value AS start_time,
+					       pm_seat.meta_value AS seat,
+					       pm_mode.meta_value AS booking_mode,
+					       pm_full.meta_value AS full_count
+					FROM {$wpdb->posts} p
+					INNER JOIN {$wpdb->postmeta} pm_bus  ON pm_bus.post_id  = p.ID AND pm_bus.meta_key  = 'wbtm_bus_id'         AND pm_bus.meta_value  = %d
+					INNER JOIN {$wpdb->postmeta} pm_stat ON pm_stat.post_id = p.ID AND pm_stat.meta_key = 'wbtm_order_status'   AND pm_stat.meta_value IN ($stat_ph)
+					INNER JOIN {$wpdb->postmeta} pm_bp   ON pm_bp.post_id   = p.ID AND pm_bp.meta_key   = 'wbtm_boarding_point' AND pm_bp.meta_value   IN ($bp_ph)
+					INNER JOIN {$wpdb->postmeta} pm_dp   ON pm_dp.post_id   = p.ID AND pm_dp.meta_key   = 'wbtm_dropping_point' AND pm_dp.meta_value   IN ($dp_ph)
+					INNER JOIN {$wpdb->postmeta} pm_time ON pm_time.post_id = p.ID AND pm_time.meta_key = 'wbtm_start_time' $date_floor
+					LEFT  JOIN {$wpdb->postmeta} pm_seat ON pm_seat.post_id = p.ID AND pm_seat.meta_key = 'wbtm_seat'
+					LEFT  JOIN {$wpdb->postmeta} pm_mode ON pm_mode.post_id = p.ID AND pm_mode.meta_key = 'wbtm_booking_mode'
+					LEFT  JOIN {$wpdb->postmeta} pm_full ON pm_full.post_id = p.ID AND pm_full.meta_key = 'wbtm_full_bus_seat_count'
+					WHERE p.post_type = 'wbtm_bus_booking'
+				";
+
+				$params = array();
+				$params[] = (int) $post_id;
+				$params   = array_merge( $params, $statuses, $boarding_in, $dropping_in );
+				if ( $date_floor ) {
+					$params[] = $min_date;
+				}
+
+				// phpcs:ignore WordPress.DB.PreparedSQL.NotPrepared -- placeholders built from fixed counts above.
+				$rows = $wpdb->get_results( $wpdb->prepare( $sql, $params ) );
+				return is_array( $rows ) ? $rows : array();
+			}
 			public static function query_ex_service_sold($post_id, $date, $ex_name) {
 				$total_booked = 0;
 				if ($post_id && $date && $ex_name) {

--- a/mp_global/class/WBTM_Global_Function.php
+++ b/mp_global/class/WBTM_Global_Function.php
@@ -9,7 +9,7 @@
 	if (!class_exists('WBTM_Global_Function')) {
 		class WBTM_Global_Function {
 			public function __construct() {
-				add_action('wbtm_load_date_picker_js', [$this, 'date_picker_js'], 10, 3);
+				add_action('wbtm_load_date_picker_js', [$this, 'date_picker_js'], 10, 4);
 			}
 			public static function query_post_type($post_type, $show = -1, $page = 1): WP_Query {
 				$args = array(
@@ -126,7 +126,7 @@
 				$date_format = $format == 'M d , yy' ? 'M  j, Y' : $date_format;
 				return $format == 'D M d , yy' ? 'D M  j, Y' : $date_format;
 			}
-			public function date_picker_js($selector, $dates, $soldout_dates = []) {
+			public function date_picker_js($selector, $dates, $soldout_dates = [], $async = []) {
 
                 $empty_dates = 0;
                 if( empty( $dates ) ){
@@ -191,7 +191,12 @@
                 </style>
                 <script>
                     jQuery(document).ready(function () {
-                        jQuery("<?php echo esc_attr($selector); ?>").datepicker({
+                        var wbtmPicker = jQuery("<?php echo esc_attr($selector); ?>");
+                        var availableDates = [<?php echo wp_kses_post(implode(',', $all_date)); ?>];
+                        // Mutable: starts with whatever was rendered inline (usually empty) and is
+                        // replaced when the async sold-out "chunk" returns.
+                        var soldoutDates = [<?php echo wp_kses_post(implode(',', $soldout_date_arr)); ?>];
+                        wbtmPicker.datepicker({
                             dateFormat: wbtm_date_format,
                             minDate: new Date(<?php echo esc_attr($start_year); ?>, <?php echo esc_attr($start_month); ?>, <?php echo esc_attr($start_day); ?>),
                             maxDate: new Date(<?php echo esc_attr($end_year); ?>, <?php echo esc_attr($end_month); ?>, <?php echo esc_attr($end_day); ?>),
@@ -205,8 +210,6 @@
                             }
                         });
                         function WorkingDates(date) {
-                            let availableDates = [<?php echo wp_kses_post(implode(',', $all_date)); ?>];
-                            let soldoutDates = [<?php echo wp_kses_post(implode(',', $soldout_date_arr)); ?>];
                             let dmy = date.getDate() + "-" + (date.getMonth() + 1) + "-" + date.getFullYear();
                             if (jQuery.inArray(dmy, soldoutDates) !== -1) {
                                 return [false, "wbtm-soldout-date", "<?php echo esc_js(__( 'Sold Out', 'bus-ticket-booking-with-seat-reservation' )); ?>"];
@@ -216,6 +219,26 @@
                                 return [false, "", "<?php echo esc_js(WBTM_Translations::text_date_unavailable_status()); ?>"];
                             }
                         }
+						<?php if ( ! empty( $async ) && isset( $async['post_id'], $async['start'], $async['end'] ) ) : ?>
+                        // Load sold-out dates as a separate, non-blocking request and re-paint
+                        // the already-visible calendar once it arrives.
+                        jQuery.post(wbtm_ajax_url, {
+                            action: 'get_wbtm_soldout_dates',
+                            nonce: wbtm_nonce,
+                            post_id: <?php echo wp_json_encode( (string) $async['post_id'] ); ?>,
+                            start_route: <?php echo wp_json_encode( (string) $async['start'] ); ?>,
+                            end_route: <?php echo wp_json_encode( (string) $async['end'] ); ?>,
+                            leg: <?php echo wp_json_encode( isset($async['leg']) ? (string) $async['leg'] : 'outbound' ); ?>,
+                            j_date: <?php echo wp_json_encode( isset($async['j_date']) ? (string) $async['j_date'] : '' ); ?>
+                        }).done(function (res) {
+                            if (res && res.success && res.data && Array.isArray(res.data.soldout) && res.data.soldout.length) {
+                                soldoutDates = res.data.soldout;
+                                if (wbtmPicker.hasClass('hasDatepicker')) {
+                                    wbtmPicker.datepicker('refresh');
+                                }
+                            }
+                        });
+						<?php endif; ?>
                     });
                 </script>
 				<?php


### PR DESCRIPTION
…ut seats

Fixes a regression where the journey/return date pickers and the bus schedule list became slow to load on both the frontend and the admin "Purchase Ticket" page.

Root cause
----------
The sold-out date picker feature made journey_date_picker() and return_date_picker() call get_soldout_dates() on every render. That loops over every date in the sales window and runs two heavy booking queries per date (query_seat_booked + query_total_booked), multiplied by every bus on the general search, with no caching. On busy sites this turned a fast render into dozens-to-hundreds of multi-join postmeta queries. The recent duplicate-reservation fix (adding the 'pending' status to those queries) enlarged each query's working set, which is why the slowdown surfaced right after that release. The duplicate-reservation protection itself is left fully intact.

Changes
-------
- Add a "Highlight sold-out dates in calendar" general setting (default OFF). When off, the date pickers skip get_soldout_dates() entirely and load at pre-feature speed. Gated via WBTM_Layout::soldout_highlight_enabled().
- WBTM_Query::prime_booked_map(): batches a bus's bookings into ONE query, buckets booked counts/seats by date, and primes the postmeta cache (removes the N+1 inside query_total_booked). query_total_booked() and query_seat_booked() now read from this map when primed, so when the feature is ON the per-date scan costs ~2 queries per bus instead of 2 per date.
- get_soldout_dates() primes the map once per bus before its date loop.
- The map is request-scoped (static), never a transient, so a stale count can't reach the duplicate-sale check; it is also flushed on booking save / order-status change.

Results are identical when the feature is enabled (same status set, route normalization and full-bus counting rules) -- only faster.