### PR TITLE
Chunk WooCommerce installer and demo import for low-memory hosts

### DIFF
--- a/admin/WBTM_Dummy_Import.php
+++ b/admin/WBTM_Dummy_Import.php
@@ -7,79 +7,290 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 	} // Cannot access pages directly.
 	if ( ! class_exists( 'WBTM_Dummy_Import' ) ) {
 		class WBTM_Dummy_Import {
+
+			/**
+			 * Final "import completed" flag (kept for backward compatibility with
+			 * sites that already imported the demo data before this refactor).
+			 */
+			const DONE_OPTION = 'wbtm_bus_seat_plan_data_input_done';
+
+			/**
+			 * In-flight progress state for the chunked importer.
+			 * Shape: array( 'phase' => 'tax'|'posts', 'index' => int ).
+			 */
+			const STATE_OPTION = 'wbtm_dummy_import_state';
+
+			/**
+			 * How many bus posts to insert per AJAX request. One keeps each
+			 * request tiny so even hosts with a very low PHP memory_limit /
+			 * max_execution_time (e.g. default shared hosting) never time out.
+			 */
+			const BATCH_SIZE = 1;
+
 			public function __construct() {
-				add_action( 'admin_init', array( $this, 'dummy_import' ), 98 );
+				// The demo is now imported in small AJAX batches instead of one
+				// heavy synchronous admin_init pass, so low-memory hosts don't
+				// fatal on the first plugin page load.
+				add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
+				add_action( 'admin_footer', array( $this, 'render_progress_ui' ) );
+				add_action( 'wp_ajax_wbtm_dummy_import_batch', array( $this, 'ajax_import_batch' ) );
 			}
 
-			public function dummy_import() {
-				$dummy_post_inserted  = get_option( 'wbtm_bus_seat_plan_data_input_done', 'no' );
-				$count_existing_event = wp_count_posts( 'wbtm_bus' )->publish;
-				$plugin_active        = WBTM_Global_Function::check_plugin( 'bus-ticket-booking-with-seat-reservation', 'woocommerce-bus.php' );
-				if ( $count_existing_event == 0 && $plugin_active == 1 && $dummy_post_inserted != 'yes' ) {
-					$dummy_taxonomies = $this->dummy_taxonomy();
-					if ( array_key_exists( 'taxonomy', $dummy_taxonomies ) ) {
-						foreach ( $dummy_taxonomies['taxonomy'] as $taxonomy => $dummy_taxonomy ) {
-							if ( taxonomy_exists( $taxonomy ) ) {
-								$check_terms = get_terms( array( 'taxonomy' => $taxonomy, 'hide_empty' => false ) );
-								if ( is_string( $check_terms ) || sizeof( $check_terms ) == 0 ) {
-									foreach ( $dummy_taxonomy as $taxonomy_data ) {
-										unset( $term );
-										$term = wp_insert_term( $taxonomy_data['name'], $taxonomy );
-										if ( array_key_exists( 'tax_data', $taxonomy_data ) ) {
-											foreach ( $taxonomy_data['tax_data'] as $meta_key => $data ) {
-												update_term_meta( $term['term_id'], $meta_key, $data );
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					$dummy_cpt = $this->dummy_cpt();
-					if ( array_key_exists( 'custom_post', $dummy_cpt ) ) {
-						foreach ( $dummy_cpt['custom_post'] as $custom_post => $dummy_post ) {
-							unset( $args );
-							$args = array(
-								'post_type'      => $custom_post,
-								'posts_per_page' => - 1,
-							);
-							unset( $post );
-							$post = new WP_Query( $args );
-							if ( $post->post_count == 0 ) {
-								foreach ( $dummy_post as $dummy_data ) {
-									if ( isset( $dummy_data['name'] ) ) {
-										$args['post_title'] = $dummy_data['name'];
-									}
-									if ( isset( $dummy_data['content'] ) ) {
-										$args['post_content'] = $dummy_data['content'];
-									}
-									$args['post_status'] = 'publish';
-									$args['post_type']   = $custom_post;
-									$post_id             = wp_insert_post( $args );
-									if ( array_key_exists( 'taxonomy_terms', $dummy_data ) && count( $dummy_data['taxonomy_terms'] ) ) {
-										foreach ( $dummy_data['taxonomy_terms'] as $taxonomy_term ) {
-											wp_set_object_terms( $post_id, $taxonomy_term['terms'], $taxonomy_term['taxonomy_name'], true );
-										}
-									}
-									if ( array_key_exists( 'post_data', $dummy_data ) ) {
-										foreach ( $dummy_data['post_data'] as $meta_key => $data ) {
-											if ( $meta_key == 'feature_image' ) {
-												$url   = $data;
-												$desc  = "The Demo Dummy Image of the bus booking";
-												$image = media_sideload_image( $url, $post_id, $desc, 'id' );
-												set_post_thumbnail( $post_id, $image );
-											} else {
-												update_post_meta( $post_id, $meta_key, $data );
-											}
-										}
-									}
-								}
-							}
-						}
-					}
-					flush_rewrite_rules();
-					update_option( 'wbtm_bus_seat_plan_data_input_done', 'yes' );
+			/**
+			 * Whether the demo import should run/resume for this site.
+			 *
+			 * A *fresh* import only starts when there are no published buses yet,
+			 * but an already-started import always resumes (even though the first
+			 * inserted bus makes the count non-zero), otherwise batching would
+			 * abort itself after the first post.
+			 *
+			 * @return bool
+			 */
+			private function is_eligible() {
+				if ( 'yes' === get_option( self::DONE_OPTION, 'no' ) ) {
+					return false;
 				}
+				if ( ! post_type_exists( 'wbtm_bus' ) ) {
+					return false; // Plugin/CPT not ready.
+				}
+				// Resume an in-progress import regardless of current post count.
+				if ( is_array( get_option( self::STATE_OPTION, null ) ) ) {
+					return true;
+				}
+				// Fresh start only on an empty site.
+				return 0 === (int) wp_count_posts( 'wbtm_bus' )->publish;
+			}
+
+			/**
+			 * Only run the auto-importer on this plugin's own admin screens
+			 * (the post-activation redirect lands on edit.php?post_type=wbtm_bus),
+			 * so we never surprise the user with a background import + reload
+			 * while they are working on an unrelated admin page.
+			 *
+			 * @return bool
+			 */
+			private function is_plugin_screen() {
+				if ( ! function_exists( 'get_current_screen' ) ) {
+					return false;
+				}
+				$screen = get_current_screen();
+				if ( ! $screen ) {
+					return false;
+				}
+				if ( isset( $screen->post_type ) && 0 === strpos( (string) $screen->post_type, 'wbtm_' ) ) {
+					return true;
+				}
+				// Plugin settings / welcome / dashboard pages live under the bus menu.
+				return isset( $screen->id ) && false !== strpos( (string) $screen->id, 'wbtm' );
+			}
+
+			/**
+			 * Enqueue the tiny importer script only when an import is pending.
+			 */
+			public function enqueue_assets() {
+				if ( ! current_user_can( 'edit_wbtm_bus' ) || ! $this->is_plugin_screen() || ! $this->is_eligible() ) {
+					return;
+				}
+
+				wp_enqueue_style(
+					'wbtm-dummy-import',
+					WBTM_PLUGIN_URL . '/assets/admin/wbtm_dummy_import.css',
+					array(),
+					WBTM_VERSION
+				);
+				wp_enqueue_script(
+					'wbtm-dummy-import',
+					WBTM_PLUGIN_URL . '/assets/admin/wbtm_dummy_import.js',
+					array( 'jquery' ),
+					WBTM_VERSION,
+					true
+				);
+				wp_localize_script( 'wbtm-dummy-import', 'wbtm_dummy_import', array(
+					'ajax_url' => admin_url( 'admin-ajax.php' ),
+					'nonce'    => wp_create_nonce( 'wbtm_dummy_import' ),
+					'i18n'     => array(
+						'importing' => __( 'Importing demo data...', 'bus-ticket-booking-with-seat-reservation' ),
+						'done'      => __( 'Demo data imported successfully.', 'bus-ticket-booking-with-seat-reservation' ),
+						'error'     => __( 'Demo import could not finish. It will retry on the next page load.', 'bus-ticket-booking-with-seat-reservation' ),
+					),
+				) );
+			}
+
+			/**
+			 * Print the small progress toast (hidden until JS starts a batch).
+			 */
+			public function render_progress_ui() {
+				if ( ! current_user_can( 'edit_wbtm_bus' ) || ! $this->is_plugin_screen() || ! $this->is_eligible() ) {
+					return;
+				}
+				?>
+				<div id="wbtm-dummy-import-toast" class="wbtm-di-toast" style="display:none;">
+					<div class="wbtm-di-toast-inner">
+						<span class="wbtm-di-spinner" aria-hidden="true"></span>
+						<div class="wbtm-di-body">
+							<p id="wbtm-di-text" class="wbtm-di-text"><?php esc_html_e( 'Importing demo data...', 'bus-ticket-booking-with-seat-reservation' ); ?></p>
+							<div class="wbtm-di-bar"><div id="wbtm-di-fill" class="wbtm-di-fill"></div></div>
+						</div>
+					</div>
+				</div>
+				<?php
+			}
+
+			/**
+			 * AJAX: process a single demo-import batch and report progress.
+			 * The browser calls this repeatedly until 'done' is true.
+			 */
+			public function ajax_import_batch() {
+				check_ajax_referer( 'wbtm_dummy_import', 'nonce' );
+
+				if ( ! current_user_can( 'edit_wbtm_bus' ) ) {
+					wp_send_json_error( array( 'message' => __( 'Permission denied.', 'bus-ticket-booking-with-seat-reservation' ) ) );
+				}
+
+				// Nothing to do (already imported, or a fresh start on a non-empty site).
+				if ( ! $this->is_eligible() ) {
+					update_option( self::DONE_OPTION, 'yes' );
+					delete_option( self::STATE_OPTION );
+					wp_send_json_success( array( 'done' => true, 'percent' => 100 ) );
+				}
+
+				// Give this one small batch a little headroom without demanding a lot.
+				if ( function_exists( 'set_time_limit' ) ) {
+					@set_time_limit( 60 ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
+				}
+				if ( function_exists( 'wp_raise_memory_limit' ) ) {
+					wp_raise_memory_limit( 'admin' );
+				}
+
+				$state = get_option( self::STATE_OPTION, array( 'phase' => 'tax', 'index' => 0 ) );
+				$state = wp_parse_args( (array) $state, array( 'phase' => 'tax', 'index' => 0 ) );
+
+				// --- Phase 1: taxonomies (categories, stops, pickup points) ---
+				if ( 'tax' === $state['phase'] ) {
+					$this->insert_taxonomies();
+					update_option( self::STATE_OPTION, array( 'phase' => 'posts', 'index' => 0 ) );
+					wp_send_json_success( array(
+						'done'    => false,
+						'percent' => 10,
+						'message' => __( 'Bus categories & stops created...', 'bus-ticket-booking-with-seat-reservation' ),
+					) );
+				}
+
+				// --- Phase 2: bus posts, BATCH_SIZE at a time ---
+				$buses = $this->dummy_cpt()['custom_post']['wbtm_bus'];
+				$total = count( $buses );
+				$index = (int) $state['index'];
+
+				$processed = 0;
+				while ( $index < $total && $processed < self::BATCH_SIZE ) {
+					if ( isset( $buses[ $index ] ) ) {
+						$this->insert_single_bus( 'wbtm_bus', $buses[ $index ] );
+					}
+					$index++;
+					$processed++;
+				}
+
+				if ( $index < $total ) {
+					update_option( self::STATE_OPTION, array( 'phase' => 'posts', 'index' => $index ) );
+					$percent = 10 + (int) round( ( $index / $total ) * 85 );
+					wp_send_json_success( array(
+						'done'    => false,
+						'percent' => $percent,
+						/* translators: 1: imported count, 2: total count */
+						'message' => sprintf( __( 'Importing buses %1$d / %2$d...', 'bus-ticket-booking-with-seat-reservation' ), $index, $total ),
+					) );
+				}
+
+				// --- All done: flush rewrite rules once and mark complete ---
+				flush_rewrite_rules();
+				update_option( self::DONE_OPTION, 'yes' );
+				delete_option( self::STATE_OPTION );
+
+				wp_send_json_success( array(
+					'done'    => true,
+					'percent' => 100,
+					'message' => __( 'Demo data imported successfully.', 'bus-ticket-booking-with-seat-reservation' ),
+				) );
+			}
+
+			/**
+			 * Insert all demo taxonomy terms. Idempotent: only fills a taxonomy
+			 * that currently has no terms, exactly like the original importer.
+			 */
+			private function insert_taxonomies() {
+				$dummy_taxonomies = $this->dummy_taxonomy();
+				if ( ! array_key_exists( 'taxonomy', $dummy_taxonomies ) ) {
+					return;
+				}
+				foreach ( $dummy_taxonomies['taxonomy'] as $taxonomy => $dummy_taxonomy ) {
+					if ( ! taxonomy_exists( $taxonomy ) ) {
+						continue;
+					}
+					$check_terms = get_terms( array( 'taxonomy' => $taxonomy, 'hide_empty' => false ) );
+					if ( ! is_string( $check_terms ) && sizeof( $check_terms ) != 0 ) {
+						continue; // Already populated.
+					}
+					foreach ( $dummy_taxonomy as $taxonomy_data ) {
+						$term = wp_insert_term( $taxonomy_data['name'], $taxonomy );
+						if ( is_wp_error( $term ) ) {
+							continue;
+						}
+						if ( array_key_exists( 'tax_data', $taxonomy_data ) ) {
+							foreach ( $taxonomy_data['tax_data'] as $meta_key => $data ) {
+								update_term_meta( $term['term_id'], $meta_key, $data );
+							}
+						}
+					}
+				}
+			}
+
+			/**
+			 * Insert a single demo bus post with its taxonomy terms and meta.
+			 * Mirrors the per-post logic of the original bulk importer.
+			 *
+			 * @param string $custom_post Post type slug.
+			 * @param array  $dummy_data  One bus definition from dummy_cpt().
+			 * @return int|false New post ID, or false on failure.
+			 */
+			private function insert_single_bus( $custom_post, $dummy_data ) {
+				$args = array(
+					'post_status' => 'publish',
+					'post_type'   => $custom_post,
+				);
+				if ( isset( $dummy_data['name'] ) ) {
+					$args['post_title'] = $dummy_data['name'];
+				}
+				if ( isset( $dummy_data['content'] ) ) {
+					$args['post_content'] = $dummy_data['content'];
+				}
+				$post_id = wp_insert_post( $args );
+				if ( ! $post_id || is_wp_error( $post_id ) ) {
+					return false;
+				}
+				if ( array_key_exists( 'taxonomy_terms', $dummy_data ) && count( $dummy_data['taxonomy_terms'] ) ) {
+					foreach ( $dummy_data['taxonomy_terms'] as $taxonomy_term ) {
+						wp_set_object_terms( $post_id, $taxonomy_term['terms'], $taxonomy_term['taxonomy_name'], true );
+					}
+				}
+				if ( array_key_exists( 'post_data', $dummy_data ) ) {
+					foreach ( $dummy_data['post_data'] as $meta_key => $data ) {
+						if ( $meta_key == 'feature_image' ) {
+							// media_sideload_image() lives in admin media includes,
+							// which are not loaded during an AJAX request.
+							require_once ABSPATH . 'wp-admin/includes/media.php';
+							require_once ABSPATH . 'wp-admin/includes/file.php';
+							require_once ABSPATH . 'wp-admin/includes/image.php';
+							$desc  = 'The Demo Dummy Image of the bus booking';
+							$image = media_sideload_image( $data, $post_id, $desc, 'id' );
+							if ( ! is_wp_error( $image ) ) {
+								set_post_thumbnail( $post_id, $image );
+							}
+						} else {
+							update_post_meta( $post_id, $meta_key, $data );
+						}
+					}
+				}
+				return $post_id;
 			}
 
 			public function dummy_taxonomy(): array {

--- a/assets/admin/wbtm_dummy_import.css
+++ b/assets/admin/wbtm_dummy_import.css
@@ -1,0 +1,84 @@
+/**
+ * WBTM Demo Data Importer — progress toast.
+ */
+.wbtm-di-toast {
+	position: fixed;
+	right: 24px;
+	bottom: 24px;
+	z-index: 99999;
+	width: 320px;
+	max-width: calc(100vw - 48px);
+	background: #fff;
+	border: 1px solid #e2e4e7;
+	border-radius: 10px;
+	box-shadow: 0 8px 28px rgba(0, 0, 0, 0.16);
+	overflow: hidden;
+}
+
+.wbtm-di-toast-inner {
+	display: flex;
+	align-items: center;
+	gap: 12px;
+	padding: 16px 18px;
+}
+
+.wbtm-di-body {
+	flex: 1 1 auto;
+	min-width: 0;
+}
+
+.wbtm-di-text {
+	margin: 0 0 8px;
+	font-size: 13px;
+	line-height: 1.4;
+	color: #1e1e1e;
+}
+
+.wbtm-di-bar {
+	height: 6px;
+	background: #eef0f2;
+	border-radius: 6px;
+	overflow: hidden;
+}
+
+.wbtm-di-fill {
+	height: 100%;
+	width: 0;
+	background: #f12971; /* Booking brand accent */
+	border-radius: 6px;
+	transition: width 0.35s ease;
+}
+
+.wbtm-di-spinner {
+	flex: 0 0 auto;
+	width: 22px;
+	height: 22px;
+	border: 3px solid #eef0f2;
+	border-top-color: #f12971;
+	border-radius: 50%;
+	animation: wbtm-di-spin 0.8s linear infinite;
+}
+
+.wbtm-di-toast.wbtm-di-success .wbtm-di-fill {
+	background: #2eb85c;
+}
+
+.wbtm-di-toast.wbtm-di-success .wbtm-di-spinner {
+	border-top-color: #2eb85c;
+	animation: none;
+	border-color: #2eb85c;
+}
+
+.wbtm-di-toast.wbtm-di-error .wbtm-di-fill {
+	background: #e53935;
+}
+
+.wbtm-di-toast.wbtm-di-error .wbtm-di-spinner {
+	animation: none;
+	border-color: #e53935;
+	border-top-color: #e53935;
+}
+
+@keyframes wbtm-di-spin {
+	to { transform: rotate(360deg); }
+}

--- a/assets/admin/wbtm_dummy_import.js
+++ b/assets/admin/wbtm_dummy_import.js
@@ -1,0 +1,95 @@
+/**
+ * WBTM Demo Data Importer (chunked).
+ * Drives the demo import one small batch at a time so low-memory hosts
+ * (e.g. default 2M/short-timeout shared hosting) never fatal on a single
+ * heavy request. Auto-starts on any plugin admin page while an import is
+ * pending; each AJAX call inserts taxonomies or a single bus and returns
+ * progress until { done: true }.
+ */
+(function ($) {
+	'use strict';
+
+	var config = window.wbtm_dummy_import || {};
+
+	var $toast = null;
+	var $text  = null;
+	var $fill  = null;
+
+	var MAX_STEPS = 100; // Hard safety ceiling so a bug can never loop forever.
+	var steps     = 0;
+
+	$(document).ready(function () {
+		$toast = $('#wbtm-dummy-import-toast');
+		if (!$toast.length || !config.ajax_url) {
+			return;
+		}
+		$text = $('#wbtm-di-text');
+		$fill = $('#wbtm-di-fill');
+
+		$toast.show();
+		setProgress(3, config.i18n.importing);
+		runBatch();
+	});
+
+	function runBatch() {
+		if (steps++ > MAX_STEPS) {
+			return finish(false);
+		}
+
+		$.ajax({
+			url:      config.ajax_url,
+			type:     'POST',
+			dataType: 'json',
+			timeout:  120000,
+			data: {
+				action: 'wbtm_dummy_import_batch',
+				nonce:  config.nonce
+			},
+			success: function (response) {
+				if (!response || !response.success || !response.data) {
+					return finish(false);
+				}
+				var data = response.data;
+				setProgress(data.percent, data.message || config.i18n.importing);
+
+				if (data.done) {
+					return finish(true);
+				}
+				// Chain the next batch immediately (each is a fresh PHP request).
+				runBatch();
+			},
+			error: function () {
+				// Leave the state option intact — it resumes on next page load.
+				finish(false);
+			}
+		});
+	}
+
+	function setProgress(percent, text) {
+		percent = Math.max(0, Math.min(100, parseInt(percent, 10) || 0));
+		if ($fill) {
+			$fill.css('width', percent + '%');
+		}
+		if ($text && text) {
+			$text.text(text);
+		}
+	}
+
+	function finish(ok) {
+		if (ok) {
+			setProgress(100, config.i18n.done);
+			$toast.addClass('wbtm-di-success');
+			// Reload so the freshly imported buses appear in the list.
+			setTimeout(function () {
+				window.location.reload();
+			}, 1200);
+		} else {
+			setProgress(100, config.i18n.error);
+			$toast.addClass('wbtm-di-error');
+			setTimeout(function () {
+				$toast.fadeOut(400);
+			}, 4000);
+		}
+	}
+
+})(jQuery);

--- a/assets/admin/wbtm_woo_installer.js
+++ b/assets/admin/wbtm_woo_installer.js
@@ -30,8 +30,10 @@
 	var progressToken    = '';
 	var progressTimer    = null;
 	var lastPercent      = 0;
-	var phase             = null;  // 'install' | 'activate'
-	var requestFinished   = false; // true once a terminal outcome (success/error) has been acted on for the current phase
+	// Chunked installer: the flow is a chain of discrete server steps
+	// (download → install → activate), each its own HTTP request.
+	var launchedSteps    = {};    // guards against launching the same step twice
+	var finished         = false; // true once a terminal outcome (success/error) has fired
 	var processStartTime  = 0;
 
 	/**
@@ -61,15 +63,15 @@
 	});
 
 	/**
-	 * Start the install → activate → redirect process.
+	 * Start the chunked download → install → activate → redirect process.
 	 */
 	function startProcess() {
 		isWorking        = true;
 		progressToken    = 'wbtm' + Date.now().toString(36) + Math.random().toString(36).slice(2);
 		lastPercent      = 0;
-		requestFinished  = false;
+		launchedSteps    = {};
+		finished         = false;
 		processStartTime = Date.now();
-		phase            = (config.woo_installed === 'yes') ? 'activate' : 'install';
 		$btn.prop('disabled', true);
 
 		// Show progress, hide actions
@@ -78,13 +80,99 @@
 
 		startProgressPolling();
 
-		if (phase === 'activate') {
-			setProgress(30, config.i18n.activating);
-			activateWooCommerce();
+		// If WooCommerce files already exist, skip straight to activation;
+		// otherwise begin with the download step.
+		if (config.woo_installed === 'yes') {
+			runStep('activate');
 		} else {
-			setProgress(5, config.i18n.installing);
-			installWooCommerce();
+			runStep('download');
 		}
+	}
+
+	/**
+	 * Human-readable starting text + baseline percent for each step, shown the
+	 * instant a step's request is fired so the UI never looks stalled.
+	 */
+	function stepIntro(step) {
+		switch (step) {
+			case 'download': return { percent: 5,  text: config.i18n.installing };
+			case 'install':  return { percent: 60, text: config.i18n.installing };
+			case 'activate': return { percent: 92, text: config.i18n.activating };
+			default:         return { percent: lastPercent, text: '' };
+		}
+	}
+
+	/**
+	 * Run a single server step. Idempotent per step: launchedSteps guards
+	 * against the same step being started twice (e.g. if both the AJAX response
+	 * and a progress-poll recovery try to advance to it).
+	 */
+	function runStep(step) {
+		if (finished || launchedSteps[step]) {
+			return;
+		}
+		launchedSteps[step] = true;
+
+		var intro = stepIntro(step);
+		if (intro.percent >= lastPercent) {
+			lastPercent = intro.percent;
+		}
+		setProgress(lastPercent, intro.text);
+
+		$.ajax({
+			url:      config.ajax_url,
+			type:     'POST',
+			dataType: 'json',
+			timeout:  AJAX_TIMEOUT,
+			data: {
+				action:         'wbtm_woo_install_step',
+				nonce:          config.install_nonce,
+				progress_token: progressToken,
+				step:           step
+			},
+			success: function (response) {
+				if (finished) {
+					return;
+				}
+				if (response && response.success) {
+					advance(response.data && response.data.next ? response.data.next : '');
+				} else {
+					showError(response && response.data && response.data.message
+						? response.data.message
+						: stepErrorText(step));
+				}
+			},
+			error: function (jqXHR, textStatus) {
+				if (textStatus === 'timeout') {
+					// The server keeps running past a dropped connection — keep
+					// polling; the poller recovers the outcome for this step.
+					setProgress(lastPercent, config.i18n.timeout_wait);
+					return;
+				}
+				if (finished) {
+					return;
+				}
+				showError(stepErrorText(step));
+			}
+		});
+	}
+
+	/**
+	 * Advance the chain to the next step, or finish when there is none.
+	 */
+	function advance(next) {
+		if (!next) {
+			if (!finished) {
+				finished = true;
+				showSuccess();
+			}
+			return;
+		}
+		runStep(next);
+	}
+
+	function stepErrorText(step) {
+		return (step === 'activate') ? config.i18n.activate_error : config.i18n.install_error;
 	}
 
 	/**
@@ -124,25 +212,21 @@
 				setProgress(percent, data.text);
 			}
 
-			if (requestFinished) {
+			if (finished) {
 				return;
 			}
 
 			if (data.status === 'error') {
-				requestFinished = true;
 				showError(data.text || config.i18n.install_error);
 				return;
 			}
 
+			// A step finished server-side. Recover the chain even if that step's
+			// own AJAX response was lost to a client-side timeout: advance to the
+			// next step, or finish when there is none. advance()/runStep() are
+			// idempotent, so this can't double-run a step already in flight.
 			if (data.status === 'success') {
-				requestFinished = true;
-				if (phase === 'install') {
-					phase = 'activate';
-					setProgress(96, config.i18n.activating);
-					activateWooCommerce();
-				} else {
-					showSuccess();
-				}
+				advance(data.next ? data.next : '');
 				return;
 			}
 
@@ -150,96 +234,9 @@
 			// absolute ceiling, in case the server process died without
 			// ever recording a final status.
 			if (Date.now() - processStartTime > MAX_TOTAL_WAIT) {
-				requestFinished = true;
 				showError(config.i18n.timeout_error);
 			}
 		}, 'json');
-	}
-
-	/**
-	 * AJAX: Install WooCommerce.
-	 */
-	function installWooCommerce() {
-		$.ajax({
-			url:      config.ajax_url,
-			type:     'POST',
-			dataType: 'json',
-			timeout:  AJAX_TIMEOUT,
-			data: {
-				action:         'wbtm_install_woocommerce',
-				nonce:          config.install_nonce,
-				progress_token: progressToken
-			},
-			success: function (response) {
-				if (requestFinished) {
-					return;
-				}
-				requestFinished = true;
-				if (response.success) {
-					phase = 'activate';
-					setProgress(96, config.i18n.activating);
-					activateWooCommerce();
-				} else {
-					showError(response.data && response.data.message
-						? response.data.message
-						: config.i18n.install_error);
-				}
-			},
-			error: function (jqXHR, textStatus) {
-				if (textStatus === 'timeout') {
-					// The server is very likely still working (it keeps running
-					// past a dropped connection) — keep polling instead of failing.
-					setProgress(lastPercent, config.i18n.timeout_wait);
-					return;
-				}
-				if (requestFinished) {
-					return;
-				}
-				requestFinished = true;
-				showError(config.i18n.install_error);
-			}
-		});
-	}
-
-	/**
-	 * AJAX: Activate WooCommerce.
-	 */
-	function activateWooCommerce() {
-		$.ajax({
-			url:      config.ajax_url,
-			type:     'POST',
-			dataType: 'json',
-			timeout:  AJAX_TIMEOUT,
-			data: {
-				action:         'wbtm_activate_woocommerce',
-				nonce:          config.activate_nonce,
-				progress_token: progressToken
-			},
-			success: function (response) {
-				if (requestFinished) {
-					return;
-				}
-				requestFinished = true;
-				if (response.success) {
-					showSuccess();
-				} else {
-					showError(response.data && response.data.message
-						? response.data.message
-						: config.i18n.activate_error);
-				}
-			},
-			error: function (jqXHR, textStatus) {
-				if (textStatus === 'timeout') {
-					setProgress(lastPercent, config.i18n.timeout_wait);
-					return;
-				}
-				if (requestFinished) {
-					return;
-				}
-				requestFinished = true;
-				showError(config.i18n.activate_error);
-			}
-		});
 	}
 
 	/**
@@ -284,6 +281,7 @@
 	 * Show error state with retry option.
 	 */
 	function showError(message) {
+		finished  = true;
 		isWorking = false;
 		stopProgressPolling();
 		$popup.addClass('wbtm-state-error');

--- a/inc/WBTM_Woo_Installer.php
+++ b/inc/WBTM_Woo_Installer.php
@@ -29,10 +29,12 @@ if ( ! class_exists( 'WBTM_Woo_Installer' ) ) {
 			add_action( 'admin_enqueue_scripts', array( $this, 'enqueue_assets' ) );
 			// Render the popup markup in admin footer
 			add_action( 'admin_footer', array( $this, 'render_popup' ) );
-			// AJAX handlers for install, activate & dismiss
-			add_action( 'wp_ajax_wbtm_install_woocommerce', array( $this, 'ajax_install_woocommerce' ) );
-			add_action( 'wp_ajax_wbtm_activate_woocommerce', array( $this, 'ajax_activate_woocommerce' ) );
-			// Polled by the popup while install/activate is running to read the live percentage.
+			// Chunked installer: one AJAX request per phase (download → install →
+			// activate) so each runs in a fresh PHP process and a low
+			// memory_limit / short max_execution_time host never times out
+			// trying to do everything in a single long request.
+			add_action( 'wp_ajax_wbtm_woo_install_step', array( $this, 'ajax_install_step' ) );
+			// Polled by the popup while a step is running to read the live percentage.
 			add_action( 'wp_ajax_wbtm_install_progress', array( $this, 'ajax_get_install_progress' ) );
 		}
 
@@ -108,8 +110,12 @@ if ( ! class_exists( 'WBTM_Woo_Installer' ) ) {
 		 *                        popup uses this to recover even if the original
 		 *                        AJAX response never reaches the browser (e.g. the
 		 *                        browser gave up waiting while the server kept going).
+		 * @param string $next    When a step finishes server-side, the next step to
+		 *                        run ('install'|'activate'|''). Lets the poller
+		 *                        advance the chunked flow even if the step's own
+		 *                        AJAX response was lost to a client-side timeout.
 		 */
-		private function set_progress( $token, $percent, $text, $status = 'progress' ) {
+		private function set_progress( $token, $percent, $text, $status = 'progress', $next = '' ) {
 			if ( ! $token ) {
 				return;
 			}
@@ -119,6 +125,7 @@ if ( ! class_exists( 'WBTM_Woo_Installer' ) ) {
 					'percent' => max( 0, min( 100, (int) round( $percent ) ) ),
 					'text'    => (string) $text,
 					'status'  => $status,
+					'next'    => (string) $next,
 				),
 				120
 			);
@@ -316,8 +323,8 @@ if ( ! class_exists( 'WBTM_Woo_Installer' ) ) {
 
 			wp_localize_script( 'wbtm-woo-installer', 'wbtm_woo_installer', array(
 				'ajax_url'         => admin_url( 'admin-ajax.php' ),
+				// Single nonce now guards every step of the chunked installer.
 				'install_nonce'    => wp_create_nonce( 'wbtm_install_woo' ),
-				'activate_nonce'   => wp_create_nonce( 'wbtm_activate_woo' ),
 				'redirect_url'     => admin_url( 'edit.php?post_type=wbtm_bus' ),
 				'woo_installed'    => $this->is_woo_installed() ? 'yes' : 'no',
 				'i18n'             => array(
@@ -456,6 +463,7 @@ if ( ! class_exists( 'WBTM_Woo_Installer' ) ) {
 					'percent' => 0,
 					'text'    => '',
 					'status'  => 'progress',
+					'next'    => '',
 				);
 			}
 
@@ -463,21 +471,61 @@ if ( ! class_exists( 'WBTM_Woo_Installer' ) ) {
 		}
 
 		/**
-		 * AJAX: Install WooCommerce from WordPress.org repository.
+		 * Transient key that carries the downloaded package path between the
+		 * separate 'download' and 'install' AJAX requests.
+		 *
+		 * @param string $token Per-attempt progress token.
+		 * @return string
 		 */
-		public function ajax_install_woocommerce() {
+		private function package_transient_key( $token ) {
+			return 'wbtm_woo_pkg_' . sanitize_key( $token );
+		}
+
+		/**
+		 * AJAX: run ONE step of the chunked installer.
+		 *
+		 * The whole flow is split across three separate HTTP requests —
+		 * download → install → activate — so each runs with a fresh
+		 * max_execution_time / memory budget. This is the key difference that
+		 * lets constrained hosts (default 2M-ish PHP limits, short timeouts)
+		 * finish an install that a single monolithic request would abort.
+		 */
+		public function ajax_install_step() {
 			check_ajax_referer( 'wbtm_install_woo', 'nonce' );
 
 			$token = isset( $_POST['progress_token'] ) ? sanitize_key( wp_unslash( $_POST['progress_token'] ) ) : '';
+			$step  = isset( $_POST['step'] ) ? sanitize_key( wp_unslash( $_POST['step'] ) ) : '';
 
 			if ( ! current_user_can( 'install_plugins' ) ) {
 				$this->fail_install( $token, __( 'You do not have permission to install plugins.', 'bus-ticket-booking-with-seat-reservation' ) );
 			}
 
+			switch ( $step ) {
+				case 'download':
+					$this->step_download( $token );
+					break;
+				case 'install':
+					$this->step_install( $token );
+					break;
+				case 'activate':
+					$this->step_activate( $token );
+					break;
+				default:
+					$this->fail_install( $token, __( 'Unknown installation step.', 'bus-ticket-booking-with-seat-reservation' ) );
+			}
+		}
+
+		/**
+		 * Step 1 — download the WooCommerce package to a temp file.
+		 * Kept in its own request so the (potentially large) download can't eat
+		 * into the time budget the unpack/move step needs.
+		 *
+		 * @param string $token Per-attempt progress token.
+		 */
+		private function step_download( $token ) {
 			include_once ABSPATH . 'wp-admin/includes/plugin-install.php';
 			include_once ABSPATH . 'wp-admin/includes/file.php';
 			include_once ABSPATH . 'wp-admin/includes/misc.php';
-			include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
 
 			$this->prepare_environment_for_long_task();
 			$this->set_progress( $token, 2, __( 'Preparing installation...', 'bus-ticket-booking-with-seat-reservation' ) );
@@ -513,18 +561,62 @@ if ( ! class_exists( 'WBTM_Woo_Installer' ) ) {
 				$this->fail_install( $token, $api->get_error_message() );
 			}
 
-			// Download it ourselves first so we can report real byte-level percentage.
-			// Returns false (and we fall back to Plugin_Upgrader's own download) when
-			// cURL is unavailable or outbound requests are locked down on this host.
-			$local_package = $this->download_package_with_progress( $api->download_link, $token, 10, 70 );
+			// Download it ourselves so we can report real byte-level percentage.
+			// Returns false (and the install step falls back to letting
+			// Plugin_Upgrader download from the URL) when cURL is unavailable or
+			// outbound requests are locked down on this host.
+			$local_package = $this->download_package_with_progress( $api->download_link, $token, 8, 52 );
 
 			if ( ! $local_package ) {
-				// We didn't download it ourselves — Plugin_Upgrader will, internally,
-				// with no granular progress available, so just mark the phase.
-				$this->set_progress( $token, 10, __( 'Downloading WooCommerce...', 'bus-ticket-booking-with-seat-reservation' ) );
+				$this->set_progress( $token, 10, __( 'Preparing download...', 'bus-ticket-booking-with-seat-reservation' ) );
 			}
 
-			$this->set_progress( $token, 75, __( 'Unpacking & installing WooCommerce (this can take several minutes for many files)...', 'bus-ticket-booking-with-seat-reservation' ) );
+			// Hand the package location to the install step (next request).
+			set_transient(
+				$this->package_transient_key( $token ),
+				array(
+					'path' => $local_package ? $local_package : '',
+					'url'  => $api->download_link,
+				),
+				15 * MINUTE_IN_SECONDS
+			);
+
+			$this->set_progress( $token, 55, __( 'Download complete. Preparing to install...', 'bus-ticket-booking-with-seat-reservation' ), 'success', 'install' );
+
+			wp_send_json_success( array( 'next' => 'install' ) );
+		}
+
+		/**
+		 * Step 2 — unpack & move WooCommerce into wp-content/plugins.
+		 * Runs in its own fresh request so the file copy (thousands of files)
+		 * gets a full time budget rather than whatever was left after the
+		 * download.
+		 *
+		 * @param string $token Per-attempt progress token.
+		 */
+		private function step_install( $token ) {
+			include_once ABSPATH . 'wp-admin/includes/plugin-install.php';
+			include_once ABSPATH . 'wp-admin/includes/file.php';
+			include_once ABSPATH . 'wp-admin/includes/misc.php';
+			include_once ABSPATH . 'wp-admin/includes/class-wp-upgrader.php';
+
+			$this->prepare_environment_for_long_task();
+			$this->set_progress( $token, 60, __( 'Unpacking & installing WooCommerce (this can take a few minutes for many files)...', 'bus-ticket-booking-with-seat-reservation' ) );
+
+			$pkg  = get_transient( $this->package_transient_key( $token ) );
+			$path = ( is_array( $pkg ) && ! empty( $pkg['path'] ) && file_exists( $pkg['path'] ) ) ? $pkg['path'] : '';
+			$url  = ( is_array( $pkg ) && ! empty( $pkg['url'] ) ) ? $pkg['url'] : '';
+
+			// The temp file/URL is gone (transient expired, or step order lost) —
+			// recover the download URL so we can still install without forcing the
+			// user to start over.
+			if ( ! $path && ! $url ) {
+				$api = plugins_api( 'plugin_information', array( 'slug' => 'woocommerce' ) );
+				if ( is_wp_error( $api ) ) {
+					$this->fail_install( $token, $api->get_error_message() );
+				}
+				$url = $api->download_link;
+			}
 
 			// WP core resets the execution time limit to a flat 300s right before
 			// moving files into the plugins folder (see reset_time_limit_before_copy()
@@ -533,44 +625,37 @@ if ( ! class_exists( 'WBTM_Woo_Installer' ) ) {
 			add_filter( 'upgrader_pre_install', array( $this, 'reset_time_limit_before_copy' ) );
 
 			$upgrader = new Plugin_Upgrader( new WP_Ajax_Upgrader_Skin() );
-			$package  = $local_package ? $local_package : $api->download_link;
+			$package  = $path ? $path : $url;
 			$result   = $upgrader->install( $package );
 
 			remove_filter( 'upgrader_pre_install', array( $this, 'reset_time_limit_before_copy' ) );
 
-			if ( $local_package ) {
-				@unlink( $local_package );
+			if ( $path ) {
+				@unlink( $path ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged
 			}
+			delete_transient( $this->package_transient_key( $token ) );
 
 			if ( is_wp_error( $result ) ) {
 				$this->fail_install( $token, $result->get_error_message() );
 			}
-
-			if ( $result === false ) {
+			if ( false === $result ) {
 				$this->fail_install( $token, __( 'Installation failed.', 'bus-ticket-booking-with-seat-reservation' ) );
 			}
 
-			$this->set_progress( $token, 95, __( 'WooCommerce installed successfully.', 'bus-ticket-booking-with-seat-reservation' ), 'success' );
+			$this->set_progress( $token, 88, __( 'WooCommerce installed. Activating...', 'bus-ticket-booking-with-seat-reservation' ), 'success', 'activate' );
 
-			wp_send_json_success( array( 'message' => __( 'WooCommerce installed successfully.', 'bus-ticket-booking-with-seat-reservation' ) ) );
+			wp_send_json_success( array( 'next' => 'activate' ) );
 		}
 
 		/**
-		 * AJAX: Activate WooCommerce plugin.
+		 * Step 3 — activate WooCommerce (its own request; first-run DB/table
+		 * setup can be heavy too, so it gets a fresh budget as well).
+		 *
+		 * @param string $token Per-attempt progress token.
 		 */
-		public function ajax_activate_woocommerce() {
-			check_ajax_referer( 'wbtm_activate_woo', 'nonce' );
-
-			$token = isset( $_POST['progress_token'] ) ? sanitize_key( wp_unslash( $_POST['progress_token'] ) ) : '';
-
-			if ( ! current_user_can( 'activate_plugins' ) ) {
-				$this->fail_install( $token, __( 'You do not have permission to activate plugins.', 'bus-ticket-booking-with-seat-reservation' ) );
-			}
-
-			// WooCommerce runs its own DB table/setup routines on activation,
-			// which can also be heavy on first run — give it the same headroom.
+		private function step_activate( $token ) {
 			$this->prepare_environment_for_long_task();
-			$this->set_progress( $token, 96, __( 'Activating WooCommerce...', 'bus-ticket-booking-with-seat-reservation' ) );
+			$this->set_progress( $token, 92, __( 'Activating WooCommerce...', 'bus-ticket-booking-with-seat-reservation' ) );
 
 			$result = activate_plugin( 'woocommerce/woocommerce.php' );
 
@@ -578,9 +663,9 @@ if ( ! class_exists( 'WBTM_Woo_Installer' ) ) {
 				$this->fail_install( $token, $result->get_error_message() );
 			}
 
-			$this->set_progress( $token, 100, __( 'WooCommerce activated successfully!', 'bus-ticket-booking-with-seat-reservation' ), 'success' );
+			$this->set_progress( $token, 100, __( 'WooCommerce activated successfully!', 'bus-ticket-booking-with-seat-reservation' ), 'success', '' );
 
-			wp_send_json_success( array( 'message' => __( 'WooCommerce activated successfully!', 'bus-ticket-booking-with-seat-reservation' ) ) );
+			wp_send_json_success( array( 'next' => '', 'message' => __( 'WooCommerce activated successfully!', 'bus-ticket-booking-with-seat-reservation' ) ) );
 		}
 	}
 


### PR DESCRIPTION
Split both heavy flows into small, single-purpose AJAX requests so hosts with a low PHP memory_limit / short max_execution_time no longer error trying to do everything in one long request.

WooCommerce installer:
- New stepped action wbtm_woo_install_step (download -> install -> activate), each its own HTTP request with a fresh time/memory budget.
- Downloaded package handed between steps via transient; install step re-derives the URL if it expired so the user never has to restart.
- Progress transient carries a 'next' field so the poller can recover the chain if a step response is lost to a client timeout.
- Removed the old monolithic install/activate handlers and activate_nonce.

Demo import:
- Replaced synchronous admin_init bulk import with batched action wbtm_dummy_import_batch (taxonomies, then one bus per request), single rewrite flush at the end, progress toast on plugin screens only.
- New wbtm_dummy_import.js/.css; state option wbtm_dummy_import_state resumes in-progress imports; back-compat done flag preserved.
- Load admin media includes before media_sideload_image (AJAX context).