### PR TITLE
feat(bus-list): add auto-detected SEO score column to Bus List

### DIFF
--- a/admin/WBTM_Bus_List.php
+++ b/admin/WBTM_Bus_List.php
@@ -249,8 +249,14 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 					array(),
 					null
 				);
-				wp_enqueue_style( 'wbtm_bus_list', WBTM_PLUGIN_URL . '/assets/admin/wbtm_bus_list.css', array(), WBTM_VERSION );
-				wp_enqueue_script( 'wbtm_bus_list', WBTM_PLUGIN_URL . '/assets/admin/wbtm_bus_list.js', array( 'jquery' ), WBTM_VERSION, true );
+				// Version assets by file mtime so edits bust the browser cache
+				// (falls back to the plugin version if the file can't be stat'd).
+				$css_path = WBTM_PLUGIN_DIR . '/assets/admin/wbtm_bus_list.css';
+				$js_path  = WBTM_PLUGIN_DIR . '/assets/admin/wbtm_bus_list.js';
+				$css_ver  = file_exists( $css_path ) ? filemtime( $css_path ) : WBTM_VERSION;
+				$js_ver   = file_exists( $js_path ) ? filemtime( $js_path ) : WBTM_VERSION;
+				wp_enqueue_style( 'wbtm_bus_list', WBTM_PLUGIN_URL . '/assets/admin/wbtm_bus_list.css', array(), $css_ver );
+				wp_enqueue_script( 'wbtm_bus_list', WBTM_PLUGIN_URL . '/assets/admin/wbtm_bus_list.js', array( 'jquery' ), $js_ver, true );
 			}
 
 			/**
@@ -265,6 +271,13 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 					'order'          => 'DESC',
 					'no_found_rows'  => true,
 				) );
+				// SEO column data is only gathered when a supported SEO plugin is
+				// active; AIOSEO stores scores in a custom table, so prime them once.
+				$provider   = $this->seo_provider();
+				$aioseo_map = ( $provider && $provider['key'] === 'aioseo' )
+					? $this->aioseo_scores( wp_list_pluck( $query->posts, 'ID' ) )
+					: array();
+
 				$buses = array();
 				foreach ( $query->posts as $post ) {
 					$pid       = $post->ID;
@@ -302,6 +315,7 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 						'trash_link'   => get_delete_post_link( $pid ),
 						'restore_link' => wp_nonce_url( admin_url( sprintf( 'post.php?post=%d&action=untrash', $pid ) ), 'untrash-post_' . $pid ),
 						'delete_link'  => get_delete_post_link( $pid, '', true ),
+						'seo'          => $provider ? $this->get_seo_data( $pid, $provider, $aioseo_map ) : null,
 						'duplicate_link' => wp_nonce_url(
 							admin_url( sprintf( 'admin.php?action=wbtm_duplicate_bus&post=%d', $pid ) ),
 							'wbtm_duplicate_bus_' . $pid
@@ -417,6 +431,210 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 				}
 			}
 
+			/**
+			 * Detect which SEO plugin is active, if any. Result is cached for the
+			 * request so the constant/function checks only run once.
+			 *
+			 * @return array|null { key: yoast|aioseo|rankmath, label: string } or null.
+			 */
+			private function seo_provider() {
+				static $provider = false; // false = not resolved yet, null = none active.
+				if ( $provider !== false ) {
+					return $provider;
+				}
+				if ( defined( 'WPSEO_VERSION' ) ) {
+					$provider = array( 'key' => 'yoast', 'label' => 'Yoast SEO' );
+				} elseif ( defined( 'AIOSEO_VERSION' ) || function_exists( 'aioseo' ) ) {
+					$provider = array( 'key' => 'aioseo', 'label' => 'All in One SEO' );
+				} elseif ( defined( 'RANK_MATH_VERSION' ) || class_exists( 'RankMath', false ) ) {
+					$provider = array( 'key' => 'rankmath', 'label' => 'Rank Math' );
+				} else {
+					$provider = null;
+				}
+
+				return $provider;
+			}
+
+			/**
+			 * Fetch All in One SEO (v4) scores for a set of posts in one query.
+			 * AIOSEO keeps its per-post data in a custom table, so we prime a map
+			 * keyed by post ID instead of querying once per row.
+			 *
+			 * @param int[] $ids Post IDs.
+			 * @return array<int,array> Map of post_id => row.
+			 */
+			private function aioseo_scores( array $ids ): array {
+				global $wpdb;
+				$ids = array_values( array_filter( array_map( 'absint', $ids ) ) );
+				if ( empty( $ids ) ) {
+					return array();
+				}
+				$table = $wpdb->prefix . 'aioseo_posts';
+				// Bail quietly if AIOSEO is detected but its table isn't there yet.
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+				if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) !== $table ) {
+					return array();
+				}
+				$in = implode( ',', $ids ); // Ints only — safe to inline.
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$rows = $wpdb->get_results( "SELECT post_id, seo_score, title, description, keyphrases FROM {$table} WHERE post_id IN ({$in})", ARRAY_A );
+				$map  = array();
+				if ( $rows ) {
+					foreach ( $rows as $row ) {
+						$map[ (int) $row['post_id'] ] = $row;
+					}
+				}
+
+				return $map;
+			}
+
+			/**
+			 * Normalised SEO snapshot for one post, read from the active plugin.
+			 *
+			 * @param int        $post_id    Bus post ID.
+			 * @param array      $provider   Result of seo_provider().
+			 * @param array<int,array> $aioseo_map Pre-fetched AIOSEO rows (AIOSEO only).
+			 * @return array
+			 */
+			private function get_seo_data( $post_id, array $provider, array $aioseo_map = array() ): array {
+				$data = array(
+					'analyzed'  => false,
+					'score'     => null,
+					'rating'    => 'na',
+					'label'     => esc_html__( 'Not analyzed', 'bus-ticket-booking-with-seat-reservation' ),
+					'keyword'   => '',
+					'has_desc'  => false,
+					'has_title' => false,
+					'provider'  => $provider['label'],
+				);
+
+				switch ( $provider['key'] ) {
+					case 'yoast':
+						$raw               = get_post_meta( $post_id, '_yoast_wpseo_linkdex', true );
+						$data['keyword']   = (string) get_post_meta( $post_id, '_yoast_wpseo_focuskw', true );
+						$data['has_desc']  = get_post_meta( $post_id, '_yoast_wpseo_metadesc', true ) !== '';
+						$data['has_title'] = get_post_meta( $post_id, '_yoast_wpseo_title', true ) !== '';
+						if ( $raw !== '' && $raw !== false ) {
+							$data['analyzed'] = true;
+							$data['score']    = (int) $raw;
+						}
+						break;
+
+					case 'aioseo':
+						$row = $aioseo_map[ $post_id ] ?? null;
+						if ( $row ) {
+							if ( isset( $row['seo_score'] ) && $row['seo_score'] !== null && $row['seo_score'] !== '' ) {
+								$data['analyzed'] = true;
+								$data['score']    = (int) $row['seo_score'];
+							}
+							$data['has_desc']  = ! empty( $row['description'] );
+							$data['has_title'] = ! empty( $row['title'] );
+							$keyphrases        = json_decode( (string) ( $row['keyphrases'] ?? '' ), true );
+							if ( is_array( $keyphrases ) && ! empty( $keyphrases['focus']['keyphrase'] ) ) {
+								$data['keyword'] = (string) $keyphrases['focus']['keyphrase'];
+							}
+						}
+						break;
+
+					case 'rankmath':
+						$raw = get_post_meta( $post_id, 'rank_math_seo_score', true );
+						$kw  = (string) get_post_meta( $post_id, 'rank_math_focus_keyword', true );
+						if ( $kw !== '' ) {
+							$parts           = explode( ',', $kw ); // Comma-list; first is primary.
+							$data['keyword'] = trim( $parts[0] );
+						}
+						$data['has_desc']  = get_post_meta( $post_id, 'rank_math_description', true ) !== '';
+						$data['has_title'] = get_post_meta( $post_id, 'rank_math_title', true ) !== '';
+						if ( $raw !== '' && $raw !== false ) {
+							$data['analyzed'] = true;
+							$data['score']    = (int) $raw;
+						}
+						break;
+				}
+
+				if ( $data['analyzed'] ) {
+					$rating         = $this->seo_rating( (int) $data['score'], $provider['key'] );
+					$data['rating'] = $rating['rating'];
+					$data['label']  = $rating['label'];
+				}
+
+				return $data;
+			}
+
+			/**
+			 * Map a 0-100 score to a rating + label using each plugin's own colour
+			 * bands (so the badge matches what the user sees inside that plugin).
+			 * A score of 0 (no focus keyword / not measurable) falls through to "na".
+			 */
+			private function seo_rating( int $score, string $key ): array {
+				$good = esc_html__( 'Good', 'bus-ticket-booking-with-seat-reservation' );
+				$ok   = esc_html__( 'Needs work', 'bus-ticket-booking-with-seat-reservation' );
+				$bad  = esc_html__( 'Poor', 'bus-ticket-booking-with-seat-reservation' );
+				$na   = esc_html__( 'Not analyzed', 'bus-ticket-booking-with-seat-reservation' );
+
+				switch ( $key ) {
+					case 'aioseo':
+						if ( $score >= 80 ) { return array( 'rating' => 'good', 'label' => $good ); }
+						if ( $score >= 50 ) { return array( 'rating' => 'ok', 'label' => $ok ); }
+						if ( $score > 0 )   { return array( 'rating' => 'bad', 'label' => $bad ); }
+						break;
+					case 'rankmath':
+						if ( $score > 80 ) { return array( 'rating' => 'good', 'label' => $good ); }
+						if ( $score > 50 ) { return array( 'rating' => 'ok', 'label' => $ok ); }
+						if ( $score > 0 )  { return array( 'rating' => 'bad', 'label' => $bad ); }
+						break;
+					default: // Yoast bands: 71-100 good, 41-70 ok, 1-40 bad.
+						if ( $score > 70 ) { return array( 'rating' => 'good', 'label' => $good ); }
+						if ( $score > 40 ) { return array( 'rating' => 'ok', 'label' => $ok ); }
+						if ( $score > 0 )  { return array( 'rating' => 'bad', 'label' => $bad ); }
+				}
+
+				return array( 'rating' => 'na', 'label' => $na );
+			}
+
+			/**
+			 * Render the SEO cell: a circular score gauge plus signal chips
+			 * (focus keyword / meta description) and the source plugin name.
+			 */
+			private function seo_cell( array $seo ): void {
+				$rating    = $seo['rating'];
+				$has_score = $rating !== 'na' && $seo['score'] !== null;
+				$score     = (int) $seo['score'];
+				$radius    = 15.5;
+				$circ      = 2 * M_PI * $radius;
+				$pct       = $has_score ? max( 0, min( 100, $score ) ) : 0;
+				$offset    = round( $circ * ( 1 - $pct / 100 ), 2 );
+
+				$tip = array( $seo['provider'] . ': ' . $seo['label'] . ( $has_score ? ' (' . $score . '/100)' : '' ) );
+				$tip[] = $seo['keyword'] !== ''
+					? sprintf( esc_html__( 'Focus keyword: %s', 'bus-ticket-booking-with-seat-reservation' ), $seo['keyword'] )
+					: esc_html__( 'No focus keyword set', 'bus-ticket-booking-with-seat-reservation' );
+				$tip[] = $seo['has_desc']
+					? esc_html__( 'Meta description: set', 'bus-ticket-booking-with-seat-reservation' )
+					: esc_html__( 'Meta description: missing', 'bus-ticket-booking-with-seat-reservation' );
+				?>
+				<div class="wbtm-seo wbtm-seo-<?php echo esc_attr( $rating ); ?>" title="<?php echo esc_attr( implode( "\n", $tip ) ); ?>">
+					<span class="wbtm-seo-ring">
+						<svg viewBox="0 0 40 40" width="40" height="40" aria-hidden="true">
+							<circle class="wbtm-seo-track" cx="20" cy="20" r="<?php echo esc_attr( $radius ); ?>" fill="none" stroke-width="4"/>
+							<?php if ( $has_score ) : ?>
+								<circle class="wbtm-seo-bar" cx="20" cy="20" r="<?php echo esc_attr( $radius ); ?>" fill="none" stroke-width="4" stroke-linecap="round" stroke-dasharray="<?php echo esc_attr( round( $circ, 2 ) ); ?>" stroke-dashoffset="<?php echo esc_attr( $offset ); ?>" transform="rotate(-90 20 20)"/>
+							<?php endif; ?>
+						</svg>
+						<span class="wbtm-seo-score"><?php echo $has_score ? esc_html( $score ) : '&ndash;'; ?></span>
+					</span>
+					<span class="wbtm-seo-meta">
+						<span class="wbtm-seo-label"><?php echo esc_html( $seo['label'] ); ?></span>
+						<span class="wbtm-seo-signals">
+							<span class="wbtm-seo-chip <?php echo $seo['keyword'] !== '' ? 'on' : 'off'; ?>" title="<?php echo esc_attr( $seo['keyword'] !== '' ? sprintf( esc_html__( 'Focus keyword: %s', 'bus-ticket-booking-with-seat-reservation' ), $seo['keyword'] ) : esc_html__( 'No focus keyword set', 'bus-ticket-booking-with-seat-reservation' ) ); ?>"><?php esc_html_e( 'KW', 'bus-ticket-booking-with-seat-reservation' ); ?></span>
+							<span class="wbtm-seo-chip <?php echo $seo['has_desc'] ? 'on' : 'off'; ?>" title="<?php echo esc_attr( $seo['has_desc'] ? esc_html__( 'Meta description set', 'bus-ticket-booking-with-seat-reservation' ) : esc_html__( 'Meta description missing', 'bus-ticket-booking-with-seat-reservation' ) ); ?>"><?php esc_html_e( 'Desc', 'bus-ticket-booking-with-seat-reservation' ); ?></span>
+						</span>
+						<span class="wbtm-seo-provider"><?php echo esc_html( $seo['provider'] ); ?></span>
+					</span>
+				</div>
+				<?php
+			}
+
 			public function render_page() {
 				$name = WBTM_Functions::get_name();
 				// phpcs:ignore WordPress.Security.NonceVerification.Recommended
@@ -445,6 +663,7 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 				$trash         = isset( $status_counts->trash ) ? (int) $status_counts->trash : 0;
 
 				$buses     = $is_trash ? $this->get_buses( array( 'trash' ) ) : $active;
+				$seo_provider = $this->seo_provider();
 				$base_url  = admin_url( 'admin.php?page=' . self::PAGE_SLUG );
 				$trash_url = add_query_arg( 'wbtm_status', 'trash', $base_url );
 				$add_url   = admin_url( 'post-new.php?post_type=wbtm_bus' );
@@ -545,6 +764,9 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 									<th><?php printf( esc_html__( '%s Type', 'bus-ticket-booking-with-seat-reservation' ), esc_html( $name ) ); ?></th>
 									<th><?php echo esc_html( WBTM_Translations::text_coach_type() ); ?></th>
 									<th><?php esc_html_e( 'Status', 'bus-ticket-booking-with-seat-reservation' ); ?></th>
+									<?php if ( $seo_provider ) : ?>
+										<th title="<?php echo esc_attr( sprintf( esc_html__( 'SEO score from %s', 'bus-ticket-booking-with-seat-reservation' ), $seo_provider['label'] ) ); ?>"><?php esc_html_e( 'SEO', 'bus-ticket-booking-with-seat-reservation' ); ?></th>
+									<?php endif; ?>
 									<th><?php esc_html_e( 'Actions', 'bus-ticket-booking-with-seat-reservation' ); ?></th>
 								</tr>
 							</thead>
@@ -576,6 +798,9 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 										<td data-label="<?php esc_attr_e( 'Type', 'bus-ticket-booking-with-seat-reservation' ); ?>"><span class="wbtm-t-badge type"><?php echo esc_html( $b['bus_type'] ); ?></span></td>
 										<td data-label="<?php esc_attr_e( 'Coach', 'bus-ticket-booking-with-seat-reservation' ); ?>"><?php if ( $b['type'] ) : ?><span class="wbtm-t-badge <?php echo $b['is_ac'] ? 'ac' : 'nonac'; ?>"><?php echo esc_html( $b['type'] ); ?></span><?php else : ?>-<?php endif; ?></td>
 										<td data-label="<?php esc_attr_e( 'Status', 'bus-ticket-booking-with-seat-reservation' ); ?>"><span class="wbtm-status-dot status-<?php echo esc_attr( $b['status'] ); ?>"><?php echo esc_html( $this->status_label( $b['status'] ) ); ?></span></td>
+										<?php if ( $seo_provider ) : ?>
+											<td class="wbtm-seo-cell" data-label="<?php esc_attr_e( 'SEO', 'bus-ticket-booking-with-seat-reservation' ); ?>"><?php if ( ! empty( $b['seo'] ) ) { $this->seo_cell( $b['seo'] ); } else { echo '-'; } ?></td>
+										<?php endif; ?>
 										<td data-label="<?php esc_attr_e( 'Actions', 'bus-ticket-booking-with-seat-reservation' ); ?>">
 											<div class="wbtm-table-actions">
 											<?php if ( $is_trash ) : ?>

--- a/assets/admin/wbtm_bus_list.css
+++ b/assets/admin/wbtm_bus_list.css
@@ -197,6 +197,29 @@
 /* Grid card variant */
 .wbtm-bus-body .wbtm-name-extra{margin-bottom:12px;padding-top:2px;}
 
+/* SEO COLUMN */
+.wbtm-seo{display:inline-flex;align-items:center;gap:10px;}
+.wbtm-seo-ring{position:relative;width:40px;height:40px;flex:0 0 auto;}
+.wbtm-seo-ring svg{display:block;width:40px;height:40px;}
+.wbtm-seo-track{stroke:var(--wbtm-border);}
+.wbtm-seo-bar{transition:stroke-dashoffset .4s ease;}
+.wbtm-seo-score{position:absolute;inset:0;display:flex;align-items:center;justify-content:center;font-size:12px;font-weight:800;color:var(--wbtm-ink);line-height:1;}
+.wbtm-seo-meta{display:flex;flex-direction:column;gap:3px;min-width:0;}
+.wbtm-seo-label{font-size:12px;font-weight:700;line-height:1;color:var(--wbtm-ink2);}
+.wbtm-seo-signals{display:inline-flex;gap:4px;}
+.wbtm-seo-chip{font-size:9px;font-weight:700;letter-spacing:.04em;text-transform:uppercase;padding:2px 6px;border-radius:5px;background:var(--wbtm-bg);color:var(--wbtm-muted);line-height:1.3;}
+.wbtm-seo-chip.on{background:var(--wbtm-green-soft);color:var(--wbtm-green);}
+.wbtm-seo-chip.off{background:var(--wbtm-bg);color:var(--wbtm-muted);}
+.wbtm-seo-provider{font-size:10px;color:var(--wbtm-muted);font-weight:500;line-height:1;}
+.wbtm-seo-good .wbtm-seo-bar{stroke:var(--wbtm-green);}
+.wbtm-seo-good .wbtm-seo-score,.wbtm-seo-good .wbtm-seo-label{color:var(--wbtm-green);}
+.wbtm-seo-ok .wbtm-seo-bar{stroke:var(--wbtm-orange);}
+.wbtm-seo-ok .wbtm-seo-score,.wbtm-seo-ok .wbtm-seo-label{color:var(--wbtm-orange);}
+.wbtm-seo-bad .wbtm-seo-bar{stroke:var(--wbtm-red);}
+.wbtm-seo-bad .wbtm-seo-score,.wbtm-seo-bad .wbtm-seo-label{color:var(--wbtm-red);}
+.wbtm-seo-na .wbtm-seo-track{stroke-dasharray:3 3;}
+.wbtm-seo-na .wbtm-seo-score,.wbtm-seo-na .wbtm-seo-label{color:var(--wbtm-muted);}
+
 /* PAGINATION */
 .wbtm-pagination{display:flex;align-items:center;justify-content:space-between;gap:12px;margin-top:24px;flex-wrap:wrap;}
 .wbtm-page-info{font-size:13px;color:var(--wbtm-muted);}


### PR DESCRIPTION
Add an "SEO" column to the new responsive Bus List screen that surfaces each bus's SEO health directly in the fleet table, sourced from whichever SEO plugin is active. The column renders only when a supported plugin is detected, so the table stays clean otherwise.

Supported providers (auto-detected, in priority order):
  - Yoast SEO      -> _yoast_wpseo_linkdex score + focus keyword /
                      meta description / SEO title meta
  - All in One SEO -> wp_aioseo_posts table (seo_score, keyphrases,
                      description); scores prefetched in ONE batched query
                      keyed by post ID, guarded by SHOW TABLES LIKE
  - Rank Math      -> rank_math_seo_score + focus keyword / description /
                      title meta

Display (seo_cell): a circular SVG score gauge with the number centered, colored by rating using each plugin's own color bands (Good / Needs work / Poor / Not analyzed), two signal chips (KW = focus keyword set, Desc = meta description set) that light up green when present, and the source plugin name. A score of 0 or missing data renders as a dashed grey "Not analyzed" gauge. Full breakdown shown on hover via the title attr.

Also switch the two Bus List admin assets (wbtm_bus_list.css/js) to filemtime()-based versioning (fallback to WBTM_VERSION) so edits bust the browser cache automatically on the next normal reload, in dev and on customer sites after updates.

Details / decisions:
  - Column appears only when an SEO plugin is active (matches request: show when Yoast / AIOSEO active).
  - Provider detection cached per request via a static var.
  - Yoast / Rank Math read post meta already primed by the existing WP_Query, so zero extra queries; only AIOSEO adds a single batched query because it stores data in a custom table.
  - All output escaped (esc_attr / esc_html); post IDs absint()'d before the IN() clause; table-existence guarded to avoid errors when AIOSEO is active but its table is absent.
  - No changes to the classic list, filtering JS (keys off data-* attrs with no hardcoded column count), or any existing behavior. New column slots between Status and Actions and inherits the responsive stacked (mobile) layout via its data-label.

Files:
  - admin/WBTM_Bus_List.php: seo_provider(), aioseo_scores(), get_seo_data(), seo_rating(), seo_cell(); SEO data attached in get_buses(); conditional header + cell in render_page(); filemtime asset versioning in enqueue_assets().
  - assets/admin/wbtm_bus_list.css: scoped .wbtm-seo* styles reusing the existing design tokens (green/orange/red/muted), incl. mobile view.