### PR TITLE
Add wbtm_cart_item_is_seatless filter to prevent_duplicate_bookings

### DIFF
--- a/inc/WBTM_Woocommerce.php
+++ b/inc/WBTM_Woocommerce.php
@@ -119,18 +119,37 @@
 									}
 								}
 							} elseif (!empty($legacy_seats)) {
-								// Legacy seat validation
-								foreach ($legacy_seats as $seat_info) {
-									$seat_name = array_key_exists('seat_name', $seat_info) ? $seat_info['seat_name'] : '';
-									if (WBTM_Query::query_total_booked($post_id, $start_route, $end_route, $date, '', $seat_name) > 0) {
-										WC()->cart->remove_cart_item($key);
-										wc_add_notice(
-											sprintf(
-												esc_html__( 'Seat %s has already been booked by another user. Please choose another seat.', 'bus-ticket-booking-with-seat-reservation' ),
-												esc_html( $seat_name )
-											),
-											'error'
-										);
+								/**
+								 * Added by Shahnur — 2026-07-05.
+								 * Whether this cart item books quantity tickets WITHOUT seat
+								 * labels (e.g. an addon booking flow with no customer-facing
+								 * seat plan). Such items have nothing to collide on, and an
+								 * empty seat name would make query_total_booked() run
+								 * unfiltered - counting every booking on the route/date and
+								 * falsely removing the item as "seat already booked".
+								 *
+								 * Default is FALSE, so standard seat-plan and cabin bookings
+								 * keep the full per-seat duplicate restriction unchanged.
+								 *
+								 * @param bool  $is_seatless Default false.
+								 * @param array $cart_item   The WooCommerce cart item.
+								 * @param int   $post_id     Bus post ID.
+								 */
+								$is_seatless_item = apply_filters( 'wbtm_cart_item_is_seatless', false, $cart_item, $post_id );
+								if ( ! $is_seatless_item ) {
+									// Legacy seat validation
+									foreach ($legacy_seats as $seat_info) {
+										$seat_name = array_key_exists('seat_name', $seat_info) ? $seat_info['seat_name'] : '';
+										if (WBTM_Query::query_total_booked($post_id, $start_route, $end_route, $date, '', $seat_name) > 0) {
+											WC()->cart->remove_cart_item($key);
+											wc_add_notice(
+												sprintf(
+													esc_html__( 'Seat %s has already been booked by another user. Please choose another seat.', 'bus-ticket-booking-with-seat-reservation' ),
+													esc_html( $seat_name )
+												),
+												'error'
+											);
+										}
 									}
 								}
 							}


### PR DESCRIPTION
Fixes a false 'Seat X has already been booked by another user' removal for quantity-based (seatless) cart items on seat-plan buses.

Root cause
- In prevent_duplicate_bookings(), the legacy seat branch called WBTM_Query::query_total_booked() for every wbtm_seats row without guarding empty seat names. An empty seat name means the seat meta filter is dropped, so the query counted EVERY booking on the same bus/route/date. As soon as one booking existed for a date, any later seatless booking for that date was removed from the cart with the 'seat already booked' notice.

Fix (scoped, backward compatible)
- New documented filter: wbtm_cart_item_is_seatless (default false, args: $cart_item, $post_id).
- Default behaviour is byte-for-byte unchanged: standard seat-plan and cabin bookings keep the full per-seat duplicate restriction.
- Addons that book quantity tickets without seat labels (e.g. the Booking Flow & Driver Manifest addon books with no customer-facing seat plan) return true for their own cart items only, skipping the per-seat check that has nothing to match on. Capacity checks in validate_bus_availability() still apply to those items at checkout.

Testing
- Seat-plan bus + addon flow: second booking on an already-booked date now completes (previously removed from cart).
- Default seat-plan booking with a really taken seat: still blocked.
- Cabin bookings: unchanged code path.