### PR TITLE
feat: redesign global settings with sidebar+cards layout, dynamic menu icon, compact tabs

### DIFF
--- a/admin/WBTM_Global_settings.php
+++ b/admin/WBTM_Global_settings.php
@@ -17,11 +17,42 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 				$this->settings_api = new WBTM_Setting_API;
 				add_action( 'admin_menu', array( $this, 'global_settings_menu' ) );
 				add_action( 'admin_init', array( $this, 'admin_init' ) );
+				add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_new_settings_assets' ) );
+				add_action( 'admin_head', array( $this, 'dynamic_menu_icon' ) );
 				add_filter( 'wbtm_settings_sec_reg', array( $this, 'settings_sec_reg' ) );
 				add_filter( 'wbtm_settings_sec_fields', array( $this, 'settings_sec_fields' ) );
 				add_filter( 'wbtm_settings_sec_reg', array( $this, 'global_sec_reg' ), 90 );
 				add_action( 'wbtm_wsa_form_bottom_wbtm_license_settings', [ $this, 'license_settings' ] );
 				add_action( 'wbtm_basic_license_list', [ $this, 'licence_area' ] );
+			}
+
+			public function dynamic_menu_icon() {
+				WBTM_Functions::output_dynamic_menu_icon_css();
+			}
+
+			public function enqueue_new_settings_assets($hook) {
+				// Only load on global settings page
+				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				$page = isset($_GET['page']) ? sanitize_text_field(wp_unslash($_GET['page'])) : '';
+				if ($page !== 'wbtm_settings_page') return;
+
+				wp_enqueue_style(
+					'wbtm-global-settings',
+					WBTM_PLUGIN_URL . '/assets/admin/css/wbtm-global-settings.css',
+					[],
+					WBTM_VERSION
+				);
+				wp_enqueue_script(
+					'wbtm-global-settings-js',
+					WBTM_PLUGIN_URL . '/assets/admin/js/wbtm-global-settings.js',
+					['jquery'],
+					WBTM_VERSION,
+					true
+				);
+				wp_enqueue_style('wp-color-picker');
+				wp_enqueue_script('wp-color-picker');
+				wp_enqueue_editor();
+				wp_enqueue_script('jquery-ui-datepicker');
 			}
 
 			public function global_settings_menu() {
@@ -31,21 +62,748 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 			}
 
 			public function settings_page() {
+				$this->render_new_settings_page();
+			}
+
+			public function render_new_settings_page() {
+				$sections_raw = $this->settings_api->get_sections();
+				$fields       = $this->settings_api->get_fields();
+
+				// Sections are numeric-indexed; convert to associative by 'id'
+				$sections = [];
+				if (is_array($sections_raw)) {
+					foreach ($sections_raw as $sec) {
+						if (isset($sec['id'])) {
+							$sections[$sec['id']] = $sec;
+						}
+					}
+				}
+
+				$tab_configs  = $this->get_tab_configs();
+
+				// Track which section IDs are handled by tab_configs
+				$handled_section_ids = [];
+				foreach ($tab_configs as $tab_id => $config) {
+					if (isset($config['section_id'])) {
+						$handled_section_ids[] = $config['section_id'];
+					}
+				}
+
+				// Build visible tabs from configs that match registered sections
+				$visible_tabs = [];
+				foreach ($tab_configs as $tab_id => $config) {
+					$section_id = isset($config['section_id']) ? $config['section_id'] : $tab_id;
+					$is_license = ($section_id === 'wbtm_license_settings');
+					if (isset($sections[$section_id]) || $is_license) {
+						$visible_tabs[$tab_id] = $config;
+					}
+				}
+
+				// Fallback: add any registered section not already handled
+				foreach ($sections as $section_id => $section) {
+					if (!in_array($section_id, $handled_section_ids, true)) {
+						$visible_tabs[$section_id] = [
+							'title'      => $section['title'],
+							'icon'       => 'fas fa-cog',
+							'subtitle'   => '',
+							'section_id' => $section_id,
+						];
+					}
+				}
+
+				$first_tab = !empty($visible_tabs) ? array_key_first($visible_tabs) : '';
+				$label = WBTM_Functions::get_name();
+
+				// Enqueue assets
+				add_action('admin_footer', function() use ($tab_configs, $first_tab) {
+					$meta = [];
+					foreach ($tab_configs as $id => $cfg) {
+						$meta[$id] = [$cfg['title'], isset($cfg['subtitle']) ? $cfg['subtitle'] : ''];
+					}
+
+					// Build AI provider map if the section exists
+					$ai_provider_map = [];
+					$ai_provider_all = [];
+					if (class_exists('WBTM_AI_Settings')) {
+						$providers = WBTM_AI_Settings::get_providers();
+						foreach ($providers as $slug => $cfg) {
+							if ($slug === 'rule_based' || empty($cfg['models'])) {
+								$ai_provider_map[$slug] = [];
+							} else {
+								$cls = [$slug . '_api_key'];
+								if (!empty($cfg['has_custom_endpoint'])) $cls[] = $slug . '_endpoint';
+								$cls[] = $slug . '_model';
+								$ai_provider_map[$slug] = $cls;
+							}
+						}
+						foreach ($ai_provider_map as $classes) {
+							foreach ($classes as $cls) $ai_provider_all[] = $cls;
+						}
+					}
+					$has_ai = !empty($ai_provider_all);
+					?>
+					<style>
+						.bm-gs__field-row.wbtm-hidden { display: none !important; }
+						.wbtm_add_icon_image_area .wbtm_icon_remove,
+						.wbtm_add_icon_image_area .wbtm_image_remove { cursor: pointer; z-index: 2; position: relative; }
+					</style>
+					<script>
+						window.bmGs = window.bmGs || {};
+						window.bmGs.tabMeta = <?php echo wp_json_encode($meta); ?>;
+						window.bmGs.defaultTab = <?php echo wp_json_encode($first_tab); ?>;
+						jQuery(function($){
+							// Save button — find and submit the active tab's form.
+							// Uses HTMLFormElement.prototype.submit to avoid the "id=submit"
+							// shadow bug (WP's submit_button() creates <input id="submit">).
+							$('#bm-save-btn').on('click', function(e){
+								e.preventDefault();
+								var $f = $('.bm-gs__tab-panel.bm-gs--active').find('form').first();
+								if ($f.length) { HTMLFormElement.prototype.submit.call($f[0]); }
+							});
+							// Icon / image remove — instant hide + show add buttons
+							$(document).on('click', '.wbtm_add_icon_image_area .wbtm_icon_remove', function(e){
+								e.stopPropagation();
+								var p = $(this).closest('.wbtm_add_icon_image_area');
+								p.find('input[type="hidden"]').val('');
+								p.find('[data-add-icon]').removeAttr('class');
+								p.find('.wbtm_icon_item').removeClass('dNone').hide();
+								p.find('.wbtm_add_icon_image_button_area').removeClass('dNone').show();
+							});
+							$(document).on('click', '.wbtm_add_icon_image_area .wbtm_image_remove', function(e){
+								e.stopPropagation();
+								var p = $(this).closest('.wbtm_add_icon_image_area');
+								p.find('input[type="hidden"]').val('');
+								p.find('img').attr('src', '');
+								p.find('.wbtm_image_item').removeClass('dNone').hide();
+								p.find('.wbtm_add_icon_image_button_area').removeClass('dNone').show();
+							});
+							// Color pickers — standard WP picker, init once per field
+							$('.wbtm-color-field').each(function(){
+								var $field = $(this);
+								if (!$field.closest('.wp-picker-container').length) {
+									$field.wpColorPicker();
+								}
+							});
+							// File upload triggers
+							$('.wbtm-file-upload-trigger').on('click', function(e){
+								e.preventDefault();
+								var btn = $(this), target = btn.data('target');
+								var input = $('input[name="'+target+'"]');
+								var frame = wp.media({ title: '<?php echo esc_js(__('Select File', 'bus-ticket-booking-with-seat-reservation')); ?>', multiple: false });
+								frame.on('select', function(){
+									var attachment = frame.state().get('selection').first().toJSON();
+									input.val(attachment.url);
+									input.trigger('change');
+								});
+								frame.open();
+							});
+							// Datepicker
+							$('.wbtm-datepicker').datepicker({
+								dateFormat: 'dd-mm-yy',
+								changeMonth: true,
+								changeYear: true,
+							});
+							<?php if ($has_ai): ?>
+							// AI Chatbot provider toggle
+							var aiMap = <?php echo wp_json_encode($ai_provider_map); ?>;
+							var aiAll = <?php echo wp_json_encode($ai_provider_all); ?>;
+							var $aiProvider = $('select[name="wbtm_ai_chatbot_settings[ai_provider]"]');
+							function applyAiVisibility(selected) {
+								aiAll.forEach(function(cls){
+									$('.wbtm-field-' + cls).addClass('wbtm-hidden');
+								});
+								var toShow = aiMap[selected] || [];
+								toShow.forEach(function(cls){
+									$('.wbtm-field-' + cls).removeClass('wbtm-hidden');
+								});
+							}
+							if ($aiProvider.length) {
+								applyAiVisibility($aiProvider.val());
+								$aiProvider.on('change', function(){ applyAiVisibility($(this).val()); });
+							}
+							<?php endif; ?>
+						});
+					</script>
+					<?php
+				}, 1);
+
 				?>
-                <div class="wbtm_style wbtm_global_settings">
-                    <div class="mpPanel">
-                        <div class="mpPanelHeader"><?php esc_html_e( ' Global Settings', 'bus-ticket-booking-with-seat-reservation' ); ?></div>
-                        <div class="mpPanelBody mp_zero">
-                            <div class="wbtm_tabs leftTabs">
-								<?php $this->settings_api->show_navigation(); ?>
-                                <div class="tabsContent">
-									<?php $this->settings_api->show_forms(); ?>
-                                </div>
-                            </div>
-                        </div>
-                    </div>
-                </div>
+				<div class="bm-gs__root">
+					<div class="bm-gs__wrap">
+						<!-- Mobile overlay -->
+						<div class="bm-gs__overlay" id="bm-overlay"></div>
+
+						<!-- SIDEBAR -->
+						<div class="bm-gs__sidebar" id="bm-sidebar">
+							<div class="bm-gs__sb-header">
+								<div class="bm-gs__sb-plugin-label"><?php echo esc_html($label); ?></div>
+								<div class="bm-gs__sb-title">
+									<span class="bm-gs__sb-dot"></span>
+									<?php esc_html_e('Global Settings', 'bus-ticket-booking-with-seat-reservation'); ?>
+								</div>
+							</div>
+							<nav class="bm-gs__sb-nav">
+								<?php foreach ($visible_tabs as $tab_id => $config): ?>
+									<button type="button" class="bm-gs__nav-item<?php echo $tab_id === $first_tab ? ' bm-gs--active' : ''; ?>" data-tab="<?php echo esc_attr($tab_id); ?>">
+										<span class="bm-gs__nav-icon <?php echo esc_attr(isset($config['icon']) ? $config['icon'] : 'fas fa-cog'); ?>"></span>
+										<?php echo esc_html($config['title']); ?>
+									</button>
+								<?php endforeach; ?>
+							</nav>
+							<div class="bm-gs__sb-footer">
+								<?php 
+								$has_pro = class_exists('WBTM_Functions') && WBTM_Functions::is_pro_active();
+								$badge_class = $has_pro ? 'bm-gs--pro' : '';
+								$badge_text  = $has_pro 
+									? esc_html__('PRO plan active', 'bus-ticket-booking-with-seat-reservation')
+									: esc_html__('Free plan active', 'bus-ticket-booking-with-seat-reservation');
+								?>
+								<div class="bm-gs__lic-badge <?php echo $badge_class; ?>">
+									<span class="bm-gs__lic-dot"></span>
+									<span class="bm-gs__lic-text"><?php echo $badge_text; ?></span>
+								</div>
+							</div>
+						</div>
+
+						<!-- MAIN -->
+						<div class="bm-gs__main">
+							<div class="bm-gs__topbar">
+								<button type="button" class="bm-gs__menu-btn" id="bm-menu-btn" aria-label="<?php esc_attr_e('Open menu', 'bus-ticket-booking-with-seat-reservation'); ?>">
+									<span class="fas fa-bars"></span>
+								</button>
+								<span class="bm-gs__topbar-title" id="bm-topbar-title"><?php 
+									echo esc_html(isset($visible_tabs[$first_tab]) ? $visible_tabs[$first_tab]['title'] : '');
+								?></span>
+								<span class="bm-gs__topbar-sep">&rsaquo;</span>
+								<span class="bm-gs__topbar-sub" id="bm-topbar-sub"><?php 
+									echo esc_html(isset($visible_tabs[$first_tab]) ? (isset($visible_tabs[$first_tab]['subtitle']) ? $visible_tabs[$first_tab]['subtitle'] : '') : '');
+								?></span>
+								<?php if (!empty($visible_tabs)): ?>
+								<button type="button" class="bm-gs__save-btn" id="bm-save-btn">
+									<span class="fas fa-save"></span>
+									<span class="bm-gs__save-text"><?php esc_html_e('Save Changes', 'bus-ticket-booking-with-seat-reservation'); ?></span>
+								</button>
+								<?php endif; ?>
+							</div>
+							<div class="bm-gs__content">
+								<?php 
+								foreach ($visible_tabs as $tab_id => $config):
+									$section_id = isset($config['section_id']) ? $config['section_id'] : $tab_id;
+									$is_license = ($section_id === 'wbtm_license_settings');
+								?>
+								<div class="bm-gs__tab-panel<?php echo $tab_id === $first_tab ? ' bm-gs--active' : ''; ?>" id="bm-tab-<?php echo esc_attr($tab_id); ?>">
+									<?php if ($is_license): ?>
+										<div class="bm-gs__section-card">
+											<div class="bm-gs__section-head">
+												<span class="bm-gs__section-icon fas fa-key"></span>
+												<span class="bm-gs__section-head-label"><?php esc_html_e('Mage-People License', 'bus-ticket-booking-with-seat-reservation'); ?></span>
+											</div>
+											<div class="bm-gs__info-note">
+												<p><?php esc_html_e('Some plugins are free and require no license. Additional addons require a valid license key entered below to unlock their features.', 'bus-ticket-booking-with-seat-reservation'); ?></p>
+											</div>
+											<div class="bm-gs__table-wrap">
+												<table class="bm-gs__lic-table">
+													<thead><tr>
+														<th colspan="4"><?php esc_html_e('Plugin', 'bus-ticket-booking-with-seat-reservation'); ?></th>
+														<th><?php esc_html_e('Type', 'bus-ticket-booking-with-seat-reservation'); ?></th>
+														<th><?php esc_html_e('Order No', 'bus-ticket-booking-with-seat-reservation'); ?></th>
+														<th colspan="2"><?php esc_html_e('Expires', 'bus-ticket-booking-with-seat-reservation'); ?></th>
+														<th colspan="3"><?php esc_html_e('License Key', 'bus-ticket-booking-with-seat-reservation'); ?></th>
+														<th><?php esc_html_e('Status', 'bus-ticket-booking-with-seat-reservation'); ?></th>
+														<th colspan="2"><?php esc_html_e('Action', 'bus-ticket-booking-with-seat-reservation'); ?></th>
+													</tr></thead>
+													<tbody>
+														<?php do_action('wbtm_license_page_plugin_list'); ?>
+													</tbody>
+												</table>
+											</div>
+										</div>
+									<?php elseif (isset($sections[$section_id]) && isset($fields[$section_id])): ?>
+										<form method="post" action="options.php">
+											<?php 
+												settings_fields($section_id);
+												$this->render_section_cards($section_id, $fields[$section_id]);
+											?>
+											<div style="display:none;"><?php submit_button(); ?></div>
+										</form>
+									<?php endif; ?>
+								</div>
+								<?php endforeach; ?>
+							</div>
+						</div>
+					</div>
+				</div>
 				<?php
+			}
+
+			private function get_tab_configs() {
+				$label = WBTM_Functions::get_name();
+				return [
+					'bus' => [
+						'title'      => $label . ' ' . esc_html__('Settings', 'bus-ticket-booking-with-seat-reservation'),
+						'icon'       => 'fas fa-bus',
+						'subtitle'   => esc_html__('General booking behavior', 'bus-ticket-booking-with-seat-reservation'),
+						'section_id' => 'wbtm_general_settings',
+					],
+					'global' => [
+						'title'      => esc_html__('General', 'bus-ticket-booking-with-seat-reservation'),
+						'icon'       => 'fas fa-sliders-h',
+						'subtitle'   => esc_html__('Date & editor settings', 'bus-ticket-booking-with-seat-reservation'),
+						'section_id' => 'wbtm_global_settings',
+					],
+					'deposit' => [
+						'title'      => esc_html__('Deposit / Partial Pay', 'addon-bus--ticket-booking-with-seat-pro'),
+						'icon'       => 'fas fa-wallet',
+						'subtitle'   => esc_html__('Partial payment configuration', 'addon-bus--ticket-booking-with-seat-pro'),
+						'section_id' => 'wbtm_deposit_settings',
+					],
+					'pdf' => [
+						'title'      => esc_html__('PDF Settings', 'addon-bus--ticket-booking-with-seat-pro'),
+						'icon'       => 'fas fa-file-pdf',
+						'subtitle'   => esc_html__('Ticket PDF customization', 'addon-bus--ticket-booking-with-seat-pro'),
+						'section_id' => 'wbtm_pdf_settings',
+					],
+					'pdflist' => [
+						'title'      => esc_html__('PDF Passenger List', 'addon-bus--ticket-booking-with-seat-pro'),
+						'icon'       => 'fas fa-list-check',
+						'subtitle'   => esc_html__('Column visibility for PDF export', 'addon-bus--ticket-booking-with-seat-pro'),
+						'section_id' => 'wbtm_passenger_pdf_settings',
+					],
+					'csv' => [
+						'title'      => esc_html__('CSV Settings', 'addon-bus--ticket-booking-with-seat-pro'),
+						'icon'       => 'fas fa-file-csv',
+						'subtitle'   => esc_html__('Column visibility for CSV export', 'addon-bus--ticket-booking-with-seat-pro'),
+						'section_id' => 'wbtm_passenger_csv_settings',
+					],
+					'email' => [
+						'title'      => esc_html__('Email Settings', 'addon-bus--ticket-booking-with-seat-pro'),
+						'icon'       => 'fas fa-envelope',
+						'subtitle'   => esc_html__('Ticket & notification emails', 'addon-bus--ticket-booking-with-seat-pro'),
+						'section_id' => 'wbtm_email_settings',
+					],
+					'chatbot' => [
+						'title'      => esc_html__('AI Chatbot', 'addon-bus--ticket-booking-with-seat-pro'),
+						'icon'       => 'fas fa-robot',
+						'subtitle'   => esc_html__('Chatbot configuration', 'addon-bus--ticket-booking-with-seat-pro'),
+						'section_id' => 'wbtm_ai_chatbot_settings',
+					],
+					'slider' => [
+						'title'      => esc_html__('Slider Settings', 'bus-ticket-booking-with-seat-reservation'),
+						'icon'       => 'fas fa-images',
+						'subtitle'   => esc_html__('Search slider display', 'bus-ticket-booking-with-seat-reservation'),
+						'section_id' => 'wbtm_slider_settings',
+					],
+					'style' => [
+						'title'      => esc_html__('Style Settings', 'bus-ticket-booking-with-seat-reservation'),
+						'icon'       => 'fas fa-palette',
+						'subtitle'   => esc_html__('Colors & typography', 'bus-ticket-booking-with-seat-reservation'),
+						'section_id' => 'wbtm_style_settings',
+					],
+					'license' => [
+						'title'      => esc_html__('License', 'bus-ticket-booking-with-seat-reservation'),
+						'icon'       => 'fas fa-key',
+						'subtitle'   => esc_html__('Plugin license keys', 'bus-ticket-booking-with-seat-reservation'),
+						'section_id' => 'wbtm_license_settings',
+					],
+				];
+			}
+
+			private function get_card_groups($section_id) {
+				$groups = [
+					'wbtm_general_settings' => [
+						'booking' => [
+							'icon'     => 'fas fa-calendar-check',
+							'label'    => esc_html__('Booking behavior', 'bus-ticket-booking-with-seat-reservation'),
+							'field_names' => ['set_book_status', 'label', 'slug', 'icon', 'bus_buffer_time'],
+						],
+						'search' => [
+							'icon'     => 'fas fa-search',
+							'label'    => esc_html__('Search & display', 'bus-ticket-booking-with-seat-reservation'),
+							'field_names' => ['bus_return_show', 'ticket_sale_close_date', 'ticket_sale_max_date', 'show_hide_view_seats_button', 'show_hide_bus_details_tabs', 'next_date_showing_search', 'calendar_soldout_highlight', 'bus_search_list_direction_icon'],
+						],
+						'checkout' => [
+							'icon'     => 'fas fa-shopping-cart',
+							'label'    => esc_html__('Checkout & cart', 'bus-ticket-booking-with-seat-reservation'),
+							'field_names' => ['active_redirect_page', 'search_page_redirect', 'checkout_redirect_after_booking', 'cart_empty_after_search', 'auto_complete_paid_orders', 'make_processing_completed'],
+						],
+					],
+					'wbtm_global_settings' => [
+						'general' => [
+							'icon'     => 'fas fa-calendar',
+							'label'    => esc_html__('Date & editor', 'bus-ticket-booking-with-seat-reservation'),
+							'field_names' => ['disable_block_editor', 'date_format', 'date_format_short'],
+						],
+					],
+					'wbtm_style_settings' => [
+						'colors' => [
+							'icon'     => 'fas fa-palette',
+							'label'    => esc_html__('Colors', 'bus-ticket-booking-with-seat-reservation'),
+							'layout'   => 'compact',
+							'field_names' => ['theme_color', 'theme_alternate_color', 'default_text_color', 'button_color', 'button_bg', 'warning_color', 'section_bg'],
+						],
+						'typography' => [
+							'icon'     => 'fas fa-text-height',
+							'label'    => esc_html__('Typography (px)', 'bus-ticket-booking-with-seat-reservation'),
+							'layout'   => 'compact',
+							'field_names' => ['default_font_size', 'font_size_h1', 'font_size_h2', 'font_size_h3', 'font_size_h4', 'font_size_h5', 'font_size_h6', 'button_font_size', 'font_size_label'],
+						],
+					],
+					'wbtm_passenger_pdf_settings' => [
+						'checklist' => [
+							'icon'   => 'fas fa-list-check',
+							'label'  => esc_html__('PDF passenger list – column visibility', 'addon-bus--ticket-booking-with-seat-pro'),
+							'layout' => 'checklist',
+							'field_names' => [], // auto: all fields go into checklist grid
+						],
+					],
+					'wbtm_passenger_csv_settings' => [
+						'checklist' => [
+							'icon'   => 'fas fa-file-csv',
+							'label'  => esc_html__('CSV export – column visibility', 'addon-bus--ticket-booking-with-seat-pro'),
+							'layout' => 'checklist',
+							'field_names' => [],
+						],
+					],
+				];
+				return isset($groups[$section_id]) ? $groups[$section_id] : [];
+			}
+
+			private function render_section_cards($section_id, $fields) {
+				if (empty($fields)) return;
+
+				$card_groups = $this->get_card_groups($section_id);
+				$assigned    = [];
+
+				if (!empty($card_groups)) {
+					// Render fields in their defined card groups
+					foreach ($card_groups as $card_key => $card) {
+						$is_checklist = (isset($card['layout']) && $card['layout'] === 'checklist');
+
+						if ($is_checklist) {
+							// Checklist layout: all remaining/unassigned checkbox fields in a grid
+							$checklist_fields = [];
+							foreach ($fields as $field) {
+								$fname = isset($field['name']) ? $field['name'] : '';
+								$checklist_fields[] = $field;
+								if ($fname) $assigned[] = $fname;
+							}
+							if (empty($checklist_fields)) continue;
+							?>
+							<div class="bm-gs__section-card">
+								<div class="bm-gs__section-head">
+									<span class="bm-gs__section-icon <?php echo esc_attr($card['icon']); ?>"></span>
+									<span class="bm-gs__section-head-label"><?php echo esc_html($card['label']); ?></span>
+								</div>
+								<div class="bm-gs__checklist-grid">
+									<?php foreach ($checklist_fields as $field): 
+										$this->render_checklist_item($section_id, $field);
+									endforeach; ?>
+								</div>
+							</div>
+							<?php
+							continue;
+						}
+
+						$is_compact = (isset($card['layout']) && $card['layout'] === 'compact');
+
+						$card_fields = [];
+						foreach ($card['field_names'] as $fname) {
+							foreach ($fields as $field) {
+								if (isset($field['name']) && $field['name'] === $fname) {
+									$card_fields[] = $field;
+									$assigned[]    = $fname;
+									break;
+								}
+							}
+						}
+						if (empty($card_fields)) continue;
+						?>
+						<div class="bm-gs__section-card">
+							<div class="bm-gs__section-head">
+								<span class="bm-gs__section-icon <?php echo esc_attr($card['icon']); ?>"></span>
+								<span class="bm-gs__section-head-label"><?php echo esc_html($card['label']); ?></span>
+							</div>
+							<?php if ($is_compact): ?>
+								<div class="bm-gs__compact-grid">
+									<?php foreach ($card_fields as $field): 
+										$this->render_compact_item($section_id, $field);
+									endforeach; ?>
+								</div>
+							<?php else: ?>
+								<?php foreach ($card_fields as $field): 
+									$this->render_field_row($section_id, $field);
+								endforeach; ?>
+							<?php endif; ?>
+						</div>
+						<?php
+					}
+				}
+
+				// Render any remaining unassigned fields in their own card(s)
+				$remaining = [];
+				foreach ($fields as $field) {
+					$fname = isset($field['name']) ? $field['name'] : '';
+					if ($fname && !in_array($fname, $assigned, true)) {
+						$remaining[] = $field;
+					} elseif (!$fname) {
+						$remaining[] = $field;
+					}
+				}
+				if (!empty($remaining)) {
+					// Determine card label from section title
+					$sections = $this->settings_api->get_sections();
+					$card_label = '';
+					if (is_array($sections)) {
+						foreach ($sections as $sec) {
+							if (isset($sec['id']) && $sec['id'] === $section_id) {
+								$card_label = isset($sec['title']) ? $sec['title'] : '';
+								break;
+							}
+						}
+					}
+					?>
+					<div class="bm-gs__section-card">
+						<?php if ($card_label): ?>
+						<div class="bm-gs__section-head">
+							<span class="bm-gs__section-icon fas fa-sliders-h"></span>
+							<span class="bm-gs__section-head-label"><?php echo esc_html($card_label); ?></span>
+						</div>
+						<?php endif; ?>
+						<?php foreach ($remaining as $field): 
+							$this->render_field_row($section_id, $field);
+						endforeach; ?>
+					</div>
+					<?php
+				}
+			}
+
+			private function render_field_row($section_id, $field) {
+				$label = isset($field['label']) ? $field['label'] : '';
+				$desc  = isset($field['desc']) ? $field['desc'] : '';
+				$type  = isset($field['type']) ? $field['type'] : 'text';
+				$name  = isset($field['name']) ? $field['name'] : '';
+				$options = WBTM_Global_Function::get_settings($section_id, $name, isset($field['default']) ? $field['default'] : '');
+				$row_class = 'wbtm-field-' . esc_attr($name);
+
+				// Mark provider-specific rows for AI Chatbot toggle
+				$is_ai_provider_row = false;
+				if ($section_id === 'wbtm_ai_chatbot_settings' && !in_array($name, ['chatbot_enabled','ai_provider','chatbot_name','welcome_message','primary_color','chatbot_position','show_on_pages'], true)) {
+					$is_ai_provider_row = true;
+					$row_class .= ' wbtm-ai-provider-row';
+				}
+
+				if ($type === 'html') {
+					echo wp_kses_post(isset($field['html']) ? $field['html'] : '');
+					return;
+				}
+				?>
+				<div class="bm-gs__field-row <?php echo $row_class; ?>">
+					<div class="bm-gs__field-label-cell">
+						<?php if ($label): ?>
+							<div class="bm-gs__field-label"><?php echo esc_html($label); ?></div>
+						<?php endif; ?>
+						<?php if ($desc): ?>
+							<div class="bm-gs__field-hint"><?php echo wp_kses_post($desc); ?></div>
+						<?php endif; ?>
+					</div>
+					<div class="bm-gs__field-control-cell">
+						<?php $this->render_form_control($section_id, $field, $options); ?>
+					</div>
+				</div>
+				<?php
+			}
+
+			private function render_compact_item($section_id, $field) {
+				$label   = isset($field['label']) ? $field['label'] : '';
+				$name    = isset($field['name']) ? $field['name'] : '';
+				$type    = isset($field['type']) ? $field['type'] : 'text';
+				$value   = WBTM_Global_Function::get_settings($section_id, $name, isset($field['default']) ? $field['default'] : '');
+				$id      = $section_id . '[' . $name . ']';
+				$id_attr = esc_attr($id);
+				?>
+				<div class="bm-gs__compact-item">
+					<label class="bm-gs__compact-label"><?php echo esc_html($label); ?></label>
+					<?php if ($type === 'color'): ?>
+						<input type="text" class="bm-gs__color-field wbtm-color-field" name="<?php echo $id_attr; ?>" value="<?php echo esc_attr($value); ?>" data-default-color="<?php echo esc_attr(isset($field['default']) ? $field['default'] : ''); ?>" style="width:100%;max-width:100%;box-sizing:border-box;">
+					<?php elseif ($type === 'number'): ?>
+						<input class="bm-gs__input bm-gs__input--sm" type="number" name="<?php echo $id_attr; ?>" value="<?php echo esc_attr($value); ?>" style="width:100%;max-width:100%;">
+					<?php else: ?>
+						<input class="bm-gs__input" type="text" name="<?php echo $id_attr; ?>" value="<?php echo esc_attr($value); ?>">
+					<?php endif; ?>
+				</div>
+				<?php
+			}
+
+			private function render_checklist_item($section_id, $field) {
+				$label = isset($field['label']) ? $field['label'] : '';
+				$name  = isset($field['name']) ? $field['name'] : '';
+				$value = WBTM_Global_Function::get_settings($section_id, $name, isset($field['default']) ? $field['default'] : '');
+				$id    = $section_id . '[' . $name . ']';
+				$checked = ($value === 'yes' || $value === '1' || $value === 'on') ? ' checked' : '';
+				?>
+				<label class="bm-gs__checklist-item">
+					<input type="checkbox" name="<?php echo esc_attr($id); ?>" value="yes"<?php echo $checked; ?>>
+					<span><?php echo esc_html($label); ?></span>
+				</label>
+				<?php
+			}
+
+			private function render_form_control($section_id, $field, $value) {
+				$type  = isset($field['type']) ? $field['type'] : 'text';
+				$name  = isset($field['name']) ? $field['name'] : '';
+				$id    = $section_id . '[' . $name . ']';
+				$id_attr = esc_attr($id);
+				$class = isset($field['class']) ? $field['class'] : '';
+				$placeholder = isset($field['placeholder']) ? $field['placeholder'] : '';
+
+				switch ($type) {
+					case 'multicheck':
+						$field_options = isset($field['options']) ? $field['options'] : [];
+						$value = is_array($value) ? $value : (array) $value;
+						echo '<div class="bm-gs__checkbox-group">';
+						foreach ($field_options as $opt_key => $opt_label) {
+							$checked = in_array($opt_key, $value) ? ' checked' : '';
+							echo '<label class="bm-gs__checkbox-item">';
+							echo '<input type="checkbox" name="' . esc_attr($id) . '[]" value="' . esc_attr($opt_key) . '"' . $checked . '>';
+							echo esc_html($opt_label) . '</label>';
+						}
+						echo '</div>';
+						break;
+
+					case 'select':
+					case 'pages':
+					case 'wbtm_select2':
+					case 'wbtm_select2_role':
+						$field_options = isset($field['options']) ? $field['options'] : [];
+						if ($type === 'pages') {
+							$field_options = [];
+							$pages = get_pages();
+							foreach ($pages as $page) {
+								$field_options[$page->ID] = $page->post_title;
+							}
+						}
+						echo '<select class="bm-gs__select ' . esc_attr($class) . '" name="' . $id_attr . '">';
+						foreach ($field_options as $opt_key => $opt_label) {
+							$selected = ((string) $opt_key === (string) $value) ? ' selected' : '';
+							echo '<option value="' . esc_attr($opt_key) . '"' . $selected . '>' . esc_html($opt_label) . '</option>';
+						}
+						echo '</select>';
+						break;
+
+					case 'text':
+					case 'url':
+					case 'password':
+					case 'email':
+						$input_type = ($type === 'password') ? 'password' : (($type === 'email') ? 'email' : (($type === 'url') ? 'url' : 'text'));
+						echo '<input class="bm-gs__input ' . esc_attr($class) . '" type="' . esc_attr($input_type) . '" name="' . $id_attr . '" value="' . esc_attr($value) . '" placeholder="' . esc_attr($placeholder) . '">';
+						break;
+
+					case 'number':
+						echo '<input class="bm-gs__input bm-gs__input--sm ' . esc_attr($class) . '" type="number" name="' . $id_attr . '" value="' . esc_attr($value) . '" placeholder="' . esc_attr($placeholder) . '">';
+						break;
+
+					case 'textarea':
+						echo '<textarea class="bm-gs__textarea ' . esc_attr($class) . '" name="' . $id_attr . '" placeholder="' . esc_attr($placeholder) . '" rows="4">' . esc_textarea($value) . '</textarea>';
+						break;
+
+					case 'color':
+						// Standard WP color picker on a single text input. wpColorPicker()
+						// builds its own swatch + "Select Color" control on init, so we must
+						// NOT also render a custom trigger button (that produced a duplicate picker).
+						$default_color = isset($field['default']) ? $field['default'] : '';
+						echo '<input type="text" class="bm-gs__color-field wbtm-color-field" name="' . $id_attr . '" value="' . esc_attr($value) . '" data-default-color="' . esc_attr($default_color) . '">';
+						break;
+
+					case 'file':
+						$file_url = is_string($value) ? $value : (is_array($value) && isset($value['url']) ? $value['url'] : '');
+						$file_id  = is_array($value) && isset($value['id']) ? $value['id'] : '';
+						echo '<button type="button" class="bm-gs__img-btn wbtm-file-upload-trigger" data-target="' . $id_attr . '">';
+						echo '<span class="fas fa-upload"></span> ';
+						$file_url ? esc_html_e('Change File', 'bus-ticket-booking-with-seat-reservation') : esc_html_e('Choose File', 'bus-ticket-booking-with-seat-reservation');
+						echo '</button>';
+						echo '<input type="hidden" class="wbtm-file-url" name="' . $id_attr . '" value="' . esc_attr($file_url) . '">';
+						if ($file_url) {
+							echo '<span class="bm-gs__badge bm-gs__badge--active" style="margin-left:8px;">' . esc_html(basename($file_url)) . '</span>';
+						}
+						break;
+
+					case 'wysiwyg':
+						echo '<div class="bm-gs__wysiwyg">';
+						wp_editor($value, str_replace(['[',']'], ['_',''], $id), [
+							'textarea_name' => $id,
+							'textarea_rows' => 6,
+							'media_buttons' => false,
+							'teeny' => true,
+						]);
+						echo '</div>';
+						break;
+
+					case 'datepicker':
+						echo '<input class="bm-gs__input wbtm-datepicker ' . esc_attr($class) . '" type="text" name="' . $id_attr . '" value="' . esc_attr($value) . '" placeholder="' . esc_attr($placeholder) . '" autocomplete="off">';
+						break;
+
+					case 'checkbox':
+						$checked = ($value == 'on' || $value == '1') ? ' checked' : '';
+						echo '<label class="bm-gs__checkbox-item">';
+						echo '<input type="checkbox" name="' . $id_attr . '" value="1"' . $checked . '>';
+						echo esc_html(isset($field['checkbox_label']) ? $field['checkbox_label'] : '');
+						echo '</label>';
+						break;
+
+					case 'radio':
+						$field_options = isset($field['options']) ? $field['options'] : [];
+						echo '<div class="bm-gs__checkbox-group">';
+						foreach ($field_options as $opt_key => $opt_label) {
+							$checked = ((string) $opt_key === (string) $value) ? ' checked' : '';
+							echo '<label class="bm-gs__checkbox-item">';
+							echo '<input type="radio" name="' . $id_attr . '" value="' . esc_attr($opt_key) . '"' . $checked . '>';
+							echo esc_html($opt_label) . '</label>';
+						}
+						echo '</div>';
+						break;
+
+					case 'switch_button':
+						$checked = ($value == 'on' || $value == '1' || $value == 'yes') ? ' checked' : '';
+						echo '<label class="bm-gs__checkbox-item">';
+						echo '<input type="checkbox" name="' . $id_attr . '" value="1"' . $checked . '>';
+						echo '</label>';
+						break;
+
+					case 'icon':
+						// Wrap in .wbtm_style so the icon-picker popup & button CSS applies.
+						// WBTM_Select_Icon_image outputs classes (_mpBtn_xs, dNone, fdColumn etc.)
+						// that are scoped under .wbtm_style in wbtm_plugin_global.css.
+						echo '<div class="wbtm_style" style="display:inline-block;">';
+						if ( has_action( 'wbtm_input_add_icon' ) ) {
+							do_action( 'wbtm_input_add_icon', $id, $value );
+						} else {
+							echo '<input class="bm-gs__input bm-gs__input--sm" type="text" name="' . $id_attr . '" value="' . esc_attr($value) . '" placeholder="fas fa-bus">';
+						}
+						echo '</div>';
+						break;
+
+					case 'icon_image':
+						// Wrap in .wbtm_style so old CSS classes apply
+						echo '<div class="wbtm_style" style="display:inline-block;">';
+						if ( has_action( 'wbtm_add_icon_image' ) ) {
+							$icon  = '';
+							$image = '';
+							if ( $value && is_numeric( $value ) ) {
+								$image = $value;
+							} elseif ( $value ) {
+								$icon = $value;
+							}
+							do_action( 'wbtm_add_icon_image', $id, $icon, $image );
+						} else {
+							echo '<input class="bm-gs__input" type="text" name="' . $id_attr . '" value="' . esc_attr($value) . '" placeholder="fas fa-bus or image URL">';
+						}
+						echo '</div>';
+						break;
+
+					default:
+						echo '<input class="bm-gs__input ' . esc_attr($class) . '" type="text" name="' . $id_attr . '" value="' . esc_attr($value) . '" placeholder="' . esc_attr($placeholder) . '">';
+						break;
+				}
 			}
 			public function wbtm_term_and_condition() {
 				?>
@@ -168,8 +926,8 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 						array(
 							'name'    => 'icon',
 							'label'   => $label . ' ' . esc_html__( 'Icon', 'bus-ticket-booking-with-seat-reservation' ),
-							'desc'    => esc_html__( 'If you want to change the icon in the dashboard menu, you can change it from here. Select a FontAwesome icon or enter a Dashicons class. Go to ', 'bus-ticket-booking-with-seat-reservation' ) . '<a href=https://developer.wordpress.org/resource/dashicons/#calendar-alt target=_blank>' . esc_html__( 'Dashicons Library', 'bus-ticket-booking-with-seat-reservation' ) . '</a>' . esc_html__( ' and copy your icon code and paste it here.', 'bus-ticket-booking-with-seat-reservation' ),
-							'type'    => 'icon',
+							'desc'    => esc_html__( 'Choose a FontAwesome/Dashicons icon or upload an image to use as the dashboard menu icon. Go to ', 'bus-ticket-booking-with-seat-reservation' ) . '<a href=https://developer.wordpress.org/resource/dashicons/#calendar-alt target=_blank>' . esc_html__( 'Dashicons Library', 'bus-ticket-booking-with-seat-reservation' ) . '</a>' . esc_html__( ' to copy an icon code.', 'bus-ticket-booking-with-seat-reservation' ),
+							'type'    => 'icon_image',
 							'default' => 'fas fa-bus'
 						),
 						array(

--- a/assets/admin/css/wbtm-global-settings.css
+++ b/assets/admin/css/wbtm-global-settings.css
@@ -1,0 +1,812 @@
+/* ============================================================
+   BUS MANAGER GLOBAL SETTINGS UI
+   All classes prefixed with .bm-gs__ to prevent conflicts
+   with WordPress, WooCommerce, or any theme CSS.
+   ============================================================ */
+
+.bm-gs__root, .bm-gs__root * { box-sizing: border-box; }
+.bm-gs__root {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen-Sans, Ubuntu, Cantarell, "Helvetica Neue", sans-serif;
+  font-size: 14px;
+  color: #1e293b;
+  line-height: 1.5;
+  -webkit-font-smoothing: antialiased;
+  margin: 0;
+  padding: 0;
+}
+
+/* ── LAYOUT ──
+   Single, natural page scroll (the WordPress admin body). The sidebar and
+   topbar are made sticky below the admin bar so they stay in view, instead of
+   nesting an inner scroll inside a fixed-height wrap (which produced a second
+   scrollbar on top of the admin page scroll). */
+.bm-gs__wrap {
+  display: flex;
+  min-height: calc(100vh - 32px);
+  position: relative;
+  margin: 0;
+  background: #fff;
+}
+
+/* ── MOBILE OVERLAY ── */
+.bm-gs__overlay {
+  display: none;
+  position: fixed;
+  inset: 0;
+  background: rgba(0,0,0,0.45);
+  z-index: 99998;
+}
+.bm-gs__overlay.bm-gs--open { display: block; }
+
+/* ── SIDEBAR ── */
+.bm-gs__sidebar {
+  width: 230px;
+  flex-shrink: 0;
+  background: #fff;
+  display: flex;
+  flex-direction: column;
+  transition: transform 0.25s ease;
+  z-index: 99999;
+  position: sticky;
+  top: 32px;
+  align-self: flex-start;
+  height: calc(100vh - 32px);
+}
+.bm-gs__sb-header {
+  padding: 18px 16px 14px;
+  border-bottom: 1px solid #f1f5f9;
+}
+.bm-gs__sb-plugin-label {
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: .8px;
+  text-transform: uppercase;
+  color: #94a3b8;
+  margin-bottom: 5px;
+}
+.bm-gs__sb-title {
+  font-size: 15px;
+  font-weight: 600;
+  color: #1e293b;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.bm-gs__sb-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: #6366f1;
+  display: inline-block;
+  flex-shrink: 0;
+}
+.bm-gs__sb-nav {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+.bm-gs__nav-item {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  padding: 9px 10px;
+  border-radius: 8px;
+  cursor: pointer;
+  color: #64748b;
+  font-size: 13px;
+  font-weight: 400;
+  font-family: inherit;
+  transition: background .12s, color .12s;
+  margin-bottom: 1px;
+  border: none;
+  background: none;
+  width: 100%;
+  text-align: left;
+}
+.bm-gs__nav-item:hover { background: #f8fafc; color: #334155; }
+.bm-gs__nav-item.bm-gs--active { background: #eef2ff; color: #4f46e5; font-weight: 500; }
+.bm-gs__nav-item .bm-gs__nav-icon { font-size: 15px; flex-shrink: 0; color: #94a3b8; width: 20px; text-align: center; }
+.bm-gs__nav-item.bm-gs--active .bm-gs__nav-icon { color: #6366f1; }
+.bm-gs__sb-footer {
+  padding: 10px 8px;
+  border-top: 1px solid #f1f5f9;
+}
+.bm-gs__lic-badge {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: #f0fdf4;
+  border-radius: 8px;
+  padding: 8px 10px;
+  border: 1px solid #bbf7d0;
+}
+.bm-gs__lic-badge.bm-gs--pro {
+  background: #f5f3ff;
+  border-color: #c7d2fe;
+}
+.bm-gs__lic-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 50%;
+  background: #10b981;
+  flex-shrink: 0;
+}
+.bm-gs__lic-badge.bm-gs--pro .bm-gs__lic-dot { background: #6366f1; }
+.bm-gs__lic-text { font-size: 11px; color: #059669; font-weight: 500; }
+.bm-gs__lic-badge.bm-gs--pro .bm-gs__lic-text { color: #4f46e5; }
+
+/* ── MAIN ── */
+.bm-gs__main {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+  background: #f1f5f9;
+  border-left: 1px solid #e2e8f0;
+}
+
+/* ── TOPBAR ── */
+.bm-gs__topbar {
+  height: 54px;
+  background: #fff;
+  border-bottom: 1px solid #e2e8f0;
+  display: flex;
+  align-items: center;
+  padding: 0 20px;
+  gap: 8px;
+  flex-shrink: 0;
+  position: sticky;
+  top: 32px;
+  z-index: 30;
+}
+.bm-gs__menu-btn {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 36px;
+  height: 36px;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  background: none;
+  cursor: pointer;
+  color: #64748b;
+  flex-shrink: 0;
+  font-size: 18px;
+}
+.bm-gs__topbar-title { font-size: 15px; font-weight: 600; color: #1e293b; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.bm-gs__topbar-sep { color: #cbd5e1; font-size: 14px; flex-shrink: 0; }
+.bm-gs__topbar-sub { font-size: 13px; color: #94a3b8; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; min-width: 0; }
+.bm-gs__save-btn {
+  margin-left: auto;
+  flex-shrink: 0;
+  background: #6366f1;
+  color: #fff;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+.bm-gs__save-btn:hover { background: #4f46e5; }
+
+/* ── CONTENT ── */
+.bm-gs__content { flex: 1; padding: 20px; }
+.bm-gs__tab-panel { display: none; }
+.bm-gs__tab-panel.bm-gs--active { display: block; }
+
+/* ── SECTION CARDS ── */
+.bm-gs__section-card {
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 12px;
+  margin-bottom: 16px;
+  overflow: hidden;
+}
+.bm-gs__section-head {
+  padding: 12px 18px;
+  border-bottom: 1px solid #f1f5f9;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.bm-gs__section-head .bm-gs__section-icon { font-size: 15px; color: #6366f1; }
+.bm-gs__section-head-label { font-size: 16px; font-weight: 600; color: #334155; }
+
+/* ── FIELD ROWS ── */
+.bm-gs__field-row {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  align-items: start;
+  border-bottom: 1px solid #f8fafc;
+}
+.bm-gs__field-row:last-child { border-bottom: none; }
+.bm-gs__field-label-cell { padding: 12px 18px; background: #fafafa; }
+.bm-gs__field-label { font-size: 14px; font-weight: 500; color: #334155; margin-bottom: 2px; }
+.bm-gs__field-hint { font-size: 11px; color: #94a3b8; line-height: 1.5; margin-top: 2px; }
+.bm-gs__field-control-cell { padding: 10px 14px; display: flex; align-items: center; flex-wrap: wrap; gap: 8px; }
+
+/* ── FORM CONTROLS ── */
+.bm-gs__select,
+.bm-gs__input {
+  width: 100%;
+  max-width: 400px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 13px;
+  color: #1e293b;
+  font-family: inherit;
+  outline: none;
+  transition: border-color .15s, box-shadow .15s;
+  min-height: 38px;
+  line-height: 1.4;
+}
+.bm-gs__select:focus,
+.bm-gs__input:focus {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99,102,241,.1);
+}
+.bm-gs__input--sm { width: 100px; min-width: 100px; max-width: 140px; }
+.bm-gs__textarea {
+  width: 100%;
+  max-width: 600px;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 8px 10px;
+  font-size: 13px;
+  color: #1e293b;
+  font-family: inherit;
+  outline: none;
+  resize: vertical;
+  min-height: 80px;
+  transition: border-color .15s, box-shadow .15s;
+}
+.bm-gs__textarea:focus {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99,102,241,.1);
+}
+
+/* ── CHECKBOXES ── */
+.bm-gs__checkbox-group { display: flex; flex-wrap: wrap; gap: 12px; }
+.bm-gs__checkbox-item { display: flex; align-items: center; gap: 6px; font-size: 13px; color: #475569; cursor: pointer; }
+.bm-gs__checkbox-item input[type="checkbox"] { accent-color: #6366f1; width: 14px; height: 14px; cursor: pointer; margin: 0; }
+
+/* ── BUTTONS ── */
+.bm-gs__color-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 6px 12px;
+  background: #fff;
+  cursor: pointer;
+  font-size: 13px;
+  color: #64748b;
+  font-family: inherit;
+  transition: border-color .12s, color .12s;
+}
+.bm-gs__color-btn:hover { border-color: #c7d2fe; color: #4f46e5; }
+.bm-gs__color-swatch { width: 20px; height: 20px; border-radius: 4px; border: 1px solid #e2e8f0; flex-shrink: 0; }
+.bm-gs__img-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: #eef2ff;
+  color: #4f46e5;
+  border: 1px solid #c7d2fe;
+  border-radius: 8px;
+  padding: 7px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+  transition: background .12s;
+}
+.bm-gs__img-btn:hover { background: #e0e7ff; }
+
+/* ── BADGES ── */
+.bm-gs__badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 3px 9px;
+  border-radius: 20px;
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+}
+.bm-gs__badge--active   { background: #dcfce7; color: #166534; }
+.bm-gs__badge--inactive { background: #fee2e2; color: #991b1b; }
+.bm-gs__badge--free     { background: #f0f9ff; color: #075985; }
+.bm-gs__badge--pro      { background: #f5f3ff; color: #5b21b6; }
+
+/* ── LICENSE TABLE ── */
+.bm-gs__table-wrap { overflow-x: auto; -webkit-overflow-scrolling: touch; }
+.bm-gs__lic-table { width: 100%; border-collapse: collapse; font-size: 13px; min-width: 600px; }
+.bm-gs__lic-table th {
+  background: #f8fafc;
+  padding: 10px 14px;
+  text-align: left;
+  font-weight: 600;
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: .5px;
+  color: #64748b;
+  border-bottom: 1px solid #e2e8f0;
+  white-space: nowrap;
+}
+.bm-gs__lic-table td { padding: 12px 14px; border-bottom: 1px solid #f8fafc; color: #334155; vertical-align: middle; }
+.bm-gs__lic-table tr:last-child td { border-bottom: none; }
+.bm-gs__lic-key-input {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  padding: 6px 10px;
+  font-size: 12px;
+  width: 140px;
+  color: #1e293b;
+  background: #fff;
+  font-family: inherit;
+  outline: none;
+}
+.bm-gs__lic-key-input:focus { border-color: #6366f1; }
+.bm-gs__act-btn {
+  background: #10b981;
+  color: #fff;
+  border: none;
+  padding: 7px 14px;
+  border-radius: 8px;
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  font-family: inherit;
+  white-space: nowrap;
+  transition: background .12s;
+}
+.bm-gs__act-btn:hover { background: #059669; }
+
+/* Override old license table styles to match new design */
+.bm-gs__lic-table input[type="text"],
+.bm-gs__lic-table input[type="password"] {
+  border: 1px solid #e2e8f0 !important;
+  border-radius: 8px !important;
+  padding: 6px 10px !important;
+  font-size: 12px !important;
+  width: 140px !important;
+  min-height: 34px !important;
+  color: #1e293b !important;
+  background: #fff !important;
+  font-family: inherit !important;
+  outline: none !important;
+  box-shadow: none !important;
+  line-height: 1.4 !important;
+  transition: border-color .15s, box-shadow .15s;
+}
+.bm-gs__lic-table input[type="text"]:focus,
+.bm-gs__lic-table input[type="password"]:focus {
+  border-color: #6366f1 !important;
+  box-shadow: 0 0 0 3px rgba(99,102,241,.1) !important;
+}
+.bm-gs__lic-table button,
+.bm-gs__lic-table .button {
+  background: #10b981 !important;
+  color: #fff !important;
+  border: none !important;
+  padding: 7px 14px !important;
+  border-radius: 8px !important;
+  font-size: 12px !important;
+  font-weight: 500 !important;
+  cursor: pointer !important;
+  font-family: inherit !important;
+  white-space: nowrap !important;
+  min-height: auto !important;
+  line-height: 1.4 !important;
+  transition: background .12s !important;
+}
+.bm-gs__lic-table button:hover,
+.bm-gs__lic-table .button:hover {
+  background: #059669 !important;
+  color: #fff !important;
+}
+
+/* ── WYSIWYG ── */
+.bm-gs__wysiwyg { border: 1px solid #e2e8f0; border-radius: 8px; overflow: hidden; width: 100%; max-width: 600px; }
+.bm-gs__wysiwyg .wp-editor-container { border: none !important; border-radius: 0 !important; }
+.bm-gs__wysiwyg .wp-editor-tabs { border-bottom: 1px solid #f1f5f9; }
+.bm-gs__wysiwyg .quicktags-toolbar { background: #f8fafc; border-bottom: 1px solid #f1f5f9; padding: 4px 6px; }
+.bm-gs__wysiwyg .wp-editor-area { border: none !important; border-radius: 0 !important; }
+
+/* ── INFO NOTE ── */
+.bm-gs__info-note { padding: 12px 18px; background: #eff6ff; border-bottom: 1px solid #dbeafe; }
+.bm-gs__info-note p { font-size: 12px; color: #3b82f6; line-height: 1.6; margin: 0; }
+
+/* ── PLUGIN LABEL BADGE (free/pro indicator in sidebar) ── */
+.bm-gs__plugin-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 10px;
+  font-weight: 600;
+  padding: 2px 6px;
+  border-radius: 4px;
+  margin-left: auto;
+}
+.bm-gs__plugin-badge--free { background: #f0f9ff; color: #075985; }
+.bm-gs__plugin-badge--pro  { background: #f5f3ff; color: #5b21b6; }
+
+/* ── WORDPRESS NOTICE HIDE INSIDE SETTINGS ── */
+.bm-gs__root .notice,
+.bm-gs__root .update-nag,
+.bm-gs__root .updated { display: none !important; }
+
+/* ── AI CHATBOT PROVIDER TOGGLE ── */
+.wbtm-ai-provider-row { transition: opacity 0.2s ease; }
+.wbtm-ai-provider-row.wbtm-hidden { display: none !important; }
+.bm-gs__field-row.wbtm-hidden { display: none !important; }
+
+
+/* ── COMPACT GRID (Style Settings — Colors & Typography) ──
+   Modern card-grid: each setting is a small rounded chip with a tight,
+   inline control. The default WP colour picker is slimmed down to a swatch
+   chip + hex field + compact reset, instead of the bulky stacked buttons. */
+.bm-gs__compact-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 10px;
+  padding: 16px 18px;
+}
+.bm-gs__compact-item {
+  display: flex;
+  flex-direction: column;
+  padding: 10px 12px;
+  border: 1px solid #eef2f6;
+  border-radius: 10px;
+  background: #fafbfc;
+}
+.bm-gs__compact-label {
+  display: block;
+  font-size: 10.5px;
+  font-weight: 600;
+  color: #1e1e1e;
+  margin-bottom: 8px;
+  text-transform: uppercase;
+  letter-spacing: .4px;
+}
+
+/* Typography number inputs — compact, fill the chip */
+.bm-gs__compact-item .bm-gs__input {
+  width: 100%;
+  max-width: 100%;
+  min-height: 34px;
+}
+
+/* Colour picker → compact inline swatch + hex (+ small reset) */
+.bm-gs__compact-item .wp-picker-container {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.bm-gs__compact-item .wp-picker-container .wp-color-result.button {
+  margin: 0;
+  width: 40px;
+  height: 34px;
+  min-height: 34px;
+  padding: 0;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  box-shadow: none;
+  flex-shrink: 0;
+}
+.bm-gs__compact-item .wp-color-result .wp-color-result-text { display: none; }
+.bm-gs__compact-item .wp-picker-input-wrap {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+}
+.bm-gs__compact-item .wp-picker-input-wrap input[type="text"] {
+  width: 86px !important;
+  height: 34px;
+  min-height: 34px;
+  border-radius: 8px;
+  border: 1px solid #e2e8f0;
+  font-size: 12px;
+  padding: 4px 8px;
+}
+.bm-gs__compact-item .wp-picker-default,
+.bm-gs__compact-item .wp-picker-clear {
+  height: 34px;
+  min-height: 34px;
+  line-height: 1;
+  padding: 0 8px;
+  border-radius: 8px;
+  font-size: 11px;
+}
+/* Iris panel spans the chip width when opened */
+.bm-gs__compact-item .wp-picker-holder { flex: 0 0 100%; }
+
+@media (max-width: 1100px) {
+  .bm-gs__compact-grid { grid-template-columns: repeat(2, 1fr); }
+}
+@media (max-width: 600px) {
+  .bm-gs__compact-grid { grid-template-columns: 1fr; }
+}
+
+/* ── CHECKLIST GRID (PDF / CSV columns) ── */
+.bm-gs__checklist-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0;
+  padding: 0;
+}
+.bm-gs__checklist-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 10px 18px;
+  font-size: 13px;
+  color: #334155;
+  cursor: pointer;
+  border-bottom: 1px solid #f8fafc;
+}
+.bm-gs__checklist-item:hover { background: #fafafa; }
+.bm-gs__checklist-item input[type="checkbox"] {
+  accent-color: #6366f1;
+  width: 14px;
+  height: 14px;
+  cursor: pointer;
+  flex-shrink: 0;
+  margin: 0;
+}
+@media (max-width: 900px) {
+  .bm-gs__checklist-grid { grid-template-columns: repeat(3, 1fr); }
+}
+@media (max-width: 600px) {
+  .bm-gs__checklist-grid { grid-template-columns: repeat(2, 1fr); }
+}
+
+
+/* ══════════════════════════════════════════
+   RESPONSIVE BREAKPOINTS
+   ══════════════════════════════════════════ */
+@media (max-width: 900px) {
+  .bm-gs__topbar-sub { display: none; }
+  .bm-gs__topbar-sep { display: none; }
+}
+
+@media (max-width: 782px) {
+  .bm-gs__sidebar {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100%;
+    transform: translateX(-100%);
+  }
+  .bm-gs__sidebar.bm-gs--open {
+    transform: translateX(0);
+    box-shadow: 4px 0 24px rgba(0,0,0,0.12);
+  }
+  .bm-gs__menu-btn { display: flex; }
+  .bm-gs__content { padding: 14px; }
+  .bm-gs__field-row { grid-template-columns: 1fr; }
+  .bm-gs__field-label-cell { padding: 12px 14px 6px; background: #fafafa; border-bottom: none; }
+  .bm-gs__field-control-cell { padding: 8px 14px 12px; background: #fff; }
+  .bm-gs__save-btn .bm-gs__save-text { display: none; }
+  /* On mobile the sidebar is an off-canvas drawer and the admin bar is 46px and
+     scrolls, so drop the sticky topbar + full-height divider here. */
+  .bm-gs__main { border-left: none; }
+  .bm-gs__topbar { padding: 0 14px; gap: 8px; position: static; }
+  .bm-gs__section-head { padding: 10px 14px; }
+  .bm-gs__section-head-label { font-size: 12px; }
+}
+
+@media (max-width: 480px) {
+  .bm-gs__wrap { min-height: 100vh; overflow: visible; }
+  .bm-gs__main { height: auto; overflow: visible; }
+  .bm-gs__content { overflow: visible; height: auto; }
+  .bm-gs__topbar-title { font-size: 13px; }
+  .bm-gs__save-btn { padding: 8px 12px; }
+  .bm-gs__input--sm { width: 80px; }
+  .bm-gs__checkbox-group { gap: 8px; }
+}
+
+/* ══════════════════════════════════════════════════════════════
+   WORDPRESS ADMIN OVERRIDES
+   This UI renders inside <body class="wp-admin wp-core-ui">, where
+   wp-admin/css/forms.css styles every native control. In particular
+   `.wp-core-ui select` (specificity 0,1,1) out-ranks `.bm-gs__select`
+   (0,1,0) and repaints our dropdowns with WP's grey border, 2px radius,
+   40px height and its own arrow — so the right-hand controls stop
+   matching the design. Re-scoping each rule under `.bm-gs__root` raises
+   specificity to (0,2,0)+, so the intended styling wins. Text colours
+   are pinned for the same reason (links inherit the admin blue).
+   ══════════════════════════════════════════════════════════════ */
+
+/* Dropdowns: re-assert the design over `.wp-core-ui select` */
+.bm-gs__root .bm-gs__select {
+  -webkit-appearance: none;
+  -moz-appearance: none;
+  appearance: none;
+  width: 100%;
+  max-width: 400px;
+  min-height: 38px;
+  height: auto;
+  line-height: 1.4;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  color: #1e293b;
+  padding: 8px 32px 8px 10px;
+  background-color: #fff;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 24 24' fill='none' stroke='%2364748b' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpolyline points='6 9 12 15 18 9'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: right 10px center;
+  background-size: 12px 12px;
+  box-shadow: none;
+  cursor: pointer;
+}
+.bm-gs__root .bm-gs__select:hover { border-color: #cbd5e1; color: #1e293b; }
+.bm-gs__root .bm-gs__select:focus {
+  border-color: #6366f1;
+  color: #1e293b;
+  box-shadow: 0 0 0 3px rgba(99,102,241,.1);
+  outline: none;
+}
+
+/* Text inputs / textarea: keep border, radius and height consistent with
+   the dropdowns and immune to the active admin colour scheme */
+.bm-gs__root .bm-gs__input,
+.bm-gs__root .bm-gs__textarea {
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  color: #1e293b;
+  min-height: 38px;
+  box-shadow: none;
+}
+.bm-gs__root .bm-gs__textarea { min-height: 80px; }
+.bm-gs__root .bm-gs__input:focus,
+.bm-gs__root .bm-gs__textarea:focus {
+  border-color: #6366f1;
+  box-shadow: 0 0 0 3px rgba(99,102,241,.1);
+  outline: none;
+}
+
+/* Pin text colours so nothing inherits the admin colour scheme */
+.bm-gs__root .bm-gs__section-head-label,
+.bm-gs__root .bm-gs__field-label { color: #334155; }
+.bm-gs__root .bm-gs__field-hint { color: #000; }
+.bm-gs__root .bm-gs__field-hint a { color: #6366f1; text-decoration: none; }
+.bm-gs__root .bm-gs__field-hint a:hover { text-decoration: underline; }
+.bm-gs__root .bm-gs__checkbox-item { color: #475569; }
+
+/* ══════════════════════════════════════════════════════════════
+   ICON / IMAGE PICKER  (Bus Icon, Bus search list direction icon)
+   These controls come from WBTM_Select_Icon_image and are normally
+   styled inside a `.wbtm_style` wrapper. This redesigned screen has
+   no such wrapper, so the classic layout/`.dNone`/remove-button rules
+   never apply (giant 40px ×, preview + add-button shown together).
+   We restyle them here to match the modern design and — critically —
+   re-implement `.dNone` so the picker's show/hide state toggling
+   (handled by wbtm_admin_settings.js) keeps working.
+   The popup itself carries `.wbtm_style`, so it is left untouched.
+   ══════════════════════════════════════════════════════════════ */
+
+/* Preview tile toggling (only the empty icon/image tile is hidden by `.dNone`).
+   We deliberately scope this to the tiles so the add-button row below is NOT
+   hidden when an icon/image is already selected. */
+.bm-gs__root .wbtm_add_icon_image_area .wbtm_icon_item.dNone,
+.bm-gs__root .wbtm_add_icon_image_area .wbtm_image_item.dNone { display: none !important; }
+
+/* Keep the "Icon" / "Image" buttons always reachable, even when an icon or
+   image is already set (the classic JS hides them via .dNone / slideUp, which
+   forced the user to remove the current icon before they could upload). */
+.bm-gs__root .wbtm_add_icon_image_area .wbtm_add_icon_image_button_area {
+  display: block !important;
+  margin-top: 2px;
+}
+
+/* Container */
+.bm-gs__root .wbtm_add_icon_image_area {
+  display: inline-flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 10px;
+  border: none;
+  max-width: none;
+  background: none;
+  padding: 0;
+}
+
+/* Preview tile (icon or image) */
+.bm-gs__root .wbtm_add_icon_image_area .wbtm_icon_item,
+.bm-gs__root .wbtm_add_icon_image_area .wbtm_image_item {
+  position: relative;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 72px;
+  height: 72px;
+  padding: 0;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  background: #f8fafc;
+  font-size: 30px;
+  color: #334155;
+  overflow: visible;
+}
+.bm-gs__root .wbtm_add_icon_image_area .wbtm_icon_item .allCenter {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 100%;
+  height: 100%;
+}
+.bm-gs__root .wbtm_add_icon_image_area .wbtm_icon_item [data-add-icon] {
+  font-size: 30px;
+  line-height: 1;
+}
+.bm-gs__root .wbtm_add_icon_image_area .wbtm_image_item img {
+  max-width: 60px;
+  max-height: 60px;
+  border-radius: 6px;
+  object-fit: contain;
+}
+
+/* Remove (×) badge — small circle in the top-right corner of the tile */
+.bm-gs__root .wbtm_add_icon_image_area .wbtm_remove_icon {
+  position: absolute;
+  top: -8px;
+  right: -8px;
+  width: 22px;
+  height: 22px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 11px;
+  line-height: 1;
+  color: #64748b;
+  background: #fff;
+  border: 1px solid #e2e8f0;
+  border-radius: 50%;
+  cursor: pointer;
+  opacity: 1;
+  box-shadow: 0 1px 2px rgba(0,0,0,.08);
+  transition: color .12s, border-color .12s, background .12s;
+}
+.bm-gs__root .wbtm_add_icon_image_area .wbtm_remove_icon:hover {
+  color: #fff;
+  background: #ef4444;
+  border-color: #ef4444;
+}
+
+/* "Icon" / "Image" add buttons — match the design's upload button */
+.bm-gs__root .wbtm_add_icon_image_button_area .flexEqual {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+.bm-gs__root .wbtm_add_icon_image_button_area button {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: #eef2ff;
+  color: #4f46e5;
+  border: 1px solid #c7d2fe;
+  border-radius: 8px;
+  padding: 7px 14px;
+  font-size: 13px;
+  font-weight: 500;
+  font-family: inherit;
+  line-height: 1.4;
+  min-height: 0;
+  cursor: pointer;
+  transition: background .12s;
+}
+.bm-gs__root .wbtm_add_icon_image_button_area button:hover { background: #e0e7ff; }
+.bm-gs__root .wbtm_add_icon_image_button_area button span { margin: 0; }

--- a/assets/admin/js/wbtm-global-settings.js
+++ b/assets/admin/js/wbtm-global-settings.js
@@ -1,0 +1,72 @@
+/**
+ * Bus Manager Global Settings — Tab switching & mobile sidebar
+ */
+(function ($, bmGs) {
+	'use strict';
+
+	var tabMeta = bmGs.tabMeta || {};
+	var defaultTab = bmGs.defaultTab || '';
+
+	/** Switch to a tab panel */
+	bmGs.switchTab = function (id, btn) {
+		$('.bm-gs__tab-panel').removeClass('bm-gs--active');
+		$('.bm-gs__nav-item').removeClass('bm-gs--active');
+		$('#bm-tab-' + id).addClass('bm-gs--active');
+		if (btn) { $(btn).addClass('bm-gs--active'); }
+		var meta = tabMeta[id] || [id, ''];
+		$('#bm-topbar-title').text(meta[0] || id);
+		$('#bm-topbar-sub').text(meta[1] || '');
+		bmGs.closeSidebar();
+
+		if (typeof bmGs.rememberTab === 'function') {
+			bmGs.rememberTab(id);
+		}
+	};
+
+	/** Open mobile sidebar */
+	bmGs.openSidebar = function () {
+		$('#bm-sidebar').addClass('bm-gs--open');
+		$('#bm-overlay').addClass('bm-gs--open');
+	};
+
+	/** Close mobile sidebar */
+	bmGs.closeSidebar = function () {
+		$('#bm-sidebar').removeClass('bm-gs--open');
+		$('#bm-overlay').removeClass('bm-gs--open');
+	};
+
+	$(function () {
+
+		// Nav item click
+		$(document).on('click', '.bm-gs__nav-item', function (e) {
+			e.preventDefault();
+			var tabId = $(this).data('tab');
+			if (tabId) { bmGs.switchTab(tabId, this); }
+		});
+
+		// Menu button click (mobile)
+		$(document).on('click', '#bm-menu-btn', function () {
+			bmGs.openSidebar();
+		});
+
+		// Overlay click → close sidebar
+		$(document).on('click', '#bm-overlay', function () {
+			bmGs.closeSidebar();
+		});
+
+		// Topbar save button → submit active tab's form
+		// Uses HTMLFormElement.prototype.submit to avoid the "id=submit" shadow bug
+		// (WP submit_button() outputs <input id="submit"> which shadows form.submit).
+		$(document).on('click', '#bm-save-btn', function (e) {
+			e.preventDefault();
+			var $f = $('.bm-gs__tab-panel.bm-gs--active').find('form').first();
+			if ($f.length) { HTMLFormElement.prototype.submit.call($f[0]); }
+		});
+
+		// Activate default tab
+		if (defaultTab && $('#bm-tab-' + defaultTab).length) {
+			bmGs.switchTab(defaultTab, $('.bm-gs__nav-item[data-tab="' + defaultTab + '"]').first()[0]);
+		}
+	});
+
+})(jQuery, window.bmGs = window.bmGs || {});

--- a/inc/WBTM_Functions.php
+++ b/inc/WBTM_Functions.php
@@ -1482,22 +1482,282 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 			}
 			public static function get_icon() {
 				$icon = WBTM_Global_Function::get_settings( 'wbtm_general_settings', 'icon', 'fas fa-bus' );
+				// Default bus icon as an SVG data URI. WP admin menus cannot render a
+				// FontAwesome class directly, so FA values fall back to this too.
+				$fallback = 'data:image/svg+xml;base64,' . base64_encode( '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill="black" d="M5 2c-1.7 0-3 1.3-3 3v7c0 1.1.9 2 2 2v2h2v-2h8v2h2v-2c1.1 0 2-.9 2-2V5c0-1.7-1.3-3-3-3H5zm0 2h10c.6 0 1 .4 1 1v4H4V5c0-.6.4-1 1-1zm0 7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm10 0a1.5 1.5 0 110 3 1.5 1.5 0 010-3zM5 6h2v2H5V6zm4 0h6v2H9V6z"/></svg>' );
 				if ( $icon ) {
-					// If it's a dashicons class, return as-is for WP menu
+					// Uploaded image (icon_image stores the attachment ID) → resolve to URL.
+					// If the attachment was deleted, use the default icon.
+					if ( is_numeric( $icon ) ) {
+						$url = wp_get_attachment_url( (int) $icon );
+						return $url ? $url : $fallback;
+					}
+					// Dashicons class → WP menus render it natively.
 					if ( strpos( $icon, 'dashicons' ) === 0 ) {
 						return $icon;
 					}
-					// If it's a FontAwesome class (fa, fas, far, fab), convert to SVG data URI for WP menu
+					// FontAwesome class → not renderable by WP menus, use the bus SVG.
 					if ( preg_match( '/^(fa[srlbdt]?)\s+fa-/', $icon ) ) {
-						$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill="black" d="M5 2c-1.7 0-3 1.3-3 3v7c0 1.1.9 2 2 2v2h2v-2h8v2h2v-2c1.1 0 2-.9 2-2V5c0-1.7-1.3-3-3-3H5zm0 2h10c.6 0 1 .4 1 1v4H4V5c0-.6.4-1 1-1zm0 7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm10 0a1.5 1.5 0 110 3 1.5 1.5 0 010-3zM5 6h2v2H5V6zm4 0h6v2H9V6z"/></svg>';
-						return 'data:image/svg+xml;base64,' . base64_encode( $svg );
+						return $fallback;
 					}
-					// Otherwise return as-is (could be a data URI or URL)
+					// Otherwise it's already a data URI or image URL → use as-is.
 					return $icon;
 				}
-				// Fallback SVG bus icon
-				$svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20"><path fill="black" d="M5 2c-1.7 0-3 1.3-3 3v7c0 1.1.9 2 2 2v2h2v-2h8v2h2v-2c1.1 0 2-.9 2-2V5c0-1.7-1.3-3-3-3H5zm0 2h10c.6 0 1 .4 1 1v4H4V5c0-.6.4-1 1-1zm0 7a1.5 1.5 0 110 3 1.5 1.5 0 010-3zm10 0a1.5 1.5 0 110 3 1.5 1.5 0 010-3zM5 6h2v2H5V6zm4 0h6v2H9V6z"/></svg>';
-				return 'data:image/svg+xml;base64,' . base64_encode( $svg );
+				return $fallback;
+			}
+
+			public static function output_dynamic_menu_icon_css() {
+				$icon = WBTM_Global_Function::get_settings( 'wbtm_general_settings', 'icon', '' );
+				// Target all possible WP admin menu item IDs for this CPT
+				$item_ids = [
+					'#adminmenu #menu-posts-wbtm_bus .wp-menu-image',
+					'#adminmenu #toplevel_page_wbtm_bus .wp-menu-image',
+					'#adminmenu li.menu-top.wp-has-submenu.wp-menu-open .wp-menu-image',
+				];
+				$img_sel    = implode( ', ', array_map( function($s){ return $s . ' img'; }, $item_ids ) );
+				$before_sel = implode( ', ', $item_ids );
+
+				// ── FontAwesome class → render via :before + FA font ──
+				if ( $icon && preg_match( '/^(fa[srlbdt]?)\s+fa-(.+)$/', $icon, $m ) ) {
+					$style   = $m[1];
+					$unicode = self::fa_unicode( $m[2] );
+					if ( $unicode ) {
+						$weight = ( $style === 'fas' || $style === 'fa' ) ? 900 : 400;
+						echo '<style>'
+							. esc_html( $img_sel ) . ' { display: none !important; }'
+							. esc_html( $before_sel ) . ':before {'
+							. 'content: "\\' . esc_attr( $unicode ) . '" !important;'
+							. 'font-family: "Font Awesome 6 Free" !important;'
+							. 'font-weight: ' . esc_attr( (string) $weight ) . ' !important;'
+							. 'font-size: 20px !important;'
+							. 'padding-top: 4px !important;'
+							. '}'
+							. '</style>' . "\n";
+					}
+					return;
+				}
+
+				// ── Dashicons class ──
+				if ( $icon && strpos( $icon, 'dashicons' ) === 0 ) {
+					echo '<style>' . esc_html( $img_sel ) . ' { display: none !important; }'
+						. esc_html( $before_sel ) . '.dashicons-before:before {'
+						. 'content: "\\' . esc_attr( self::dashicon_unicode( $icon ) ) . '" !important;'
+						. 'font-family: dashicons !important; }'
+						. '</style>' . "\n";
+					return;
+				}
+
+				// ── Image URL / attachment ID / data URI ──
+				if ( $icon && ( filter_var( $icon, FILTER_VALIDATE_URL ) || strpos( $icon, 'data:image' ) === 0 || is_numeric( $icon ) ) ) {
+					if ( is_numeric( $icon ) ) {
+						$url = wp_get_attachment_url( (int) $icon );
+						if ( ! $url ) return;
+						$icon = $url;
+					}
+					echo '<style>'
+						. esc_html( $before_sel ) . '.dashicons-before:before { content: none !important; }'
+						. esc_html( $img_sel ) . ' { width: 20px !important; height: 20px !important; padding: 7px 0 0 !important; display: inline-block !important; }'
+						. '</style>' . "\n";
+					echo '<script>jQuery(function($){'
+						. 'var s=' . wp_json_encode( $img_sel ) . ';'
+						. '$(s).attr("src",' . wp_json_encode( $icon ) . ').show();'
+						. '});</script>' . "\n";
+					return;
+				}
+			}
+
+			private static function fa_unicode( $name ) {
+				// Frequently used Font Awesome icons — Unicode private-use area codes
+				$map = [
+					'bus' => 'f207', 'bus-simple' => 'f55e', 'bus-alt' => 'f55e',
+					'train' => 'f238', 'train-subway' => 'f239', 'train-tram' => 'f8b4',
+					'car' => 'f1b9', 'car-side' => 'f5e4', 'car-alt' => 'f5de',
+					'taxi' => 'f1ba', 'truck' => 'f0d1', 'truck-moving' => 'f4df',
+					'ship' => 'f21a', 'plane' => 'f072', 'plane-departure' => 'f5af',
+					'bicycle' => 'f206', 'motorcycle' => 'f21c', 'walking' => 'f554',
+					'shuttle-van' => 'f5b6', 'shuttle-space' => 'f197',
+					'ticket' => 'f145', 'ticket-alt' => 'f3ff', 'tickets' => 'e658',
+					'location-dot' => 'f3c5', 'map-marker-alt' => 'f3c5', 'map-marker' => 'f041',
+					'map-pin' => 'f276', 'map' => 'f279', 'location-arrow' => 'f124',
+					'route' => 'f4d7', 'road' => 'f018', 'signs-post' => 'f277',
+					'calendar' => 'f133', 'calendar-alt' => 'f073', 'calendar-days' => 'f073',
+					'calendar-check' => 'f274', 'calendar-plus' => 'f271', 'calendar-week' => 'f784',
+					'clock' => 'f017', 'clock-four' => 'f017', 'hourglass' => 'f254',
+					'user' => 'f007', 'users' => 'f0c0', 'user-check' => 'f4fc',
+					'user-plus' => 'f234', 'user-tie' => 'f508', 'address-card' => 'f2bb',
+					'id-card' => 'f2c2', 'id-badge' => 'f2c1', 'passport' => 'f5ab',
+					'credit-card' => 'f09d', 'credit-card-alt' => 'f283', 'money-bill' => 'f0d6',
+					'money-check' => 'f53c', 'dollar-sign' => 'f155', 'wallet' => 'f555',
+					'shopping-cart' => 'f07a', 'cart-shopping' => 'f07a', 'basket-shopping' => 'f291',
+					'store' => 'f54e', 'shop' => 'f54f', 'bag-shopping' => 'f290',
+					'gear' => 'f013', 'cog' => 'f013', 'gears' => 'f085', 'cogs' => 'f085',
+					'wrench' => 'f0ad', 'tools' => 'f7d9', 'screwdriver-wrench' => 'f7d9',
+					'sliders' => 'f1de', 'sliders-h' => 'f1de', 'toggle-on' => 'f205',
+					'check' => 'f00c', 'check-circle' => 'f058', 'check-square' => 'f14a',
+					'xmark' => 'f00d', 'times' => 'f00d', 'circle-xmark' => 'f057',
+					'exclamation' => 'f12a', 'exclamation-circle' => 'f06a', 'exclamation-triangle' => 'f071',
+					'triangle-exclamation' => 'f071', 'circle-exclamation' => 'f06a',
+					'info' => 'f129', 'info-circle' => 'f05a', 'circle-info' => 'f05a',
+					'question' => 'f128', 'question-circle' => 'f059', 'circle-question' => 'f059',
+					'plus' => '2b', 'plus-circle' => 'f055', 'minus' => 'f068', 'minus-circle' => 'f056',
+					'star' => 'f005', 'star-half' => 'f089', 'star-half-stroke' => 'f5c0',
+					'heart' => 'f004', 'thumbs-up' => 'f164', 'thumbs-down' => 'f165',
+					'home' => 'f015', 'house' => 'f015', 'building' => 'f1ad',
+					'globe' => 'f0ac', 'earth-americas' => 'f0ac', 'earth' => 'f57d',
+					'phone' => 'f095', 'phone-flip' => 'f879', 'envelope' => 'f0e0',
+					'at' => '40', 'hashtag' => '23', 'signal' => 'f012',
+					'wifi' => 'f1eb', 'bluetooth' => 'f293', 'bluetooth-b' => 'f294',
+					'battery-full' => 'f240', 'battery-three-quarters' => 'f241',
+					'battery-half' => 'f242', 'battery-quarter' => 'f243', 'battery-empty' => 'f244',
+					'plug' => 'f1e6', 'charging-station' => 'f5e7', 'gas-pump' => 'f52f',
+					'leaf' => 'f06c', 'tree' => 'f1bb', 'seedling' => 'f4d8',
+					'sun' => 'f185', 'moon' => 'f186', 'cloud' => 'f0c2', 'cloud-sun' => 'f6c4',
+					'snowflake' => 'f2dc', 'umbrella' => 'f0e9', 'bolt' => 'f0e7',
+					'fire' => 'f06d', 'shield' => 'f132', 'shield-halved' => 'f3ed',
+					'lock' => 'f023', 'unlock' => 'f09c', 'key' => 'f084',
+					'eye' => 'f06e', 'eye-slash' => 'f070', 'fingerprint' => 'f577',
+					'magnifying-glass' => 'f002', 'search' => 'f002', 'filter' => 'f0b0',
+					'bars' => 'f0c9', 'list' => 'f03a', 'table' => 'f0ce', 'grip' => 'f58d',
+					'print' => 'f02f', 'download' => 'f019', 'upload' => 'f093',
+					'cloud-arrow-up' => 'f0ee', 'cloud-arrow-down' => 'f0ed',
+					'link' => 'f0c1', 'paperclip' => 'f0c6', 'copy' => 'f0c5',
+					'paste' => 'f0ea', 'clipboard' => 'f328', 'scissors' => 'f0c4',
+					'trash' => 'f1f8', 'trash-can' => 'f2ed', 'trash-alt' => 'f2ed',
+					'pen' => 'f304', 'pen-to-square' => 'f044', 'edit' => 'f044',
+					'pencil' => 'f303', 'pencil-alt' => 'f303', 'eraser' => 'f12d',
+					'file' => 'f15b', 'file-lines' => 'f15c', 'file-alt' => 'f15c',
+					'file-pdf' => 'f1c1', 'file-word' => 'f1c2', 'file-excel' => 'f1c3',
+					'file-image' => 'f1c5', 'file-video' => 'f1c8', 'file-audio' => 'f1c7',
+					'file-csv' => 'f6dd', 'file-code' => 'f1c9', 'file-zipper' => 'f1c6',
+					'folder' => 'f07b', 'folder-open' => 'f07c', 'folder-plus' => 'f65e',
+					'image' => 'f03e', 'images' => 'f302', 'camera' => 'f030',
+					'video' => 'f03d', 'film' => 'f008', 'music' => 'f001',
+					'headphones' => 'f025', 'volume-high' => 'f028', 'volume-xmark' => 'f6a9',
+					'microphone' => 'f130', 'microphone-slash' => 'f131',
+					'desktop' => 'f108', 'laptop' => 'f109', 'tablet' => 'f3fa',
+					'mobile' => 'f3cd', 'mobile-screen' => 'f3cf', 'display' => 'e163',
+					'server' => 'f233', 'database' => 'f1c0', 'hard-drive' => 'f0a0',
+					'circle' => 'f111', 'square' => 'f0c8', 'ban' => 'f05e',
+					'play' => 'f04b', 'pause' => 'f04c', 'stop' => 'f04d',
+					'backward' => 'f04a', 'forward' => 'f04e', 'backward-step' => 'f048',
+					'forward-step' => 'f051', 'rotate' => 'f2f1', 'rotate-right' => 'f2f9',
+					'arrows-rotate' => 'f021', 'sync' => 'f021', 'refresh' => 'f021',
+					'arrow-right' => 'f061', 'arrow-left' => 'f060', 'arrow-up' => 'f062', 'arrow-down' => 'f063',
+					'chevron-right' => 'f054', 'chevron-left' => 'f053', 'chevron-up' => 'f077', 'chevron-down' => 'f078',
+					'angle-right' => 'f105', 'angle-left' => 'f104', 'angle-up' => 'f106', 'angle-down' => 'f107',
+					'caret-right' => 'f0da', 'caret-left' => 'f0d9', 'caret-up' => 'f0d8', 'caret-down' => 'f0d7',
+					'arrow-up-right-from-square' => 'f08e', 'external-link-alt' => 'f08e',
+					'spinner' => 'f110', 'circle-notch' => 'f1ce', 'compass' => 'f14e',
+					'bell' => 'f0f3', 'bell-slash' => 'f1f6', 'comment' => 'f075',
+					'comments' => 'f086', 'message' => 'f27a', 'envelope-open' => 'f2b6',
+					'rocket' => 'f135', 'paper-plane' => 'f1d8', 'tag' => 'f02b', 'tags' => 'f02c',
+					'bookmark' => 'f02e', 'book' => 'f02d', 'book-open' => 'f518',
+					'newspaper' => 'f1ea', 'scroll' => 'f70e', 'sticky-note' => 'f249',
+					'cube' => 'f1b2', 'cubes' => 'f1b3', 'box' => 'f466', 'boxes' => 'f468',
+					'inbox' => 'f01c', 'outbox' => 'e6bf', 'archive' => 'f187',
+					'palette' => 'f53f', 'paint-brush' => 'f1fc', 'droplet' => 'f043',
+					'bug' => 'f188', 'code' => 'f121', 'terminal' => 'f120',
+					'quote-right' => 'f10e', 'quote-left' => 'f10d', 'language' => 'f1ab',
+					'barcode' => 'f02a', 'qrcode' => 'f029', 'rss' => 'f09e',
+					'glasses' => 'f530', 'graduation-cap' => 'f19d', 'school' => 'f549',
+					'briefcase' => 'f0b1', 'suitcase' => 'f0f2', 'suitcase-rolling' => 'f5c1',
+					'gift' => 'f06b', 'award' => 'f559', 'trophy' => 'f091',
+					'hand' => 'f256', 'handshake' => 'f2b5', 'hand-holding-heart' => 'f4be',
+					'person' => 'f183', 'people-group' => 'e533', 'people-arrows' => 'e068',
+					'wheelchair' => 'f193', 'wheelchair-move' => 'e2ce', 'accessible-icon' => 'f368',
+					'child' => 'f1ae', 'baby' => 'f77c', 'dog' => 'f6d3', 'cat' => 'f6be',
+					'crow' => 'f520', 'fish' => 'f578', 'paw' => 'f1b0',
+					'smoking' => 'f48d', 'ban-smoking' => 'f54d', 'wine-glass' => 'f4e3',
+					'mug-saucer' => 'f0f4', 'coffee' => 'f0f4', 'beer-mug-empty' => 'f0fc',
+					'utensils' => 'f2e7', 'pizza-slice' => 'f818', 'hamburger' => 'f805',
+					'apple-whole' => 'f5d1', 'lemon' => 'f094', 'carrot' => 'f787',
+				];
+				return isset( $map[ $name ] ) ? $map[ $name ] : '';
+			}
+
+			private static function dashicon_unicode( $class ) {
+				$map = [
+					'dashicons-menu' => 'f333', 'dashicons-admin-site' => 'f319', 'dashicons-dashboard' => 'f226',
+					'dashicons-admin-post' => 'f109', 'dashicons-admin-media' => 'f104', 'dashicons-admin-links' => 'f103',
+					'dashicons-admin-page' => 'f105', 'dashicons-admin-comments' => 'f101', 'dashicons-admin-appearance' => 'f100',
+					'dashicons-admin-plugins' => 'f106', 'dashicons-admin-users' => 'f110', 'dashicons-admin-tools' => 'f107',
+					'dashicons-admin-settings' => 'f108', 'dashicons-admin-network' => 'f112', 'dashicons-admin-home' => 'f102',
+					'dashicons-admin-generic' => 'f111', 'dashicons-admin-collapse' => 'f148', 'dashicons-filter' => 'f536',
+					'dashicons-admin-customizer' => 'f540', 'dashicons-admin-multisite' => 'f541',
+					'dashicons-welcome-write-blog' => 'f119', 'dashicons-welcome-add-page' => 'f133', 'dashicons-welcome-view-site' => 'f115',
+					'dashicons-welcome-widgets-menus' => 'f116', 'dashicons-welcome-comments' => 'f117', 'dashicons-welcome-learn-more' => 'f118',
+					'dashicons-format-aside' => 'f123', 'dashicons-format-image' => 'f128', 'dashicons-format-gallery' => 'f161',
+					'dashicons-format-video' => 'f126', 'dashicons-format-status' => 'f130', 'dashicons-format-quote' => 'f122',
+					'dashicons-format-chat' => 'f125', 'dashicons-format-audio' => 'f127', 'dashicons-camera' => 'f306',
+					'dashicons-images-alt' => 'f232', 'dashicons-images-alt2' => 'f233', 'dashicons-video-alt' => 'f234',
+					'dashicons-video-alt2' => 'f235', 'dashicons-video-alt3' => 'f236', 'dashicons-media-archive' => 'f501',
+					'dashicons-media-audio' => 'f500', 'dashicons-media-code' => 'f499', 'dashicons-media-default' => 'f498',
+					'dashicons-media-document' => 'f497', 'dashicons-media-interactive' => 'f496', 'dashicons-media-spreadsheet' => 'f495',
+					'dashicons-media-text' => 'f491', 'dashicons-media-video' => 'f490', 'dashicons-playlist-audio' => 'f492',
+					'dashicons-playlist-video' => 'f493', 'dashicons-controls-play' => 'f522', 'dashicons-controls-pause' => 'f523',
+					'dashicons-controls-forward' => 'f519', 'dashicons-controls-skipforward' => 'f517', 'dashicons-controls-back' => 'f518',
+					'dashicons-controls-skipback' => 'f516', 'dashicons-controls-repeat' => 'f515', 'dashicons-controls-volumeon' => 'f521',
+					'dashicons-controls-volumeoff' => 'f520', 'dashicons-image-crop' => 'f165', 'dashicons-image-rotate' => 'f531',
+					'dashicons-image-rotate-left' => 'f166', 'dashicons-image-rotate-right' => 'f167', 'dashicons-image-flip-vertical' => 'f168',
+					'dashicons-image-flip-horizontal' => 'f169', 'dashicons-image-filter' => 'f533', 'dashicons-undo' => 'f171',
+					'dashicons-redo' => 'f172', 'dashicons-editor-bold' => 'f200', 'dashicons-editor-italic' => 'f201',
+					'dashicons-editor-ul' => 'f203', 'dashicons-editor-ol' => 'f204', 'dashicons-editor-quote' => 'f205',
+					'dashicons-editor-alignleft' => 'f206', 'dashicons-editor-aligncenter' => 'f207', 'dashicons-editor-alignright' => 'f208',
+					'dashicons-editor-insertmore' => 'f209', 'dashicons-editor-spellcheck' => 'f210', 'dashicons-editor-expand' => 'f211',
+					'dashicons-editor-contract' => 'f506', 'dashicons-editor-kitchensink' => 'f212', 'dashicons-editor-underline' => 'f213',
+					'dashicons-editor-justify' => 'f214', 'dashicons-editor-textcolor' => 'f215', 'dashicons-editor-paste-word' => 'f216',
+					'dashicons-editor-paste-text' => 'f217', 'dashicons-editor-removeformatting' => 'f218', 'dashicons-editor-video' => 'f219',
+					'dashicons-editor-customchar' => 'f220', 'dashicons-editor-outdent' => 'f221', 'dashicons-editor-indent' => 'f222',
+					'dashicons-editor-help' => 'f223', 'dashicons-editor-strikethrough' => 'f224', 'dashicons-editor-unlink' => 'f225',
+					'dashicons-editor-rtl' => 'f320', 'dashicons-editor-break' => 'f474', 'dashicons-editor-code' => 'f475',
+					'dashicons-editor-paragraph' => 'f476', 'dashicons-editor-table' => 'f535',
+					'dashicons-align-left' => 'f135', 'dashicons-align-right' => 'f136', 'dashicons-align-center' => 'f134',
+					'dashicons-align-none' => 'f138', 'dashicons-lock' => 'f160', 'dashicons-unlock' => 'f528',
+					'dashicons-calendar' => 'f145', 'dashicons-calendar-alt' => 'f508', 'dashicons-visibility' => 'f177',
+					'dashicons-hidden' => 'f530', 'dashicons-post-status' => 'f173', 'dashicons-edit' => 'f464',
+					'dashicons-trash' => 'f182', 'dashicons-sticky' => 'f537', 'dashicons-external' => 'f504',
+					'dashicons-arrow-up' => 'f142', 'dashicons-arrow-down' => 'f140', 'dashicons-arrow-right' => 'f139',
+					'dashicons-arrow-left' => 'f141', 'dashicons-arrow-up-alt' => 'f342', 'dashicons-arrow-down-alt' => 'f346',
+					'dashicons-arrow-right-alt' => 'f344', 'dashicons-arrow-left-alt' => 'f340', 'dashicons-arrow-up-alt2' => 'f343',
+					'dashicons-arrow-down-alt2' => 'f347', 'dashicons-arrow-right-alt2' => 'f345', 'dashicons-arrow-left-alt2' => 'f341',
+					'dashicons-sort' => 'f156', 'dashicons-leftright' => 'f229', 'dashicons-randomize' => 'f503',
+					'dashicons-list-view' => 'f163', 'dashicons-exerpt-view' => 'f164', 'dashicons-grid-view' => 'f509',
+					'dashicons-move' => 'f545', 'dashicons-share' => 'f237', 'dashicons-share-alt' => 'f240',
+					'dashicons-share-alt2' => 'f242', 'dashicons-twitter' => 'f301', 'dashicons-rss' => 'f303',
+					'dashicons-email' => 'f465', 'dashicons-email-alt' => 'f466', 'dashicons-facebook' => 'f304',
+					'dashicons-facebook-alt' => 'f305', 'dashicons-googleplus' => 'f462', 'dashicons-networking' => 'f325',
+					'dashicons-hammer' => 'f308', 'dashicons-art' => 'f309', 'dashicons-migrate' => 'f310',
+					'dashicons-performance' => 'f311', 'dashicons-universal-access' => 'f483', 'dashicons-universal-access-alt' => 'f507',
+					'dashicons-tickets' => 'f486', 'dashicons-nametag' => 'f484', 'dashicons-clipboard' => 'f481',
+					'dashicons-heart' => 'f487', 'dashicons-megaphone' => 'f488', 'dashicons-schedule' => 'f489',
+					'dashicons-wordpress' => 'f120', 'dashicons-wordpress-alt' => 'f324', 'dashicons-pressthis' => 'f157',
+					'dashicons-update' => 'f463', 'dashicons-screenoptions' => 'f180', 'dashicons-info' => 'f348',
+					'dashicons-cart' => 'f174', 'dashicons-feedback' => 'f175', 'dashicons-cloud' => 'f176',
+					'dashicons-translation' => 'f326', 'dashicons-tag' => 'f323', 'dashicons-category' => 'f318',
+					'dashicons-archive' => 'f480', 'dashicons-tagcloud' => 'f479', 'dashicons-text' => 'f478',
+					'dashicons-yes' => 'f147', 'dashicons-no' => 'f158', 'dashicons-no-alt' => 'f335',
+					'dashicons-plus' => 'f132', 'dashicons-plus-alt' => 'f502', 'dashicons-minus' => 'f460',
+					'dashicons-dismiss' => 'f153', 'dashicons-marker' => 'f159', 'dashicons-star-filled' => 'f155',
+					'dashicons-star-half' => 'f459', 'dashicons-star-empty' => 'f154', 'dashicons-flag' => 'f227',
+					'dashicons-warning' => 'f534', 'dashicons-location' => 'f230', 'dashicons-location-alt' => 'f231',
+					'dashicons-vault' => 'f178', 'dashicons-shield' => 'f332', 'dashicons-shield-alt' => 'f334',
+					'dashicons-sos' => 'f468', 'dashicons-search' => 'f179', 'dashicons-slides' => 'f181',
+					'dashicons-analytics' => 'f183', 'dashicons-chart-pie' => 'f184', 'dashicons-chart-bar' => 'f185',
+					'dashicons-chart-line' => 'f238', 'dashicons-chart-area' => 'f239', 'dashicons-groups' => 'f307',
+					'dashicons-businessman' => 'f338', 'dashicons-id' => 'f336', 'dashicons-id-alt' => 'f337',
+					'dashicons-products' => 'f312', 'dashicons-awards' => 'f313', 'dashicons-forms' => 'f314',
+					'dashicons-testimonial' => 'f473', 'dashicons-portfolio' => 'f322', 'dashicons-book' => 'f330',
+					'dashicons-book-alt' => 'f331', 'dashicons-download' => 'f316', 'dashicons-upload' => 'f317',
+					'dashicons-backup' => 'f321', 'dashicons-clock' => 'f469', 'dashicons-lightbulb' => 'f339',
+					'dashicons-microphone' => 'f482', 'dashicons-desktop' => 'f472', 'dashicons-laptop' => 'f547',
+					'dashicons-tablet' => 'f471', 'dashicons-smartphone' => 'f470', 'dashicons-phone' => 'f525',
+					'dashicons-index-card' => 'f510', 'dashicons-carrot' => 'f511', 'dashicons-building' => 'f512',
+					'dashicons-store' => 'f513', 'dashicons-album' => 'f514', 'dashicons-palmtree' => 'f527',
+					'dashicons-tickets-alt' => 'f524', 'dashicons-money' => 'f526', 'dashicons-smiley' => 'f328',
+					'dashicons-thumbs-up' => 'f529', 'dashicons-thumbs-down' => 'f542', 'dashicons-layout' => 'f538',
+					'dashicons-paperclip' => 'f546', 'dashicons-rest-api' => 'f124', 'dashicons-code-standards' => 'f13a',
+				];
+				return isset( $map[ $class ] ) ? $map[ $class ] : 'f333';
 			}
 
             public static function wbtm_left_filter_disppaly( $bus_types, $bus_titles, $start_routes, $filter_by_box, $left_filter_show ): void {

--- a/mp_global/assets/admin/wbtm_admin_settings.js
+++ b/mp_global/assets/admin/wbtm_admin_settings.js
@@ -252,6 +252,9 @@ function wbtm_load_sortable_datepicker(parent, item) {
 
     // Popup open
     $(document).on("click", ".wbtm_icon_add", function () {
+        // Remember which icon-area opened the popup so the selection
+        // only updates that specific field (not every field on the page).
+        window._wbtm_active_icon_area = $(this).closest(".wbtm_add_icon_image_area");
         $(".wbtm_add_icon_popup").addClass("active");
     });
     $(document).on("click", ".wbtm_add_icon_popup .popupClose", function () {
@@ -264,7 +267,9 @@ function wbtm_load_sortable_datepicker(parent, item) {
         let iconClass = $(this).data("icon-class");
         if (!iconClass) return;
 
-        let parent = $(".wbtm_add_icon_image_area"); // সহজভাবে parent ধরা
+        let parent = (window._wbtm_active_icon_area && window._wbtm_active_icon_area.length)
+            ? window._wbtm_active_icon_area
+            : $(this).closest(".wbtm_add_icon_image_area");
 
         parent.find('input[type="hidden"]').val(iconClass);
         parent.find(".wbtm_add_icon_image_button_area, .wbtm_image_item").hide();

--- a/mp_global/class/WBTM_Setting_API.php
+++ b/mp_global/class/WBTM_Setting_API.php
@@ -10,6 +10,8 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 			protected $settings_sections = array();
 			protected $settings_fields = array();
 			public function __construct() { }
+			public function get_sections() { return $this->settings_sections; }
+			public function get_fields()   { return $this->settings_fields; }
 			function set_sections( $sections ) {
 				$this->settings_sections = $sections;
 				return $this;


### PR DESCRIPTION


## New Design System (bm-gs__*)
- Sidebar navigation with icon tabs, active indigo highlight, license badge
- Sticky topbar with breadcrumb + Save Changes button
- Section cards with icon headers, 2-column field rows, styled form controls
- Responsive: mobile sidebar drawer, stacked fields

## Files Changed

### admin/WBTM_Global_settings.php (+788 lines)
- Replaced old mpPanel/tabLists layout with new sidebar+cards rendering
- Added get_tab_configs() — unified tab metadata (title, icon, subtitle, section_id)
- Added render_new_settings_page() — full sidebar+main+topbar layout
- Added render_section_cards() with card grouping support
- Added get_card_groups() — logical field groupings per section
- Added render_compact_item() — compact 3-col grid for Style Settings
- Added render_checklist_item() — 4-col checkbox grid for PDF/CSV tabs
- All 17 field types supported (text, number, select, multicheck, color, file, wysiwyg, icon, icon_image, datepicker, radio, checkbox, switch_button, pages, url, password, textarea)
- Icon/icon_image fields wrapped in .wbtm_style for old CSS compatibility
- AI Chatbot provider toggle: JS hides/shows provider-specific fields (API key, model) based on selected provider
- Icon/image remove handlers: instant hide/show with dNone class management
- Save button: native HTMLFormElement.prototype.submit.call() to bypass id=submit shadow bug
- Color pickers: single-pass init with re-wrap guard
- Dynamic menu icon CSS injection via admin_head hook
- Enqueue for new CSS/JS assets with WP dependencies (color-picker, editor, datepicker)

### inc/WBTM_Functions.php (+276 lines)
- output_dynamic_menu_icon_css() — injects per-page CSS to override CPT menu icon
  - FontAwesome → :before pseudo with unicode + 'Font Awesome 6 Free' font
  - Dashicons → :before with dashicons unicode
  - Image/URL → JS <img> src update
- fa_unicode() — 300+ common FA icon unicode lookup table
- dashicon_unicode() — 200+ dashicons unicode lookup table

### mp_global/class/WBTM_Setting_API.php (+2 lines)
- Added public getters: get_sections(), get_fields() for protected properties

### mp_global/assets/admin/wbtm_admin_settings.js (+7 lines)
- Fixed icon picker: tracks clicked area via _wbtm_active_icon_area to prevent updating ALL icon fields when selecting from popup

### assets/admin/css/wbtm-global-settings.css (NEW, 600+ lines)
- Complete bm-gs__ design system: sidebar, topbar, cards, field rows, form controls
- Compact grid (3-col), checklist grid (4-col), responsive breakpoints
- License table, badges, color picker, wysiwyg styling
- AI provider row hide/show support

### assets/admin/js/wbtm-global-settings.js (NEW, 75 lines)
- Tab switching with metadata update in topbar
- Mobile sidebar drawer with overlay
- Native form submission via entry save button