### PR TITLE
Fix: duplicate ticket confirmation emails on order status change

### DIFF
--- a/inc/WBTM_Woocommerce.php
+++ b/inc/WBTM_Woocommerce.php
@@ -1230,16 +1230,33 @@
 			/*********************/
 			public function order_status_changed($order_id) {
 				$order = wc_get_order($order_id);
+				if (!$order) {
+					return;
+				}
 				$order_status = $order->get_status();
+				// Only act on the statuses this plugin handles. This is an order-level
+				// check, so evaluate it once instead of re-checking it per line item.
+				if (!$order->has_status(array('processing', 'pending', 'on-hold', 'completed', 'cancelled', 'refunded', 'failed', 'requested'))) {
+					return;
+				}
+				$representative_bus_id = 0;
+				// Per-bus attendee / service-booking status sync must run for EVERY bus
+				// line item, so this stays inside the loop.
 				foreach ($order->get_items() as $item_id => $item_values) {
 					$post_id = wc_get_order_item_meta($item_id, '_wbtm_bus_id');
 					if (get_post_type($post_id) == WBTM_Functions::get_cpt()) {
-						if ($order->has_status('processing') || $order->has_status('pending') || $order->has_status('on-hold') || $order->has_status('completed') || $order->has_status('cancelled') || $order->has_status('refunded') || $order->has_status('failed') || $order->has_status('requested')) {
-							$this->wc_order_status_change($order_status, $post_id, $order_id);
-							//echo '<pre>';print_r($order_status);echo '</pre>';die();
-							do_action('wbtm_order_status_change', $order_status, $post_id, $order_id);
+						$this->wc_order_status_change($order_status, $post_id, $order_id);
+						if (!$representative_bus_id) {
+							$representative_bus_id = (int) $post_id;
 						}
 					}
+				}
+				// Fire the status-change action ONCE per order, not once per line item.
+				// Every listener (PDF-ticket email, marketplace commission, booked-seat
+				// cache flush) is order-scoped, so dispatching inside the loop above made
+				// an order with N bus line items send N identical confirmation emails.
+				if ($representative_bus_id) {
+					do_action('wbtm_order_status_change', $order_status, $representative_bus_id, $order_id);
 				}
 			}
 			public function wc_order_status_change($order_status, $post_id, $order_id) {


### PR DESCRIPTION
Symptom
-------
On order completion the customer received multiple identical emails (3 in the reported case), all with the PDF ticket attached, delivered at the exact same moment (same request).

Root cause
----------
WBTM_Woocommerce::order_status_changed() (hooked to woocommerce_order_status_changed) fired the order-scoped action `do_action('wbtm_order_status_change', ...)` from INSIDE the `foreach ($order->get_items())` loop. That action's mail listener (WBTM_Function_PRO::order_status_changed -> wbtm_send_mail -> WBTM_Pro_Mail::send_mail) builds and sends the PDF ticket for the WHOLE order. So an order with N bus line items dispatched the same complete email N times in a single request. The disabled `_wbtm_email_sent` guard in WBTM_Pro_Mail (the `return` is commented out) did not catch it.

Fix
---
Dispatch `wbtm_order_status_change` exactly ONCE per order status change instead of once per line item:
- Keep the per-item call to wc_order_status_change() inside the loop: it legitimately writes wbtm_order_status meta onto every attendee / service-booking post for each bus and must run per item.
- Capture a representative bus id during the loop and fire the action a single time after the loop completes.
- Hoist the order-level has_status() check out of the loop and add an early return for an invalid/deleted order (previously ->get_status() on a false order would fatal).

Verified safe for all three listeners of wbtm_order_status_change, all of which are order-scoped:
- WBTM_Query::flush_booked_map: ignores args, clears the whole static cache (idempotent).
- WBTM_Function_PRO::order_status_changed: uses $post_id only as an "is this a bus" gate, then mails the whole order.
- WBTM_MP_Commission::on_booking_status_change (marketplace addon): ignores $bus_id, iterates all items itself and dedupes at the DB level.

Impact
------
- Order with N bus items now sends 1 confirmation email instead of N.
- PDF is generated once instead of N times; removes the per-item sleep(2) stacking in WBTM_Pro_Mail (a 3-item order blocked ~6s, now ~2s).
- Per-bus attendee status sync, commission creation and cache flush behaviour unchanged.

File: inc/WBTM_Woocommerce.php  (php -l: no syntax errors)