### PR TITLE
feat(settings): add Frontend Display tab to show/hide search-result filters

### DIFF
--- a/admin/WBTM_Global_settings.php
+++ b/admin/WBTM_Global_settings.php
@@ -480,6 +480,11 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 							'layout'   => 'toggles',
 							'field_names' => ['show_filter_departure_time', 'show_filter_bus_type', 'show_filter_bus_operator', 'show_filter_boarding_point', 'show_sort_bar'],
 						],
+						'unpriced' => [
+							'icon'     => 'fas fa-ban',
+							'label'    => esc_html__('Unpriced Routes', 'bus-ticket-booking-with-seat-reservation'),
+							'field_names' => ['unpriced_route_action', 'unpriced_route_message'],
+						],
 					],
 					'wbtm_passenger_pdf_settings' => [
 						'checklist' => [
@@ -1558,6 +1563,25 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 							'type'    => 'toggle',
 							'icon'    => 'fas fa-arrow-down-short-wide',
 							'default' => 'show',
+						),
+						array(
+							'name'    => 'unpriced_route_action',
+							'label'   => esc_html__( 'Routes with no price', 'bus-ticket-booking-with-seat-reservation' ),
+							'desc'    => esc_html__( 'What to do when a customer selects a route segment that has no fare configured. This prevents such segments from being booked at 0.', 'bus-ticket-booking-with-seat-reservation' ),
+							'type'    => 'select',
+							'default' => 'message',
+							'options' => array(
+								'message' => esc_html__( 'Show a "not available" message', 'bus-ticket-booking-with-seat-reservation' ),
+								'hide'    => esc_html__( 'Hide the route from the results', 'bus-ticket-booking-with-seat-reservation' ),
+							),
+						),
+						array(
+							'name'        => 'unpriced_route_message',
+							'label'       => esc_html__( 'Not-available message', 'bus-ticket-booking-with-seat-reservation' ),
+							'desc'        => esc_html__( 'Shown in place of the price/Book button when a route has no fare (only used when the option above is set to show a message).', 'bus-ticket-booking-with-seat-reservation' ),
+							'type'        => 'text',
+							'default'     => esc_html__( 'This route is not currently available for booking.', 'bus-ticket-booking-with-seat-reservation' ),
+							'placeholder' => esc_html__( 'This route is not currently available for booking.', 'bus-ticket-booking-with-seat-reservation' ),
 						),
 					) ),
 				);

--- a/admin/WBTM_Global_settings.php
+++ b/admin/WBTM_Global_settings.php
@@ -351,6 +351,12 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 						'subtitle'   => esc_html__('Date & editor settings', 'bus-ticket-booking-with-seat-reservation'),
 						'section_id' => 'wbtm_global_settings',
 					],
+					'frontend' => [
+						'title'      => esc_html__('Frontend Display', 'bus-ticket-booking-with-seat-reservation'),
+						'icon'       => 'fas fa-eye',
+						'subtitle'   => esc_html__('Search result filter visibility', 'bus-ticket-booking-with-seat-reservation'),
+						'section_id' => 'wbtm_frontend_display_settings',
+					],
 					'deposit' => [
 						'title'      => esc_html__('Deposit / Partial Pay', 'addon-bus--ticket-booking-with-seat-pro'),
 						'icon'       => 'fas fa-wallet',
@@ -461,6 +467,20 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 							'field_names' => ['promo_enabled', 'promo_title', 'promo_desc', 'promo_button_text', 'promo_button_link'],
 						],
 					],
+					'wbtm_frontend_display_settings' => [
+						'panel' => [
+							'icon'     => 'fas fa-sliders-h',
+							'label'    => esc_html__('Filter Sidebar', 'bus-ticket-booking-with-seat-reservation'),
+							'layout'   => 'toggles',
+							'field_names' => ['show_filter_panel'],
+						],
+						'filters' => [
+							'icon'     => 'fas fa-list-check',
+							'label'    => esc_html__('Individual Filters', 'bus-ticket-booking-with-seat-reservation'),
+							'layout'   => 'toggles',
+							'field_names' => ['show_filter_departure_time', 'show_filter_bus_type', 'show_filter_bus_operator', 'show_filter_boarding_point', 'show_sort_bar'],
+						],
+					],
 					'wbtm_passenger_pdf_settings' => [
 						'checklist' => [
 							'icon'   => 'fas fa-list-check',
@@ -510,6 +530,38 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 								<div class="bm-gs__checklist-grid">
 									<?php foreach ($checklist_fields as $field): 
 										$this->render_checklist_item($section_id, $field);
+									endforeach; ?>
+								</div>
+							</div>
+							<?php
+							continue;
+						}
+
+						$is_toggles = (isset($card['layout']) && $card['layout'] === 'toggles');
+
+						if ($is_toggles) {
+							// Toggle-switch layout: modern on/off switches in a compact grid.
+							$toggle_fields = [];
+							foreach ($card['field_names'] as $fname) {
+								foreach ($fields as $field) {
+									if (isset($field['name']) && $field['name'] === $fname) {
+										$toggle_fields[] = $field;
+										$assigned[]      = $fname;
+										break;
+									}
+								}
+							}
+							if (empty($toggle_fields)) continue;
+							$grid_mod = (count($toggle_fields) === 1) ? ' bm-gs__toggle-grid--single' : '';
+							?>
+							<div class="bm-gs__section-card">
+								<div class="bm-gs__section-head">
+									<span class="bm-gs__section-icon <?php echo esc_attr($card['icon']); ?>"></span>
+									<span class="bm-gs__section-head-label"><?php echo esc_html($card['label']); ?></span>
+								</div>
+								<div class="bm-gs__toggle-grid<?php echo esc_attr($grid_mod); ?>">
+									<?php foreach ($toggle_fields as $field):
+										$this->render_toggle_item($section_id, $field);
 									endforeach; ?>
 								</div>
 							</div>
@@ -661,6 +713,42 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 				<?php
 			}
 
+			/**
+			 * Renders a single modern on/off toggle switch (Show / Hide).
+			 *
+			 * Uses a hidden input + checkbox with the SAME name so a value is
+			 * always submitted: unchecked posts 'hide' (hidden field), checked
+			 * posts 'show' (checkbox wins as the later same-name value in $_POST).
+			 * This avoids the classic WordPress bug where an unchecked checkbox is
+			 * absent from POST and silently reverts to its saved/default value.
+			 */
+			private function render_toggle_item($section_id, $field) {
+				$label = isset($field['label']) ? $field['label'] : '';
+				$desc  = isset($field['desc']) ? $field['desc'] : '';
+				$name  = isset($field['name']) ? $field['name'] : '';
+				$icon  = isset($field['icon']) ? $field['icon'] : 'fas fa-toggle-on';
+				$value = WBTM_Global_Function::get_settings($section_id, $name, isset($field['default']) ? $field['default'] : 'show');
+				$id    = $section_id . '[' . $name . ']';
+				$id_attr = esc_attr($id);
+				$checked = ($value === 'hide') ? '' : ' checked';
+				?>
+				<div class="bm-gs__toggle-item">
+					<span class="bm-gs__toggle-icon"><i class="<?php echo esc_attr($icon); ?>" aria-hidden="true"></i></span>
+					<div class="bm-gs__toggle-text">
+						<div class="bm-gs__toggle-label"><?php echo esc_html($label); ?></div>
+						<?php if ($desc): ?>
+							<div class="bm-gs__toggle-hint"><?php echo wp_kses_post($desc); ?></div>
+						<?php endif; ?>
+					</div>
+					<label class="bm-gs__switch">
+						<input type="hidden" name="<?php echo $id_attr; ?>" value="hide">
+						<input type="checkbox" name="<?php echo $id_attr; ?>" value="show"<?php echo $checked; ?>>
+						<span class="bm-gs__switch-track"><span class="bm-gs__switch-thumb"></span></span>
+					</label>
+				</div>
+				<?php
+			}
+
 			private function render_form_control($section_id, $field, $value) {
 				$type  = isset($field['type']) ? $field['type'] : 'text';
 				$name  = isset($field['name']) ? $field['name'] : '';
@@ -782,6 +870,16 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 						echo '</label>';
 						break;
 
+					case 'toggle':
+						// Show / Hide switch backed by a hidden field so a value is always saved.
+						$checked = ($value === 'hide') ? '' : ' checked';
+						echo '<label class="bm-gs__switch">';
+						echo '<input type="hidden" name="' . $id_attr . '" value="hide">';
+						echo '<input type="checkbox" name="' . $id_attr . '" value="show"' . $checked . '>';
+						echo '<span class="bm-gs__switch-track"><span class="bm-gs__switch-thumb"></span></span>';
+						echo '</label>';
+						break;
+
 					case 'icon':
 						// Wrap in .wbtm_style so the icon-picker popup & button CSS applies.
 						// WBTM_Select_Icon_image outputs classes (_mpBtn_xs, dNone, fdColumn etc.)
@@ -893,6 +991,10 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 					array(
 						'id'    => 'wbtm_promo_settings',
 						'title' => esc_html__( 'Promo Banner', 'bus-ticket-booking-with-seat-reservation' )
+					),
+					array(
+						'id'    => 'wbtm_frontend_display_settings',
+						'title' => esc_html__( 'Frontend Display', 'bus-ticket-booking-with-seat-reservation' )
 					),
 					array(
 						'id'    => 'wbtm_license_settings',
@@ -1406,6 +1508,56 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 							'type'        => 'url',
 							'default'     => '',
 							'placeholder' => 'https://example.com/membership',
+						),
+					) ),
+					'wbtm_frontend_display_settings' => apply_filters( 'wbtm_filter_frontend_display_settings', array(
+						array(
+							'name'    => 'show_filter_panel',
+							'label'   => esc_html__( 'Filter Sidebar', 'bus-ticket-booking-with-seat-reservation' ),
+							'desc'    => esc_html__( 'Master switch. Turn off to remove the entire Filters sidebar from the search results — the bus list then spans the full width.', 'bus-ticket-booking-with-seat-reservation' ),
+							'type'    => 'toggle',
+							'icon'    => 'fas fa-sliders-h',
+							'default' => 'show',
+						),
+						array(
+							'name'    => 'show_filter_departure_time',
+							'label'   => esc_html__( 'Departure Time', 'bus-ticket-booking-with-seat-reservation' ),
+							'desc'    => esc_html__( 'The Morning / Afternoon / Evening / Night filter. Turn off if you do not offer time-of-day choices.', 'bus-ticket-booking-with-seat-reservation' ),
+							'type'    => 'toggle',
+							'icon'    => 'fas fa-clock',
+							'default' => 'show',
+						),
+						array(
+							'name'    => 'show_filter_bus_type',
+							'label'   => esc_html__( 'Bus Type', 'bus-ticket-booking-with-seat-reservation' ),
+							'desc'    => esc_html__( 'The AC / Non-AC style bus-type filter.', 'bus-ticket-booking-with-seat-reservation' ),
+							'type'    => 'toggle',
+							'icon'    => 'fas fa-bus',
+							'default' => 'show',
+						),
+						array(
+							'name'    => 'show_filter_bus_operator',
+							'label'   => esc_html__( 'Bus Operator', 'bus-ticket-booking-with-seat-reservation' ),
+							'desc'    => esc_html__( 'Filter by operator / bus name.', 'bus-ticket-booking-with-seat-reservation' ),
+							'type'    => 'toggle',
+							'icon'    => 'fas fa-building',
+							'default' => 'show',
+						),
+						array(
+							'name'    => 'show_filter_boarding_point',
+							'label'   => esc_html__( 'Boarding Point', 'bus-ticket-booking-with-seat-reservation' ),
+							'desc'    => esc_html__( 'Filter by boarding location.', 'bus-ticket-booking-with-seat-reservation' ),
+							'type'    => 'toggle',
+							'icon'    => 'fas fa-map-marker-alt',
+							'default' => 'show',
+						),
+						array(
+							'name'    => 'show_sort_bar',
+							'label'   => esc_html__( 'Sort Bar', 'bus-ticket-booking-with-seat-reservation' ),
+							'desc'    => esc_html__( 'The "Sort by: Earliest First" dropdown above the bus list.', 'bus-ticket-booking-with-seat-reservation' ),
+							'type'    => 'toggle',
+							'icon'    => 'fas fa-arrow-down-short-wide',
+							'default' => 'show',
 						),
 					) ),
 				);

--- a/admin/settings/WTBM_Features_Seating.php
+++ b/admin/settings/WTBM_Features_Seating.php
@@ -1,4 +1,4 @@
-﻿<?php
+<?php
 
 if ( ! defined( 'ABSPATH' ) ) { die; }
 

--- a/assets/admin/css/wbtm-global-settings.css
+++ b/assets/admin/css/wbtm-global-settings.css
@@ -572,6 +572,82 @@
   .bm-gs__checklist-grid { grid-template-columns: repeat(2, 1fr); }
 }
 
+/* ── TOGGLE SWITCHES (Frontend Display) ── */
+.bm-gs__toggle-grid {
+  display: grid;
+  grid-template-columns: repeat(2, 1fr);
+  gap: 10px;
+  padding: 14px;
+}
+.bm-gs__toggle-grid--single { grid-template-columns: 1fr; }
+.bm-gs__toggle-item {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 12px 14px;
+  background: #fafafa;
+  border: 1px solid #eef1f5;
+  border-radius: 10px;
+  transition: border-color .15s, background .15s;
+}
+.bm-gs__toggle-item:hover { background: #fff; border-color: #e2e8f0; }
+.bm-gs__toggle-icon {
+  font-size: 15px;
+  color: #6366f1;
+  width: 32px;
+  height: 32px;
+  border-radius: 8px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(99, 102, 241, .1);
+  flex-shrink: 0;
+}
+/* Nested <i> so Font Awesome's own .fas{display:inline-block} can't override
+   the flex centering above; keep the glyph perfectly centered in the badge. */
+.bm-gs__toggle-icon > i {
+  display: block;
+  line-height: 1;
+}
+.bm-gs__toggle-text { flex: 1; min-width: 0; }
+.bm-gs__toggle-label { font-size: 13.5px; font-weight: 600; color: #334155; }
+.bm-gs__toggle-hint { font-size: 11px; color: #94a3b8; line-height: 1.45; margin-top: 3px; }
+
+/* iOS-style switch */
+.bm-gs__switch {
+  position: relative;
+  display: inline-flex;
+  flex-shrink: 0;
+  cursor: pointer;
+}
+.bm-gs__switch input { position: absolute; opacity: 0; width: 0; height: 0; }
+.bm-gs__switch-track {
+  display: block;
+  width: 42px;
+  height: 24px;
+  border-radius: 999px;
+  background: #cbd5e1;
+  transition: background .2s ease;
+  position: relative;
+}
+.bm-gs__switch-thumb {
+  position: absolute;
+  top: 3px;
+  left: 3px;
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, .2);
+  transition: transform .2s ease;
+}
+.bm-gs__switch input:checked + .bm-gs__switch-track { background: #6366f1; }
+.bm-gs__switch input:checked + .bm-gs__switch-track .bm-gs__switch-thumb { transform: translateX(18px); }
+.bm-gs__switch input:focus-visible + .bm-gs__switch-track { box-shadow: 0 0 0 3px rgba(99, 102, 241, .25); }
+@media (max-width: 600px) {
+  .bm-gs__toggle-grid { grid-template-columns: 1fr; }
+}
+
 
 /* ══════════════════════════════════════════
    RESPONSIVE BREAKPOINTS

--- a/assets/frontend/wtbm_search.css
+++ b/assets/frontend/wtbm_search.css
@@ -486,3 +486,24 @@
         margin-top: 10px;
     }
 }
+
+/* Route with no fare configured (Frontend Display -> Unpriced Routes).
+   Shown in place of the price/Book button in the flix search layout. */
+.wbtm-route-unavailable {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    text-align: left;
+    background: #fff7ed;
+    border: 1px solid #fed7aa;
+    color: #b45309;
+    border-radius: 10px;
+    padding: 10px 12px;
+    font-size: 13px;
+    font-weight: 600;
+    line-height: 1.4;
+}
+.wbtm-route-unavailable i {
+    font-size: 15px;
+    flex-shrink: 0;
+}

--- a/inc/WBTM_Functions.php
+++ b/inc/WBTM_Functions.php
@@ -1761,6 +1761,11 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 			}
 
             public static function wbtm_left_filter_disppaly( $bus_types, $bus_titles, $start_routes, $filter_by_box, $left_filter_show ): void {
+                // Frontend Display settings (Global Settings → Frontend Display).
+                // Default 'show' keeps existing behavior; only an explicit 'hide' turns a filter off.
+                $fd_type     = WBTM_Global_Function::get_settings( 'wbtm_frontend_display_settings', 'show_filter_bus_type', 'show' ) !== 'hide';
+                $fd_operator = WBTM_Global_Function::get_settings( 'wbtm_frontend_display_settings', 'show_filter_bus_operator', 'show' ) !== 'hide';
+                $fd_boarding = WBTM_Global_Function::get_settings( 'wbtm_frontend_display_settings', 'show_filter_boarding_point', 'show' ) !== 'hide';
                 ?>
                 <div id="wbtm_bus_filter-options">
                     <div class="wbtm_left_filter_title_holder">
@@ -1772,7 +1777,7 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
                         </div>
                     </div>
                     <div class="wbtm_left_filter_element_holder">
-                        <?php if( $left_filter_show['left_filter_type'] === 'on' && !empty( $bus_types ) ) {?>
+                        <?php if( $fd_type && $left_filter_show['left_filter_type'] === 'on' && !empty( $bus_types ) ) {?>
                         <div class="wbtm_bus_filter_items">
                                 <span class="wbtm_bus_toggle-header"><?php echo esc_html(WBTM_Translations::text_bus_type()); ?> <span class="wbtm_bus_toggle-icon"></span></span>
                                 <?php
@@ -1806,7 +1811,7 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
                         <?php }
 						
 						
-                        if( $left_filter_show['left_filter_operator'] === 'on' && !empty( $bus_titles ) ) { ?>
+                        if( $fd_operator && $left_filter_show['left_filter_operator'] === 'on' && !empty( $bus_titles ) ) { ?>
                         <div class="wbtm_bus_filter_items">
                             <span class="wbtm_bus_toggle-header"><?php echo esc_html(WBTM_Translations::text_bus_operator()); ?> <span class="wbtm_bus_toggle-icon"></span></span>
                             <?php
@@ -1822,7 +1827,7 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
                         </div>
                         <?php }
 						
-                        if( $left_filter_show['left_filter_boarding'] === 'on' && is_array( $start_routes ) && count( $start_routes ) >0 ){
+                        if( $fd_boarding && $left_filter_show['left_filter_boarding'] === 'on' && is_array( $start_routes ) && count( $start_routes ) >0 ){
                         ?>
                         <div class="wbtm_bus_filter_items">
                             <span class="wbtm_bus_toggle-header"><?php echo esc_html(WBTM_Translations::text_boarding_point()); ?> <span class="wbtm_bus_toggle-icon"></span></span>

--- a/inc/WBTM_Functions.php
+++ b/inc/WBTM_Functions.php
@@ -1368,6 +1368,20 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 				}
 				return false;
 			}
+			/**
+			 * Whether an origin -> destination segment has a fare configured.
+			 *
+			 * get_seat_price() returns boolean false when no price row exists for the
+			 * OD pair (a configured free route returns numeric 0, not false), so this
+			 * cleanly distinguishes "not priced / not bookable" from "priced at 0".
+			 * Reuses get_seat_price(), so it honors the same return-leg / same-bus-return
+			 * fallbacks used everywhere else.
+			 *
+			 * @return bool True if bookable (a fare exists), false if unpriced.
+			 */
+			public static function route_price_configured( $post_id, $start_route, $end_route, $price_leg = 'outbound' ) {
+				return self::get_seat_price( $post_id, $start_route, $end_route, 0, false, $price_leg ) !== false;
+			}
 			public static function get_ex_service_price( $post_id, $service_name ) {
 				$show_extra_service = WBTM_Global_Function::get_post_info( $post_id, 'show_extra_service', 'no' );
 				if ( $show_extra_service == 'yes' ) {

--- a/inc/WBTM_Woocommerce.php
+++ b/inc/WBTM_Woocommerce.php
@@ -224,6 +224,17 @@
 					return true;
 				}
 				$booking_mode = $booking_mode === 'full_bus' ? 'full_bus' : 'seat';
+				// Reject segments with no fare configured so they can't be booked at 0,
+				// even via a crafted request that bypasses the hidden UI. Full-bus pricing
+				// is validated separately, so this guard applies to seat bookings only.
+				if ( $booking_mode === 'seat'
+					&& ! WBTM_Functions::route_price_configured( $post_id, $bp, $dp, 'outbound' )
+					&& ! WBTM_Functions::route_price_configured( $post_id, $bp, $dp, 'return' ) ) {
+					return new WP_Error(
+						'wbtm_route_unpriced',
+						esc_html__( 'This route is not currently available for booking.', 'bus-ticket-booking-with-seat-reservation' )
+					);
+				}
 				if ( $booking_mode === 'full_bus' ) {
 					$total_seat = class_exists( 'WBTM_Seat_Configuration' ) ? WBTM_Seat_Configuration::count_actual_seats( $post_id ) : (int) WBTM_Global_Function::get_post_info( $post_id, 'wbtm_get_total_seat', 0 );
 					$sold_seat  = WBTM_Query::query_total_booked( $post_id, $bp, $dp, $date );

--- a/mp_global/class/WBTM_Setting_API.php
+++ b/mp_global/class/WBTM_Setting_API.php
@@ -193,6 +193,24 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
                 </fieldset>
 				<?php
 			}
+			function callback_toggle( $args ) {
+				// Show / Hide switch. A hidden "hide" field guarantees a value is
+				// always posted, so an unchecked toggle reliably saves as 'hide'
+				// instead of silently reverting to the default.
+				$std     = isset( $args['std'] ) ? $args['std'] : 'show';
+				$value   = WBTM_Global_Function::get_settings( $args['section'], $args['id'], $std );
+				$name    = $args['section'] . '[' . $args['id'] . ']';
+				$checked = ( $value === 'hide' ) ? '' : ' checked';
+				?>
+                <fieldset>
+                    <label class="roundSwitchLabel">
+                        <input type="hidden" name="<?php echo esc_attr( $name ); ?>" value="hide"/>
+                        <input type="checkbox" name="<?php echo esc_attr( $name ); ?>" value="show"<?php echo esc_attr( $checked ); ?>>
+                        <span class="roundSwitch"></span>
+                    </label>
+                </fieldset>
+				<?php
+			}
 			function callback_multicheck( $args ) {
 				$value = WBTM_Global_Function::get_settings( $args['section'], $args['id'], $args['std'] );
 				$name  = $args['section'] . '[' . $args['id'] . ']';

--- a/templates/layout/search_result.php
+++ b/templates/layout/search_result.php
@@ -43,6 +43,14 @@ if (sizeof($bus_ids) > 0) {
     $all_boarding_routes = [];
    
     $wbtm_price_leg = ( $journey_type === 'return_journey' ) ? 'return' : 'outbound';
+
+    // Unpriced-route handling (Global Settings -> Frontend Display -> Unpriced Routes).
+    // A segment with no fare configured returns price === false from get_bus_all_info().
+    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+    $wbtm_unpriced_action = WBTM_Global_Function::get_settings('wbtm_frontend_display_settings', 'unpriced_route_action', 'message');
+    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+    $wbtm_unpriced_msg = WBTM_Global_Function::get_settings('wbtm_frontend_display_settings', 'unpriced_route_message', __('This route is not currently available for booking.', 'bus-ticket-booking-with-seat-reservation'));
+
     foreach ($bus_ids as $bus_id) {
         $wbtm_price_leg = WBTM_Functions::resolve_price_leg_for_od_pair(
             $bus_id,
@@ -50,14 +58,22 @@ if (sizeof($bus_ids) > 0) {
             $end_route,
             ( $journey_type === 'return_journey' ) ? 'return' : 'outbound'
         );
-       
+
         $all_info = WBTM_Functions::get_bus_all_info($bus_id, $date, $start_route, $end_route, $wbtm_price_leg);
         if (sizeof($all_info) > 0) {
-           
+
+            // No fare configured for this exact origin -> destination segment.
+            $route_priced = ($all_info['price'] !== false);
+            if (!$route_priced && $wbtm_unpriced_action === 'hide') {
+                // Hidden entirely: not listed, not filtered, not counted.
+                continue;
+            }
+
             $bus_data[] = [
                 'bus_id'   => $bus_id,
                 'all_info' => $all_info,
                 'price_leg' => $wbtm_price_leg,
+                'route_priced' => $route_priced,
             ];
            
             $bus_titles[] = get_the_title($bus_id);
@@ -902,6 +918,25 @@ div#wbtm_date_start_route { height: 50px; }
     font-size: inherit !important;
     color:     inherit !important;
 }
+/* Route with no fare configured: shown in place of the price + Book button. */
+.wbtm-route-unavailable {
+    display:       flex;
+    align-items:   center;
+    gap:           8px;
+    text-align:    left;
+    background:    #fff7ed;
+    border:        1px solid #fed7aa;
+    color:         #b45309;
+    border-radius: 10px;
+    padding:       10px 12px;
+    font-size:     13px;
+    font-weight:   600;
+    line-height:   1.4;
+}
+.wbtm-route-unavailable i {
+    font-size:  15px;
+    flex-shrink: 0;
+}
 .wbtm-card-price .wbtm-seat-book {
     width:      100%;
     margin-top: 2px;
@@ -1208,6 +1243,7 @@ div#wbtm_date_start_route { height: 50px; }
             $popup_tabs   = WBTM_Functions::single_bus_details_tabs_filtered($bus_id);
             $all_info     = $bus['all_info'];
             $wbtm_price_leg = $bus['price_leg'] ?? $wbtm_price_leg;
+            $route_priced = $bus['route_priced'] ?? true;
             $bus_count++;
             $price        = $all_info['price'];
             $bp_time      = $all_info['bp_time'];
@@ -1333,7 +1369,12 @@ div#wbtm_date_start_route { height: 50px; }
 
                     <!-- RIGHT: price + Book Seat button -->
                     <div class="wbtm-card-price">
-                        <?php if ($is_sold_out) : ?>
+                        <?php if (!$route_priced) : ?>
+                            <div class="wbtm-route-unavailable">
+                                <i class="fas fa-circle-info" aria-hidden="true"></i>
+                                <span><?php echo esc_html($wbtm_unpriced_msg); ?></span>
+                            </div>
+                        <?php elseif ($is_sold_out) : ?>
                             <div class="wbtm-soldout-badge">
                                 <?php esc_html_e('Sold Out', 'bus-ticket-booking-with-seat-reservation'); ?>
                             </div>
@@ -1345,6 +1386,7 @@ div#wbtm_date_start_route { height: 50px; }
                                 <?php echo wp_kses_post(wc_price($price)); ?>
                             </div>
                         <?php endif; ?>
+                        <?php if ($route_priced) : ?>
                         <div class="wbtm-seat-book <?php echo esc_html($btn_show); ?>">
                             <?php echo WBTM_Functions::full_bus_booking_button($bus_id, $all_info, $date, $wbtm_price_leg); ?>
                             <button type="button"
@@ -1362,6 +1404,7 @@ div#wbtm_date_start_route { height: 50px; }
                                 </span>
                             </button>
                         </div>
+                        <?php endif; ?>
                     </div>
 
                 </div><!-- /.wbtm-card-wrap -->

--- a/templates/layout/search_result.php
+++ b/templates/layout/search_result.php
@@ -1010,7 +1010,22 @@ div#wbtm_date_start_route { height: 50px; }
     // booking widget (e.g. the "search from this bus" box on the bus's
     // single page) — there's only ever one bus in that result set, so a
     // filter sidebar is meaningless there; the list area goes full width.
-    $has_left_filter = count($bus_titles) > 0 && empty($post_id);
+    // Frontend Display settings (Global Settings → Frontend Display).
+    // Each defaults to 'show' so existing sites are unaffected until toggled.
+    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+    $wbtm_fd_panel     = WBTM_Global_Function::get_settings('wbtm_frontend_display_settings', 'show_filter_panel', 'show') !== 'hide';
+    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+    $wbtm_fd_time      = WBTM_Global_Function::get_settings('wbtm_frontend_display_settings', 'show_filter_departure_time', 'show') !== 'hide';
+    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+    $wbtm_fd_type      = WBTM_Global_Function::get_settings('wbtm_frontend_display_settings', 'show_filter_bus_type', 'show') !== 'hide';
+    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+    $wbtm_fd_operator  = WBTM_Global_Function::get_settings('wbtm_frontend_display_settings', 'show_filter_bus_operator', 'show') !== 'hide';
+    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+    $wbtm_fd_boarding  = WBTM_Global_Function::get_settings('wbtm_frontend_display_settings', 'show_filter_boarding_point', 'show') !== 'hide';
+    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+    $wbtm_fd_sort      = WBTM_Global_Function::get_settings('wbtm_frontend_display_settings', 'show_sort_bar', 'show') !== 'hide';
+
+    $has_left_filter = count($bus_titles) > 0 && empty($post_id) && $wbtm_fd_panel;
 
     // Always show all 4 departure-time options, regardless of whether the
     // current result set happens to have a bus in that window.
@@ -1052,7 +1067,7 @@ div#wbtm_date_start_route { height: 50px; }
             </div>
 
             <!-- Departure Time -->
-            <?php if (!empty($wbtm_time_buckets)) : ?>
+            <?php if ($wbtm_fd_time && !empty($wbtm_time_buckets)) : ?>
             <div class="wbtm-filter-section">
                 <div class="wbtm-filter-section-label"><?php esc_html_e('Departure Time', 'bus-ticket-booking-with-seat-reservation'); ?></div>
                 <?php foreach ($wbtm_time_buckets as $k => $opt) : ?>
@@ -1069,7 +1084,7 @@ div#wbtm_date_start_route { height: 50px; }
 
             <!-- Bus Type -->
             <?php $unique_bus_types = array_unique(array_filter($bus_types)); ?>
-            <?php if (!empty($unique_bus_types)) : ?>
+            <?php if ($wbtm_fd_type && !empty($unique_bus_types)) : ?>
             <div class="wbtm-filter-section">
                 <div class="wbtm-filter-section-label"><?php esc_html_e('Bus Type', 'bus-ticket-booking-with-seat-reservation'); ?></div>
                 <?php foreach ($unique_bus_types as $type) : ?>
@@ -1082,7 +1097,7 @@ div#wbtm_date_start_route { height: 50px; }
             <?php endif; ?>
 
             <!-- Bus Operator -->
-            <?php if (!empty($bus_titles)) : ?>
+            <?php if ($wbtm_fd_operator && !empty($bus_titles)) : ?>
             <div class="wbtm-filter-section">
                 <div class="wbtm-filter-section-label"><?php esc_html_e('Bus Operator', 'bus-ticket-booking-with-seat-reservation'); ?></div>
                 <?php foreach (array_unique($bus_titles) as $title) : ?>
@@ -1095,7 +1110,7 @@ div#wbtm_date_start_route { height: 50px; }
             <?php endif; ?>
 
             <!-- Boarding Point -->
-            <?php if (!empty($all_boarding_routes)) : ?>
+            <?php if ($wbtm_fd_boarding && !empty($all_boarding_routes)) : ?>
             <div class="wbtm-filter-section">
                 <div class="wbtm-filter-section-label"><?php esc_html_e('Boarding Point', 'bus-ticket-booking-with-seat-reservation'); ?></div>
                 <?php foreach (array_unique($all_boarding_routes) as $route) : if (!$route) continue; ?>
@@ -1172,6 +1187,7 @@ div#wbtm_date_start_route { height: 50px; }
                 <?php echo esc_html__('buses available for', 'bus-ticket-booking-with-seat-reservation'); ?>
                 <?php echo esc_html(date_i18n('F j', strtotime($date))); ?>
             </div>
+            <?php if ($wbtm_fd_sort) : ?>
             <div class="wbtm-list-sort">
                 <label for="wbtm_sort_select" class="wbtm-sort-label-text">
                     <?php esc_html_e('Sort by', 'bus-ticket-booking-with-seat-reservation'); ?>:
@@ -1184,6 +1200,7 @@ div#wbtm_date_start_route { height: 50px; }
                     <option value="duration_asc"><?php esc_html_e('Shortest Duration', 'bus-ticket-booking-with-seat-reservation'); ?></option>
                 </select>
             </div>
+            <?php endif; ?>
         </div>
 
         <?php foreach ($bus_data as $key => $bus) :

--- a/templates/layout/search_result_flix.php
+++ b/templates/layout/search_result_flix.php
@@ -104,7 +104,10 @@ if (sizeof($bus_ids) > 0) {
                 </div>
             </div>
         </div>
-        <?php if( !empty($left_filter_show['left_filter_input']) && $left_filter_show['left_filter_input'] === 'on' && count( $bus_titles ) > 0 ){
+        <?php
+        // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+        $wbtm_fd_panel = WBTM_Global_Function::get_settings('wbtm_frontend_display_settings', 'show_filter_panel', 'show') !== 'hide';
+        if( $wbtm_fd_panel && !empty($left_filter_show['left_filter_input']) && $left_filter_show['left_filter_input'] === 'on' && count( $bus_titles ) > 0 ){
             // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
             $width = 'calc( 100% - 180px )'
             ?>

--- a/templates/layout/search_result_flix.php
+++ b/templates/layout/search_result_flix.php
@@ -40,6 +40,12 @@ if (sizeof($bus_ids) > 0) {
     // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
     $wbtm_price_leg = ( $journey_type === 'return_journey' ) ? 'return' : 'outbound';
 
+    // Unpriced-route handling (Global Settings -> Frontend Display -> Unpriced Routes).
+    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+    $wbtm_unpriced_action = WBTM_Global_Function::get_settings('wbtm_frontend_display_settings', 'unpriced_route_action', 'message');
+    // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+    $wbtm_unpriced_msg = WBTM_Global_Function::get_settings('wbtm_frontend_display_settings', 'unpriced_route_message', __('This route is not currently available for booking.', 'bus-ticket-booking-with-seat-reservation'));
+
     foreach ($bus_ids as $bus_id) {
         // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
         $wbtm_price_leg = WBTM_Functions::resolve_price_leg_for_od_pair(
@@ -52,10 +58,16 @@ if (sizeof($bus_ids) > 0) {
         $all_info = WBTM_Functions::get_bus_all_info($bus_id, $date, $start_route, $end_route, $wbtm_price_leg);
         if (sizeof($all_info) > 0) {
             // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+            $route_priced = ($all_info['price'] !== false);
+            if (!$route_priced && $wbtm_unpriced_action === 'hide') {
+                continue;
+            }
+            // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
             $bus_data[] = [
                 'bus_id'   => $bus_id,
                 'all_info' => $all_info,
                 'price_leg' => $wbtm_price_leg,
+                'route_priced' => $route_priced,
             ];
             // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
             $bus_titles[] = get_the_title($bus_id);
@@ -160,6 +172,8 @@ if (sizeof($bus_ids) > 0) {
 			$bus_count++;
             // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 			$price = $all_info['price'];
+            // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+            $route_priced = array_key_exists('route_priced', $bus) ? $bus['route_priced'] : true;
 
             $bus_boarding_routes = WBTM_Functions::get_bus_route( $bus_id );
 
@@ -247,7 +261,14 @@ if (sizeof($bus_ids) > 0) {
                         </div>
                     </div>
                     <div class="price">
-                        <h4 class="textTheme"><?php echo wp_kses_post( wc_price($price) ); ?></h4>
+                        <?php if ( $route_priced ) { ?>
+                            <h4 class="textTheme"><?php echo wp_kses_post( wc_price($price) ); ?></h4>
+                        <?php } else { ?>
+                            <div class="wbtm-route-unavailable">
+                                <i class="fas fa-circle-info" aria-hidden="true"></i>
+                                <span><?php echo esc_html( $wbtm_unpriced_msg ); ?></span>
+                            </div>
+                        <?php } ?>
                     </div>
 
                 </div>
@@ -272,6 +293,7 @@ if (sizeof($bus_ids) > 0) {
                         WBTM_Layout::trigger_view_seat_details();
                     }
                     ?>
+                    <?php if ( $route_priced ) { ?>
                     <div class="wbtm-seat-book <?php echo esc_attr( $btn_show ); ?>">
 						<?php echo WBTM_Functions::full_bus_booking_button( $bus_id, $all_info, $date, $wbtm_price_leg ); ?>
                         <button type="button" class="_themeButton_xs" id="get_wbtm_bus_details"
@@ -283,6 +305,7 @@ if (sizeof($bus_ids) > 0) {
                             <?php echo esc_html(WBTM_Translations::text_view_seat()); ?>
                         </button>
                     </div>
+                    <?php } ?>
                 </div>
 			</div>
 


### PR DESCRIPTION


Adds a new "Frontend Display" tab under Bus -> Settings (Global Settings) that lets operators show or hide each search-result filter. Requested because operators who do not run time-of-day shuttles need to hide the Departure Time (Morning/Afternoon/Evening/Night) filter, which was otherwise misleading to customers.

New option `wbtm_frontend_display_settings` (values `show`/`hide`, every key defaults to `show`, so existing sites are unchanged until toggled):
  - show_filter_panel          master; hides the whole Filters sidebar
                               (the bus list then spans full width)
  - show_filter_departure_time Morning/Afternoon/Evening/Night filter
  - show_filter_bus_type       AC / Non-AC bus-type filter
  - show_filter_bus_operator   operator / bus-name filter
  - show_filter_boarding_point boarding-location filter
  - show_sort_bar              "Sort by: Earliest First" dropdown

Admin (admin/WBTM_Global_settings.php):
  - Register the section in global_sec_reg(), fields in settings_sec_fields(), the tab in get_tab_configs(), and the card layout in get_card_groups().
  - New `toggle` field type and `toggles` card layout, rendered as modern iOS-style switches in a compact grid (render_toggle_item()).
  - Toggles use a hidden `value="hide"` + checkbox `value="show"` pair sharing the same name, so an OFF state is ALWAYS submitted. This avoids the classic WordPress bug where an unchecked checkbox is absent from POST and silently reverts to its saved/default value.

Setting API (mp_global/class/WBTM_Setting_API.php):
  - Add a defensive callback_toggle() so the legacy settings renderer is safe if it ever renders this field type via do_settings_sections().

Styling (assets/admin/css/wbtm-global-settings.css):
  - Add .bm-gs__toggle-grid / .bm-gs__toggle-item / .bm-gs__switch styles.
  - Nest the Font Awesome glyph in an <i> inside the icon badge so FA's own `.fas{display:inline-block}` cannot override the badge's flex centering (it was pushing the icon to the badge's top-left corner).

Frontend wiring (all additive AND-conditions; default `show` = no change):
  - templates/layout/search_result.php (the active classic template): gate the sidebar master, each of the four filter sections, and the sort bar on the new settings.
  - templates/layout/search_result_flix.php and the shared helper WBTM_Functions::wbtm_left_filter_disppaly(): gate the sidebar master and the bus-type / operator / boarding sections for consistency.

Also (hotfix): strip a stray UTF-8 BOM (3 bytes) from admin/settings/WTBM_Features_Seating.php that caused the "plugin generated 3 characters of unexpected output during activation" / "headers already sent" warning on activation.