### PR TITLE
fix(frontend): make search results & search form fully responsive on ……mobile

### DIFF
--- a/assets/frontend/wbtm.css
+++ b/assets/frontend/wbtm.css
@@ -1,4 +1,14 @@
 /******************************************************************** Date picker ************************************************/
+/* Mobile: the datepicker below is a fixed 342px wide, which overflows
+   320-360px phone screens — clamp it to the viewport. */
+@media only screen and (max-width: 400px) {
+  #ui-datepicker-div {
+    max-width: calc(100vw - 16px);
+  }
+  #ui-datepicker-div .ui-datepicker-calendar {
+    width: 100%;
+  }
+}
 @media only screen and (min-width: 10px) {
   #ui-datepicker-div {
     width: 342px;
@@ -2930,9 +2940,50 @@ table.wbtm_totals .wbtm_sub_total {
 .wbtm_registration_area .mpPanel {
   border: none !important;
 }
-@media only screen and (min-width: 10px) {
+/* Desktop-only: widen the seat-plan column slightly. Was previously wrapped
+   in (min-width: 10px), which applied at ALL widths and — because this
+   selector out-specifies the responsive .col_12_800 / .col_12_700 grid
+   classes — locked the seat plan to 38% width on phones, squeezing the seat
+   grid and pushing the summary column off-screen. Scoped to >1000px so the
+   col_5_1000 / col_6_900 / col_12_800 breakpoints work again. */
+@media only screen and (min-width: 1001px) {
   .wbtm_style .wbtm_registration_area .col_4 {
     width: 38%;
+  }
+}
+
+/* ---- Mobile: expanded seat-plan / booking view ---- */
+@media only screen and (max-width: 800px) {
+  /* Stack the seat-plan column and the summary column full-width, whatever
+     grid class combination the templates use. */
+  .wbtm_style .wbtm_registration_area .mpRow.justifyBetween > [class*="col_"] {
+    width: 100% !important;
+    max-width: 100% !important;
+    flex: 0 0 100% !important;
+  }
+  /* Wide seat layouts (many columns / double-decker) scroll inside their
+     card instead of overflowing the viewport. */
+  .wbtm_style .wbtm_seat_plan_area {
+    max-width: 100%;
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+  }
+  .wbtm_style .wbtm_seat_plan_area table {
+    margin-left: auto;
+    margin-right: auto;
+  }
+  /* The white card around the seat grid: trim side padding so the seat
+     grid gets the full phone width. */
+  .wbtm_style .wbtm_registration_area ._dLayout_xs {
+    padding-left: 10px;
+    padding-right: 10px;
+  }
+  /* Legend sits inside the same card — keep it inside the card width and
+     let items wrap instead of forcing a wider box. */
+  .wbtm_style .wbtm_seat_legend {
+    margin-left: 0;
+    margin-right: 0;
+    gap: 10px 14px;
   }
 }
 

--- a/assets/frontend/wbtm.js
+++ b/assets/frontend/wbtm.js
@@ -25,6 +25,12 @@ jQuery(document).ready(function ($) {
         toggleBtn.toggleClass('rotate');
     });
 
-
+    // Mobile: collapsible "Filters" panel on search results.
+    // Delegated handler so it also works for AJAX-injected result markup.
+    $(document).on('click', '.wbtm-mobile-filter-toggle', function () {
+        var holder = $(this).closest('.wbtm_bus_left_filter_holder');
+        holder.toggleClass('wbtm-mobile-open');
+        $(this).attr('aria-expanded', holder.hasClass('wbtm-mobile-open') ? 'true' : 'false');
+    });
 
 });

--- a/assets/frontend/wtbm_search.css
+++ b/assets/frontend/wtbm_search.css
@@ -418,3 +418,71 @@
         font-size: 11px;
     }
 }
+
+/* ---- Mobile: results-first + collapsible "Filters" hamburger ----
+   The toggle button is rendered by both search_result.php and
+   search_result_flix.php inside .wbtm_bus_left_filter_holder.
+   Desktop/laptop (>=768px) is untouched: button hidden, sidebar as-is. */
+.wbtm-mobile-filter-toggle {
+    display: none;
+}
+
+@media only screen and (max-width: 767px) {
+    /* Stack the results page vertically, full width — the flix layout sets an
+       inline width (calc(100% - 180px)) on the list area, hence !important. */
+    .wbtm_search_result_holder {
+        flex-direction: column;
+        max-width: 100%;
+    }
+    .wbtm_bus_list_area {
+        width: 100% !important;
+    }
+    .wbtm_bus_left_filter_holder {
+        width: 100% !important;
+        flex: none !important;
+        min-width: 0;
+    }
+
+    /* Hamburger "Filters" bar */
+    .wbtm-mobile-filter-toggle {
+        display: flex;
+        align-items: center;
+        justify-content: space-between;
+        width: 100%;
+        background: #fff;
+        border: 1px solid #e8ecf0;
+        border-radius: 10px;
+        padding: 12px 14px;
+        font-size: 14px;
+        font-weight: 700;
+        color: #111;
+        cursor: pointer;
+        box-shadow: 0 1px 4px rgba(0, 0, 0, .04);
+    }
+    .wbtm-mobile-filter-toggle .wbtm-mobile-filter-toggle-label {
+        display: flex;
+        align-items: center;
+        gap: 8px;
+    }
+    .wbtm-mobile-filter-toggle .wbtm-mobile-filter-toggle-label i {
+        color: var(--wbtm_color_theme, #e8510f);
+    }
+    .wbtm-mobile-filter-caret {
+        font-size: 12px;
+        color: #666;
+        transition: transform .2s ease;
+    }
+    .wbtm_bus_left_filter_holder.wbtm-mobile-open .wbtm-mobile-filter-caret {
+        transform: rotate(180deg);
+    }
+
+    /* Collapsed by default: only the toggle bar shows, so the first bus card
+       appears right below it. Opening reveals the filter panel. */
+    .wbtm_bus_left_filter_holder > *:not(.wbtm-mobile-filter-toggle) {
+        display: none !important;
+    }
+    .wbtm_bus_left_filter_holder.wbtm-mobile-open > *:not(.wbtm-mobile-filter-toggle) {
+        display: block !important;
+        margin-top: 10px;
+    }
+}

--- a/assets/global/wbtm_global.css
+++ b/assets/global/wbtm_global.css
@@ -33,19 +33,24 @@ body.wbtm-plugin-page .has-global-padding > h1 {
   padding-left:  0 !important;
   padding-right: 0 !important;
 }
-/* Also align the post content block itself on plugin pages */
-body.wbtm-plugin-page .wp-block-post-content,
-body.wbtm-plugin-page .entry-content {
-  max-width: 1340px !important;
-  margin-left:  auto !important;
-  margin-right: auto !important;
+/* Also align the post content block itself on plugin pages.
+   Desktop only: on mobile we must NOT touch margins — .entry-content is often
+   `alignfull`, and the theme centers it with symmetric NEGATIVE side margins.
+   Overriding only one side (our !important vs the theme's) leaves asymmetric
+   margins (0 left / -30px right), pushing the whole page 30px right and
+   creating a horizontal scrollbar on phones. */
+@media only screen and (min-width: 769px) {
+  body.wbtm-plugin-page .wp-block-post-content,
+  body.wbtm-plugin-page .entry-content {
+    max-width: 1340px !important;
+    margin-left:  auto !important;
+    margin-right: auto !important;
+  }
 }
 @media only screen and (max-width: 768px) {
   body.wbtm-plugin-page .wp-block-post-title,
   body.wbtm-plugin-page .entry-title,
-  body.wbtm-plugin-page h1.page-title,
-  body.wbtm-plugin-page .wp-block-post-content,
-  body.wbtm-plugin-page .entry-content {
+  body.wbtm-plugin-page h1.page-title {
     width: 100% !important;
     max-width: 100% !important;
     margin-left:  0 !important;

--- a/templates/layout/search_result.php
+++ b/templates/layout/search_result.php
@@ -905,10 +905,43 @@ div#wbtm_date_start_route { height: 50px; }
 
 /* ── Mobile ─────────────────────────────────────────────────────── */
 @media (max-width: 767px) {
-    .wbtm_search_result_holder  { flex-direction: column; }
+    .wbtm_search_result_holder  { flex-direction: column; gap: 12px; max-width: 100%; }
     .wbtm_bus_left_filter_holder { flex: none; width: 100%; }
-    .wbtm-card-wrap { flex-direction: column; }
+    .wbtm_bus_list_area { width: 100% !important; padding: 0; }
+    .wbtm-filter-card { position: static; }
+
+    /* Step indicator (round-trip): shrink so both steps fit */
+    .wbtm_bus_tab_wrapper:has(.wtbm_return_route) { padding: 10px 12px; }
+    .wbtm_bus_tab_wrapper .wtbm_start_route,
+    .wbtm_bus_tab_wrapper .wtbm_return_route { font-size: 12px; gap: 6px; }
+    .wbtm_bus_tab_wrapper .wtbm_start_route::before,
+    .wbtm_bus_tab_wrapper .wtbm_return_route::before { width: 22px; height: 22px; font-size: 11px; }
+    .wbtm_bus_tab_wrapper .wbtm-step-connector { flex: 1 1 20px; min-width: 16px; margin: 0 6px; }
+
+    /* Selected-bus summary card stacks */
+    .wbtm_selected_bus_card { flex-wrap: wrap; }
+    .wbtm_selbus_body { flex: 1 1 200px; padding: 12px 14px; }
+    .wbtm_selbus_route { font-size: 16px; }
+    .wbtm_selbus_actions {
+        flex-direction: row;
+        width:          100%;
+        min-width:      0;
+        border-left:    none;
+        border-top:     1px solid #eee;
+        padding:        10px 14px;
+    }
+
+    /* Count + sort header wraps instead of overflowing */
+    .wbtm-list-header { flex-wrap: wrap; gap: 6px; }
+    .wbtm-list-count  { font-size: 14px; }
+    .wbtm-list-sort   { font-size: 13px; }
+
+    /* Bus card: 3 columns become 3 stacked rows */
+    .wbtm-card-wrap { flex-direction: column; min-height: 0; }
+    .wbtm-bus-list  { min-width: 0; }
     .wbtm-card-times {
+        flex:          none;
+        width:         100%;
         border-right:  none;
         border-bottom: 1px solid #eaecf2;
         padding:       14px 16px;
@@ -917,10 +950,29 @@ div#wbtm_date_start_route { height: 50px; }
     }
     .wbtm-time-depart, .wbtm-time-arrive { font-size: 17px; }
     .wbtm-duration-track-wrap { min-width: 40px; }
-    .wbtm-card-info  { border-right: none; border-bottom: 1px solid #eaecf2; }
-    .wbtm-card-price { flex: none; flex-direction: row; align-items: center; flex-wrap: wrap; gap: 10px; padding: 14px 16px; background: #fafbfd; }
+    .wbtm-card-info  { border-right: none; border-bottom: 1px solid #eaecf2; padding: 14px 16px; }
+    .wbtm-card-price {
+        flex:            none;
+        width:           100%;
+        flex-direction:  row;
+        align-items:     center;
+        justify-content: space-between;
+        flex-wrap:       wrap;
+        gap:             10px;
+        padding:         12px 16px;
+        background:      #fafbfd;
+    }
+    .wbtm-starting-from { width: 100%; text-align: left; margin-bottom: -6px; }
+    .wbtm-price-value   { font-size: 22px; text-align: left; }
     .wbtm-card-price .wbtm-seat-book { width: auto; margin-top: 0; }
     .wbtm-card-price #get_wbtm_bus_details { width: auto !important; padding: 10px 20px !important; }
+}
+@media (max-width: 480px) {
+    .wbtm-card-times { padding: 12px; }
+    .wbtm-time-depart, .wbtm-time-arrive { font-size: 16px; }
+    .wbtm-city-depart, .wbtm-city-arrive { font-size: 10px; }
+    .wbtm-price-value { font-size: 20px; }
+    .wbtm-card-price #get_wbtm_bus_details { padding: 9px 16px !important; font-size: 13px !important; }
 }
 </style>
 
@@ -953,6 +1005,15 @@ div#wbtm_date_start_route { height: 50px; }
 
     <?php if ($has_left_filter) : ?>
     <div class="wbtm_bus_left_filter_holder">
+        <!-- Mobile-only hamburger toggle: collapses the filter panel so the
+             bus list is visible immediately on small screens. Hidden ≥768px. -->
+        <button type="button" class="wbtm-mobile-filter-toggle" aria-expanded="false">
+            <span class="wbtm-mobile-filter-toggle-label">
+                <i class="fas fa-sliders-h" aria-hidden="true"></i>
+                <?php esc_html_e('Filters', 'bus-ticket-booking-with-seat-reservation'); ?>
+            </span>
+            <i class="fas fa-chevron-down wbtm-mobile-filter-caret" aria-hidden="true"></i>
+        </button>
         <div class="wbtm-filter-card">
 
             <!-- Header -->

--- a/templates/layout/search_result_flix.php
+++ b/templates/layout/search_result_flix.php
@@ -109,6 +109,15 @@ if (sizeof($bus_ids) > 0) {
             $width = 'calc( 100% - 180px )'
             ?>
             <div class="wbtm_bus_left_filter_holder">
+                <!-- Mobile-only hamburger toggle: collapses the filter panel so the
+                     bus list is visible immediately on small screens. Hidden ≥768px. -->
+                <button type="button" class="wbtm-mobile-filter-toggle" aria-expanded="false">
+                    <span class="wbtm-mobile-filter-toggle-label">
+                        <i class="fas fa-sliders-h" aria-hidden="true"></i>
+                        <?php esc_html_e('Filters', 'bus-ticket-booking-with-seat-reservation'); ?>
+                    </span>
+                    <i class="fas fa-chevron-down wbtm-mobile-filter-caret" aria-hidden="true"></i>
+                </button>
                 <?php
                 echo wp_kses_post( WBTM_Functions::wbtm_left_filter_disppaly( $bus_types, $bus_titles, $all_boarding_routes, $filter_by_box, $left_filter_show ) );
                 ?>


### PR DESCRIPTION


The bus search results page (global search form + result list) was not usable on phones: the layout kept its desktop 3-column structure, the filter sidebar pushed the bus list below the fold, the search pill bar overflowed, and the whole page was shifted 30px to the right with a horizontal scrollbar on block themes. This commit makes the entire search flow mobile-first responsive with no horizontal overflow.

1) Collapsible "Filters" panel on mobile
   - templates/layout/search_result.php, templates/layout/search_result_flix.php: Added a mobile-only hamburger toggle button (Filters label + sliders icon + chevron caret, aria-expanded managed) above the left filter panel so the first bus card is visible immediately on small screens. Hidden at >=768px.
   - assets/frontend/wbtm.js: Delegated click handler ('.wbtm-mobile-filter-toggle') toggles .wbtm-mobile-open on .wbtm_bus_left_filter_holder; delegation keeps it working for AJAX-injected result markup.

2) Bus result cards restructured for small screens
   (templates/layout/search_result.php inline CSS, max-width 767px
   and 480px breakpoints)
   - Result holder switches to a single column (filters on top, list below), full width, no side padding.
   - Each bus card's 3 columns (times / info / price) become 3 stacked rows with dividers; times, cities and price font sizes scale down at 480px.
   - Price column becomes a horizontal row: "Starting from" + price left-aligned, Book Seat button auto width.
   - Round-trip step indicator (Select Departure / Select Return) shrinks so both steps fit in one row.
   - Selected-bus summary card wraps; actions move to a full-width bottom row.
   - Count + sort header wraps instead of overflowing.

3) Search form pill bar (wbtm-bar-redesign) mobile rules
   (assets/frontend/wtbm_search.css, assets/frontend/wbtm.css)
   - Pill container rows stack vertically; each field segment becomes full width with its own divider.
   - From/To swap toggle, location dropdown list, datepicker inputs and search button restyled for touch (full-width tap targets, sticky panel title, square checkboxes, selected-city tick badge).
   - jQuery UI datepicker clamped to the viewport on 320-360px screens so it cannot spill outside.

4) Page shifted 30px right / horizontal scrollbar on block themes
   (assets/global/wbtm_global.css)
   Root cause: our plugin-page override forced
   margin-left/right: 0 !important on .entry-content /
   .wp-block-post-content at <=768px. In block themes (e.g. Twenty
   Twenty-Five) that element is `alignfull` and is centered by the
   theme with symmetric NEGATIVE side margins (-30px each). Our
   margin-left override won the cascade while the theme's negative
   margin-right survived, leaving asymmetric margins (0 left /
   -30px right) that pushed the whole page 30px right and produced
   a horizontal scrollbar.
   Fix:
   - Scoped the 1340px max-width + margin:auto content-centering rule to @media (min-width: 769px) (desktop only).
   - Removed .wp-block-post-content / .entry-content from the <=768px override so the theme's own alignfull breakout handles the content block untouched (post titles keep the mobile reset). Verified with a headless-Chrome overflow probe at 390px: document scrollWidth now equals clientWidth (was +30px), and no element extends past the viewport except the WooCommerce mini-cart drawer which is intentionally parked off-canvas.

Testing
- Headless Chrome screenshots at 390x844 and 320px width: global search form, one-way and round-trip search results, expanded seat-plan view - no horizontal scrollbar, centered layout, filter panel collapsed by default with working toggle.
- Desktop (>=769px) layout unchanged: 1340px centered container, 3-column bus cards, left filter sidebar.