### PR TITLE
fix(search-results): keep "Sort by" on one line + modernize Filters t…

### DIFF
--- a/assets/frontend/wtbm_search.css
+++ b/assets/frontend/wtbm_search.css
@@ -425,6 +425,43 @@
    Desktop/laptop (>=768px) is untouched: button hidden, sidebar as-is. */
 .wbtm-mobile-filter-toggle {
     display: none;
+    /* Modern styling kept OUT of the mobile media query so the button looks good
+       wherever it is shown (it also appears on the desktop results header). Only
+       the display toggle is size-dependent. */
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    background: #fff;
+    border: 1px solid #e4e7ec;
+    border-radius: 12px;
+    padding: 11px 16px;
+    font-size: 14px;
+    font-weight: 700;
+    color: #101828;
+    cursor: pointer;
+    box-shadow: 0 1px 3px rgba(16, 24, 40, .06);
+    transition: border-color .15s ease, box-shadow .15s ease, background .15s ease;
+}
+.wbtm-mobile-filter-toggle:hover {
+    border-color: var(--wbtm_color_theme, #e8510f);
+    box-shadow: 0 4px 12px rgba(16, 24, 40, .10);
+}
+.wbtm-mobile-filter-toggle .wbtm-mobile-filter-toggle-label {
+    display: flex;
+    align-items: center;
+    gap: 8px;
+}
+.wbtm-mobile-filter-toggle .wbtm-mobile-filter-toggle-label i,
+.wbtm-mobile-filter-toggle .wbtm-mobile-filter-toggle-label svg {
+    color: var(--wbtm_color_theme, #e8510f);
+}
+.wbtm-mobile-filter-caret {
+    font-size: 12px;
+    color: #98a2b3;
+    transition: transform .2s ease;
+}
+.wbtm_bus_left_filter_holder.wbtm-mobile-open .wbtm-mobile-filter-caret {
+    transform: rotate(180deg);
 }
 
 @media only screen and (max-width: 767px) {

--- a/templates/layout/search_result.php
+++ b/templates/layout/search_result.php
@@ -607,9 +607,11 @@ div#wbtm_date_start_route { height: 50px; }
     color:      #666;
     display:    flex;
     align-items: center;
-    gap:        5px;
+    gap:        8px;
+    flex-shrink: 0;
+    white-space: nowrap;
 }
-.wbtm-sort-label-text { font-weight: 600; color: #222; }
+.wbtm-sort-label-text { font-weight: 600; color: #222; white-space: nowrap; }
 .wbtm-sort-select {
     padding: 6px 28px 6px 10px;
     border: 1px solid #d8dcea;


### PR DESCRIPTION
…oggle

Two fixes to the shared frontend results toolbar (search_result.php), which also shows on the admin Purchase Ticket page.

- Sort by wrapped: the "Sort by:" label broke onto two lines ("Sort" / "by:") because .wbtm-list-sort could shrink and the label could wrap. Added white-space:nowrap to the label and .wbtm-list-sort, plus flex-shrink:0 so the whole control stays inline on one row. Verified the label height dropped from 34px (two lines) to 17px (one line) at both 1400px and 420px.

- Filters toggle looked unstyled on desktop: the .wbtm-mobile-filter-toggle button also renders in the desktop results header, but ALL of its styling lived inside the max-width:767px media query, so on wider screens it fell back to a plain browser button. Moved the visual styling (white card, border, radius, padding, theme-coloured icon, hover, caret) to the base rule so it looks modern wherever it appears; the media query still owns only the size-dependent bits (display + full-width bar on mobile).

Verified on the live frontend (bus-global-search) at desktop and mobile: sort is inline, the Filters button is a modern card, no regressions.