### PR TITLE
feat(admin): add conditional SEO workflow to modern editor

### DIFF
--- a/admin/WBTM_Admin.php
+++ b/admin/WBTM_Admin.php
@@ -45,6 +45,8 @@
 				require_once WBTM_PLUGIN_DIR . '/admin/settings/WBTM_Term_Condition_Setting.php';
 				require_once WBTM_PLUGIN_DIR . '/admin/settings/WTBM_Term_Condition_Add_Bus.php';
 				require_once WBTM_PLUGIN_DIR . '/admin/settings/WTBM_Features_Seating.php';
+				//========Provider-neutral Rank Math / Yoast / AIOSEO integration==========//
+				require_once WBTM_PLUGIN_DIR . '/admin/WBTM_SEO.php';
 				//========Modern bus editor (parallel to classic; per-user opt-in)==========//
 				require_once WBTM_PLUGIN_DIR . '/admin/settings-modern/WBTM_Settings_Modern.php';
 				//========Modern Bus Type taxonomy screen (edit-tags.php / term.php)========//

--- a/admin/WBTM_Bus_List.php
+++ b/admin/WBTM_Bus_List.php
@@ -455,21 +455,7 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 			 * @return array|null { key: yoast|aioseo|rankmath, label: string } or null.
 			 */
 			private function seo_provider() {
-				static $provider = false; // false = not resolved yet, null = none active.
-				if ( $provider !== false ) {
-					return $provider;
-				}
-				if ( defined( 'WPSEO_VERSION' ) ) {
-					$provider = array( 'key' => 'yoast', 'label' => 'Yoast SEO' );
-				} elseif ( defined( 'AIOSEO_VERSION' ) || function_exists( 'aioseo' ) ) {
-					$provider = array( 'key' => 'aioseo', 'label' => 'All in One SEO' );
-				} elseif ( defined( 'RANK_MATH_VERSION' ) || class_exists( 'RankMath', false ) ) {
-					$provider = array( 'key' => 'rankmath', 'label' => 'Rank Math' );
-				} else {
-					$provider = null;
-				}
-
-				return $provider;
+				return class_exists( 'WBTM_SEO' ) ? WBTM_SEO::provider() : null;
 			}
 
 			/**
@@ -481,28 +467,7 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 			 * @return array<int,array> Map of post_id => row.
 			 */
 			private function aioseo_scores( array $ids ): array {
-				global $wpdb;
-				$ids = array_values( array_filter( array_map( 'absint', $ids ) ) );
-				if ( empty( $ids ) ) {
-					return array();
-				}
-				$table = $wpdb->prefix . 'aioseo_posts';
-				// Bail quietly if AIOSEO is detected but its table isn't there yet.
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery
-				if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) !== $table ) {
-					return array();
-				}
-				$in = implode( ',', $ids ); // Ints only — safe to inline.
-				// phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
-				$rows = $wpdb->get_results( "SELECT post_id, seo_score, title, description, keyphrases FROM {$table} WHERE post_id IN ({$in})", ARRAY_A );
-				$map  = array();
-				if ( $rows ) {
-					foreach ( $rows as $row ) {
-						$map[ (int) $row['post_id'] ] = $row;
-					}
-				}
-
-				return $map;
+				return class_exists( 'WBTM_SEO' ) ? WBTM_SEO::aioseo_scores( $ids ) : array();
 			}
 
 			/**
@@ -514,99 +479,7 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 			 * @return array
 			 */
 			private function get_seo_data( $post_id, array $provider, array $aioseo_map = array() ): array {
-				$data = array(
-					'analyzed'  => false,
-					'score'     => null,
-					'rating'    => 'na',
-					'label'     => esc_html__( 'Not analyzed', 'bus-ticket-booking-with-seat-reservation' ),
-					'keyword'   => '',
-					'has_desc'  => false,
-					'has_title' => false,
-					'provider'  => $provider['label'],
-				);
-
-				switch ( $provider['key'] ) {
-					case 'yoast':
-						$raw               = get_post_meta( $post_id, '_yoast_wpseo_linkdex', true );
-						$data['keyword']   = (string) get_post_meta( $post_id, '_yoast_wpseo_focuskw', true );
-						$data['has_desc']  = get_post_meta( $post_id, '_yoast_wpseo_metadesc', true ) !== '';
-						$data['has_title'] = get_post_meta( $post_id, '_yoast_wpseo_title', true ) !== '';
-						if ( $raw !== '' && $raw !== false ) {
-							$data['analyzed'] = true;
-							$data['score']    = (int) $raw;
-						}
-						break;
-
-					case 'aioseo':
-						$row = $aioseo_map[ $post_id ] ?? null;
-						if ( $row ) {
-							if ( isset( $row['seo_score'] ) && $row['seo_score'] !== null && $row['seo_score'] !== '' ) {
-								$data['analyzed'] = true;
-								$data['score']    = (int) $row['seo_score'];
-							}
-							$data['has_desc']  = ! empty( $row['description'] );
-							$data['has_title'] = ! empty( $row['title'] );
-							$keyphrases        = json_decode( (string) ( $row['keyphrases'] ?? '' ), true );
-							if ( is_array( $keyphrases ) && ! empty( $keyphrases['focus']['keyphrase'] ) ) {
-								$data['keyword'] = (string) $keyphrases['focus']['keyphrase'];
-							}
-						}
-						break;
-
-					case 'rankmath':
-						$raw = get_post_meta( $post_id, 'rank_math_seo_score', true );
-						$kw  = (string) get_post_meta( $post_id, 'rank_math_focus_keyword', true );
-						if ( $kw !== '' ) {
-							$parts           = explode( ',', $kw ); // Comma-list; first is primary.
-							$data['keyword'] = trim( $parts[0] );
-						}
-						$data['has_desc']  = get_post_meta( $post_id, 'rank_math_description', true ) !== '';
-						$data['has_title'] = get_post_meta( $post_id, 'rank_math_title', true ) !== '';
-						if ( $raw !== '' && $raw !== false ) {
-							$data['analyzed'] = true;
-							$data['score']    = (int) $raw;
-						}
-						break;
-				}
-
-				if ( $data['analyzed'] ) {
-					$rating         = $this->seo_rating( (int) $data['score'], $provider['key'] );
-					$data['rating'] = $rating['rating'];
-					$data['label']  = $rating['label'];
-				}
-
-				return $data;
-			}
-
-			/**
-			 * Map a 0-100 score to a rating + label using each plugin's own colour
-			 * bands (so the badge matches what the user sees inside that plugin).
-			 * A score of 0 (no focus keyword / not measurable) falls through to "na".
-			 */
-			private function seo_rating( int $score, string $key ): array {
-				$good = esc_html__( 'Good', 'bus-ticket-booking-with-seat-reservation' );
-				$ok   = esc_html__( 'Needs work', 'bus-ticket-booking-with-seat-reservation' );
-				$bad  = esc_html__( 'Poor', 'bus-ticket-booking-with-seat-reservation' );
-				$na   = esc_html__( 'Not analyzed', 'bus-ticket-booking-with-seat-reservation' );
-
-				switch ( $key ) {
-					case 'aioseo':
-						if ( $score >= 80 ) { return array( 'rating' => 'good', 'label' => $good ); }
-						if ( $score >= 50 ) { return array( 'rating' => 'ok', 'label' => $ok ); }
-						if ( $score > 0 )   { return array( 'rating' => 'bad', 'label' => $bad ); }
-						break;
-					case 'rankmath':
-						if ( $score > 80 ) { return array( 'rating' => 'good', 'label' => $good ); }
-						if ( $score > 50 ) { return array( 'rating' => 'ok', 'label' => $ok ); }
-						if ( $score > 0 )  { return array( 'rating' => 'bad', 'label' => $bad ); }
-						break;
-					default: // Yoast bands: 71-100 good, 41-70 ok, 1-40 bad.
-						if ( $score > 70 ) { return array( 'rating' => 'good', 'label' => $good ); }
-						if ( $score > 40 ) { return array( 'rating' => 'ok', 'label' => $ok ); }
-						if ( $score > 0 )  { return array( 'rating' => 'bad', 'label' => $bad ); }
-				}
-
-				return array( 'rating' => 'na', 'label' => $na );
+				return WBTM_SEO::get_data( $post_id, $provider, $aioseo_map );
 			}
 
 			/**

--- a/admin/WBTM_SEO.php
+++ b/admin/WBTM_SEO.php
@@ -1,0 +1,362 @@
+<?php
+	/**
+	 * SEO plugin adapter and modern bus-editor SEO panel.
+	 *
+	 * Rank Math, Yoast SEO and All in One SEO use different storage. This class
+	 * keeps the bus UI provider-neutral while leaving each SEO plugin as the
+	 * source of truth for its own metadata and analysis score.
+	 */
+	if ( ! defined( 'ABSPATH' ) ) {
+		die;
+	}
+	if ( ! class_exists( 'WBTM_SEO' ) ) {
+		class WBTM_SEO {
+			public function __construct() {
+				add_action( 'save_post_wbtm_bus', array( $this, 'save' ), 30, 2 );
+			}
+
+			/**
+			 * Return the active supported SEO provider.
+			 *
+			 * @return array|null Provider key/label or null when none is active.
+			 */
+			public static function provider() {
+				static $provider = false;
+				if ( $provider !== false ) {
+					return $provider;
+				}
+				if ( defined( 'WPSEO_VERSION' ) ) {
+					$provider = array( 'key' => 'yoast', 'label' => 'Yoast SEO' );
+				} elseif ( defined( 'AIOSEO_VERSION' ) || function_exists( 'aioseo' ) ) {
+					$provider = array( 'key' => 'aioseo', 'label' => 'All in One SEO' );
+				} elseif ( defined( 'RANK_MATH_VERSION' ) || class_exists( 'RankMath', false ) ) {
+					$provider = array( 'key' => 'rankmath', 'label' => 'Rank Math' );
+				} else {
+					$provider = null;
+				}
+
+				return apply_filters( 'wbtm_seo_provider', $provider );
+			}
+
+			/** Fetch AIOSEO rows in one query for the fleet list. */
+			public static function aioseo_scores( array $ids ): array {
+				global $wpdb;
+				$ids = array_values( array_filter( array_map( 'absint', $ids ) ) );
+				if ( empty( $ids ) ) {
+					return array();
+				}
+				$table = $wpdb->prefix . 'aioseo_posts';
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+				if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) !== $table ) {
+					return array();
+				}
+				$in = implode( ',', $ids );
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery, WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+				$rows = $wpdb->get_results( "SELECT post_id, seo_score, title, description, keyphrases, canonical_url FROM {$table} WHERE post_id IN ({$in})", ARRAY_A );
+				$map  = array();
+				foreach ( (array) $rows as $row ) {
+					$map[ (int) $row['post_id'] ] = $row;
+				}
+
+				return $map;
+			}
+
+			/** Return normalized SEO data for one post. */
+			public static function get_data( $post_id, ?array $provider = null, array $aioseo_map = array() ): array {
+				$provider = $provider ?: self::provider();
+				$data     = array(
+					'analyzed'   => false,
+					'score'      => null,
+					'rating'     => 'na',
+					'label'      => esc_html__( 'Not analyzed', 'bus-ticket-booking-with-seat-reservation' ),
+					'keyword'    => '',
+					'title'      => '',
+					'description' => '',
+					'canonical'  => '',
+					'has_desc'   => false,
+					'has_title'  => false,
+					'provider'   => $provider['label'] ?? '',
+					'provider_key' => $provider['key'] ?? '',
+				);
+				if ( ! $provider ) {
+					return $data;
+				}
+				$raw = '';
+
+				switch ( $provider['key'] ) {
+					case 'yoast':
+						$raw                 = get_post_meta( $post_id, '_yoast_wpseo_linkdex', true );
+						$data['keyword']     = (string) get_post_meta( $post_id, '_yoast_wpseo_focuskw', true );
+						$data['title']       = (string) get_post_meta( $post_id, '_yoast_wpseo_title', true );
+						$data['description'] = (string) get_post_meta( $post_id, '_yoast_wpseo_metadesc', true );
+						$data['canonical']   = (string) get_post_meta( $post_id, '_yoast_wpseo_canonical', true );
+						break;
+
+					case 'aioseo':
+						$row = $aioseo_map[ $post_id ] ?? self::aioseo_row( $post_id );
+						$raw = $row['seo_score'] ?? '';
+						if ( $row ) {
+							$data['title']       = (string) ( $row['title'] ?? '' );
+							$data['description'] = (string) ( $row['description'] ?? '' );
+							$data['canonical']   = (string) ( $row['canonical_url'] ?? '' );
+							$keyphrases          = json_decode( (string) ( $row['keyphrases'] ?? '' ), true );
+							if ( is_array( $keyphrases ) && ! empty( $keyphrases['focus']['keyphrase'] ) ) {
+								$data['keyword'] = (string) $keyphrases['focus']['keyphrase'];
+							}
+						}
+						break;
+
+					case 'rankmath':
+						$raw                 = get_post_meta( $post_id, 'rank_math_seo_score', true );
+						$keywords            = (string) get_post_meta( $post_id, 'rank_math_focus_keyword', true );
+						$data['keyword']     = trim( explode( ',', $keywords )[0] ?? '' );
+						$data['title']       = (string) get_post_meta( $post_id, 'rank_math_title', true );
+						$data['description'] = (string) get_post_meta( $post_id, 'rank_math_description', true );
+						$data['canonical']   = (string) get_post_meta( $post_id, 'rank_math_canonical_url', true );
+						break;
+
+					default:
+						return $data;
+				}
+
+				$data['has_desc']  = $data['description'] !== '';
+				$data['has_title'] = $data['title'] !== '';
+				if ( $raw !== '' && $raw !== false && $raw !== null ) {
+					$data['analyzed'] = true;
+					$data['score']    = (int) $raw;
+					$rating           = self::rating( (int) $raw, $provider['key'] );
+					$data['rating']   = $rating['rating'];
+					$data['label']    = $rating['label'];
+				}
+
+				return apply_filters( 'wbtm_seo_data', $data, $post_id, $provider );
+			}
+
+			/** Provider-specific score bands. */
+			public static function rating( int $score, string $key ): array {
+				$good = esc_html__( 'Good', 'bus-ticket-booking-with-seat-reservation' );
+				$ok   = esc_html__( 'Needs work', 'bus-ticket-booking-with-seat-reservation' );
+				$bad  = esc_html__( 'Poor', 'bus-ticket-booking-with-seat-reservation' );
+				$na   = esc_html__( 'Not analyzed', 'bus-ticket-booking-with-seat-reservation' );
+				if ( $key === 'aioseo' ) {
+					if ( $score >= 80 ) { return array( 'rating' => 'good', 'label' => $good ); }
+					if ( $score >= 50 ) { return array( 'rating' => 'ok', 'label' => $ok ); }
+				} elseif ( $key === 'rankmath' ) {
+					if ( $score > 80 ) { return array( 'rating' => 'good', 'label' => $good ); }
+					if ( $score > 50 ) { return array( 'rating' => 'ok', 'label' => $ok ); }
+				} else {
+					if ( $score > 70 ) { return array( 'rating' => 'good', 'label' => $good ); }
+					if ( $score > 40 ) { return array( 'rating' => 'ok', 'label' => $ok ); }
+				}
+				if ( $score > 0 ) {
+					return array( 'rating' => 'bad', 'label' => $bad );
+				}
+
+				return array( 'rating' => 'na', 'label' => $na );
+			}
+
+			/** Write normalized SEO data to the active plugin's native storage. */
+			public static function update_data( $post_id, array $values, ?array $provider = null ) {
+				$provider = $provider ?: self::provider();
+				if ( ! $provider ) {
+					return new WP_Error( 'wbtm_no_seo_provider', __( 'No supported SEO plugin is active.', 'bus-ticket-booking-with-seat-reservation' ) );
+				}
+				$keyword     = sanitize_text_field( $values['keyword'] ?? '' );
+				$title       = sanitize_text_field( $values['title'] ?? '' );
+				$description = sanitize_textarea_field( $values['description'] ?? '' );
+				$canonical   = esc_url_raw( $values['canonical'] ?? '' );
+
+				switch ( $provider['key'] ) {
+					case 'yoast':
+						update_post_meta( $post_id, '_yoast_wpseo_focuskw', $keyword );
+						update_post_meta( $post_id, '_yoast_wpseo_title', $title );
+						update_post_meta( $post_id, '_yoast_wpseo_metadesc', $description );
+						update_post_meta( $post_id, '_yoast_wpseo_canonical', $canonical );
+						break;
+
+					case 'aioseo':
+						$result = self::update_aioseo( $post_id, $keyword, $title, $description, $canonical );
+						if ( is_wp_error( $result ) ) {
+							return $result;
+						}
+						break;
+
+					case 'rankmath':
+						update_post_meta( $post_id, 'rank_math_focus_keyword', $keyword );
+						update_post_meta( $post_id, 'rank_math_title', $title );
+						update_post_meta( $post_id, 'rank_math_description', $description );
+						update_post_meta( $post_id, 'rank_math_canonical_url', $canonical );
+						break;
+
+					default:
+						return new WP_Error( 'wbtm_unsupported_seo_provider', __( 'The active SEO plugin is not supported.', 'bus-ticket-booking-with-seat-reservation' ) );
+				}
+
+				clean_post_cache( $post_id );
+				do_action( 'wbtm_seo_data_updated', $post_id, $provider, compact( 'keyword', 'title', 'description', 'canonical' ) );
+
+				return true;
+			}
+
+			/** Save manually edited modern-editor fields. */
+			public function save( $post_id, $post ) {
+				if ( ! isset( $_POST['wbtm_seo_present'], $_POST['wbtm_type_nonce'] ) ) {
+					return;
+				}
+				$nonce = sanitize_text_field( wp_unslash( $_POST['wbtm_type_nonce'] ) );
+				if ( ! wp_verify_nonce( $nonce, 'wbtm_type_nonce' ) || ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) || wp_is_post_revision( $post_id ) ) {
+					return;
+				}
+				if ( ! $post || $post->post_type !== 'wbtm_bus' || ! current_user_can( 'edit_post', $post_id ) ) {
+					return;
+				}
+				self::update_data( $post_id, array(
+					'keyword'     => isset( $_POST['wbtm_seo_focus_keyword'] ) ? sanitize_text_field( wp_unslash( $_POST['wbtm_seo_focus_keyword'] ) ) : '',
+					'title'       => isset( $_POST['wbtm_seo_title'] ) ? sanitize_text_field( wp_unslash( $_POST['wbtm_seo_title'] ) ) : '',
+					'description' => isset( $_POST['wbtm_seo_description'] ) ? sanitize_textarea_field( wp_unslash( $_POST['wbtm_seo_description'] ) ) : '',
+					'canonical'   => isset( $_POST['wbtm_seo_canonical'] ) ? esc_url_raw( wp_unslash( $_POST['wbtm_seo_canonical'] ) ) : '',
+				) );
+			}
+
+			/** Render the dedicated SEO step in the modern editor. */
+			public function tab_content( $post_id ) {
+				$provider = self::provider();
+				?>
+				<div class="tabsItem wbtm-seo-editor" data-tabs="#wbtm_settings_seo">
+					<?php if ( ! $provider ) : ?>
+						<div class="wbtm-seo-editor__empty">
+							<span class="dashicons dashicons-search"></span>
+							<h3><?php esc_html_e( 'Connect an SEO plugin', 'bus-ticket-booking-with-seat-reservation' ); ?></h3>
+							<p><?php esc_html_e( 'Install and activate Rank Math, Yoast SEO, or All in One SEO. This panel will then edit that plugin’s native SEO fields.', 'bus-ticket-booking-with-seat-reservation' ); ?></p>
+						</div>
+					<?php else :
+						$data   = self::get_data( $post_id, $provider );
+						$audit  = self::audit( $post_id, $data );
+						$ai     = apply_filters( 'wbtm_seo_ai_status', array( 'available' => false, 'enabled' => false ), $post_id, $provider );
+						$score  = $data['score'] === null ? '–' : (int) $data['score'];
+						?>
+						<input type="hidden" name="wbtm_seo_present" value="1"/>
+						<div class="wbtm-seo-editor__summary">
+							<div class="wbtm-seo-editor__score wbtm-seo-editor__score--<?php echo esc_attr( $data['rating'] ); ?>">
+								<strong><?php echo esc_html( $score ); ?></strong><span>/100</span>
+							</div>
+							<div>
+								<span class="wbtm-seo-editor__provider"><?php echo esc_html( $provider['label'] ); ?></span>
+								<h3><?php echo esc_html( $data['label'] ); ?></h3>
+								<p><?php esc_html_e( 'The SEO plugin calculates the official score. Save the bus after editing so its analyzer can refresh.', 'bus-ticket-booking-with-seat-reservation' ); ?></p>
+							</div>
+							<?php if ( ! empty( $ai['available'] ) ) : ?>
+								<button type="button" class="wbtm-bme__btn wbtm-bme__btn--primary wbtm-seo-ai-button" data-wbtm-seo-ai data-post-id="<?php echo esc_attr( $post_id ); ?>" data-nonce="<?php echo esc_attr( wp_create_nonce( 'wbtm_ai_seo_' . $post_id ) ); ?>" <?php disabled( empty( $ai['enabled'] ) ); ?>>
+									<span class="dashicons dashicons-superhero-alt"></span>
+									<span data-wbtm-seo-ai-label><?php esc_html_e( 'AI Auto-Fix SEO', 'bus-ticket-booking-with-seat-reservation' ); ?></span>
+								</button>
+							<?php endif; ?>
+						</div>
+						<?php if ( ! empty( $ai['available'] ) && empty( $ai['enabled'] ) ) : ?>
+							<div class="wbtm-seo-editor__ai-note"><?php echo wp_kses_post( $ai['message'] ?? '' ); ?></div>
+						<?php elseif ( ! empty( $ai['available'] ) ) : ?>
+							<div class="wbtm-seo-editor__ai-note wbtm-seo-editor__ai-note--privacy"><?php esc_html_e( 'AI generation sends this bus name, description, and route stops to your selected AI provider. API credentials remain server-side.', 'bus-ticket-booking-with-seat-reservation' ); ?></div>
+						<?php endif; ?>
+						<div class="wbtm-seo-editor__grid">
+							<div class="wbtm-seo-editor__fields">
+								<label for="wbtm-seo-focus-keyword"><?php esc_html_e( 'Focus keyphrase', 'bus-ticket-booking-with-seat-reservation' ); ?></label>
+								<input type="text" id="wbtm-seo-focus-keyword" name="wbtm_seo_focus_keyword" class="formControl" value="<?php echo esc_attr( $data['keyword'] ); ?>"/>
+
+								<label for="wbtm-seo-title"><?php esc_html_e( 'SEO title', 'bus-ticket-booking-with-seat-reservation' ); ?></label>
+								<input type="text" id="wbtm-seo-title" name="wbtm_seo_title" class="formControl" maxlength="70" value="<?php echo esc_attr( $data['title'] ); ?>"/>
+								<span class="wbtm-seo-editor__counter" data-seo-counter="wbtm-seo-title" data-good-min="30" data-good-max="60"><?php echo esc_html( mb_strlen( $data['title'] ) ); ?>/60</span>
+
+								<label for="wbtm-seo-description"><?php esc_html_e( 'Meta description', 'bus-ticket-booking-with-seat-reservation' ); ?></label>
+								<textarea id="wbtm-seo-description" name="wbtm_seo_description" class="formControl" rows="4" maxlength="170"><?php echo esc_textarea( $data['description'] ); ?></textarea>
+								<span class="wbtm-seo-editor__counter" data-seo-counter="wbtm-seo-description" data-good-min="120" data-good-max="160"><?php echo esc_html( mb_strlen( $data['description'] ) ); ?>/160</span>
+
+								<label for="wbtm-seo-canonical"><?php esc_html_e( 'Canonical URL', 'bus-ticket-booking-with-seat-reservation' ); ?></label>
+								<input type="url" id="wbtm-seo-canonical" name="wbtm_seo_canonical" class="formControl" value="<?php echo esc_attr( $data['canonical'] ); ?>" placeholder="<?php echo esc_attr( get_permalink( $post_id ) ); ?>"/>
+								<p class="description"><?php esc_html_e( 'Leave empty to use this bus URL. Only set this when another URL is the preferred original.', 'bus-ticket-booking-with-seat-reservation' ); ?></p>
+							</div>
+							<div class="wbtm-seo-editor__audit" data-wbtm-seo-audit>
+								<h4><?php esc_html_e( 'SEO readiness', 'bus-ticket-booking-with-seat-reservation' ); ?> <span><?php echo esc_html( $audit['score'] ); ?>%</span></h4>
+								<?php foreach ( $audit['checks'] as $check ) : ?>
+									<div class="wbtm-seo-editor__check <?php echo $check['pass'] ? 'is-pass' : 'is-fail'; ?>">
+										<span class="dashicons <?php echo $check['pass'] ? 'dashicons-yes-alt' : 'dashicons-warning'; ?>"></span>
+										<span><?php echo esc_html( $check['label'] ); ?></span>
+									</div>
+								<?php endforeach; ?>
+							</div>
+						</div>
+						<div class="wbtm-seo-editor__result" data-wbtm-seo-ai-result hidden></div>
+					<?php endif; ?>
+				</div>
+				<?php
+			}
+
+			private static function aioseo_row( $post_id ): array {
+				$rows = self::aioseo_scores( array( $post_id ) );
+
+				return $rows[ $post_id ] ?? array();
+			}
+
+			private static function update_aioseo( $post_id, $keyword, $title, $description, $canonical ) {
+				global $wpdb;
+				$table = $wpdb->prefix . 'aioseo_posts';
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+				if ( $wpdb->get_var( $wpdb->prepare( 'SHOW TABLES LIKE %s', $table ) ) !== $table ) {
+					return new WP_Error( 'wbtm_aioseo_table_missing', __( 'The All in One SEO data table is unavailable.', 'bus-ticket-booking-with-seat-reservation' ) );
+				}
+				$keyphrases = wp_json_encode( array(
+					'focus'      => array( 'keyphrase' => $keyword, 'score' => 0 ),
+					'additional' => array(),
+				) );
+				$values = array(
+					'title'         => $title,
+					'description'   => $description,
+					'keyphrases'    => $keyphrases,
+					'canonical_url' => $canonical,
+					'post_type'     => get_post_type( $post_id ),
+					'updated'       => current_time( 'mysql' ),
+				);
+				// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+				$exists = (int) $wpdb->get_var( $wpdb->prepare( "SELECT id FROM {$table} WHERE post_id = %d", $post_id ) );
+				if ( $exists ) {
+					// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+					$ok = $wpdb->update( $table, $values, array( 'post_id' => $post_id ) );
+				} else {
+					$values['post_id'] = $post_id;
+					$values['created'] = current_time( 'mysql' );
+					// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+					$ok = $wpdb->insert( $table, $values );
+				}
+				if ( $ok === false ) {
+					return new WP_Error( 'wbtm_aioseo_update_failed', __( 'All in One SEO could not save the generated fields.', 'bus-ticket-booking-with-seat-reservation' ) );
+				}
+
+				return true;
+			}
+
+			private static function audit( $post_id, array $data ): array {
+				$post        = get_post( $post_id );
+				$keyword     = trim( $data['keyword'] );
+				$title       = trim( $data['title'] );
+				$description = trim( $data['description'] );
+				$content     = $post ? wp_strip_all_tags( strip_shortcodes( $post->post_content ) ) : '';
+				$word_count  = count( preg_split( '/\s+/u', trim( $content ), -1, PREG_SPLIT_NO_EMPTY ) );
+				$contains    = static function( $haystack, $needle ) {
+					return $needle !== '' && mb_stripos( (string) $haystack, $needle ) !== false;
+				};
+				$checks = array(
+					array( 'pass' => $keyword !== '', 'label' => __( 'A focus keyphrase is set', 'bus-ticket-booking-with-seat-reservation' ) ),
+					array( 'pass' => mb_strlen( $title ) >= 30 && mb_strlen( $title ) <= 60, 'label' => __( 'SEO title is 30–60 characters', 'bus-ticket-booking-with-seat-reservation' ) ),
+					array( 'pass' => mb_strlen( $description ) >= 120 && mb_strlen( $description ) <= 160, 'label' => __( 'Meta description is 120–160 characters', 'bus-ticket-booking-with-seat-reservation' ) ),
+					array( 'pass' => $contains( $title, $keyword ), 'label' => __( 'Keyphrase appears in the SEO title', 'bus-ticket-booking-with-seat-reservation' ) ),
+					array( 'pass' => $contains( $description, $keyword ), 'label' => __( 'Keyphrase appears in the description', 'bus-ticket-booking-with-seat-reservation' ) ),
+					array( 'pass' => has_post_thumbnail( $post_id ), 'label' => __( 'A featured image is set', 'bus-ticket-booking-with-seat-reservation' ) ),
+					array( 'pass' => $word_count >= 200, 'label' => __( 'Bus description contains at least 200 words', 'bus-ticket-booking-with-seat-reservation' ) ),
+				);
+				$passed = count( array_filter( $checks, static fn( $check ) => $check['pass'] ) );
+
+				return array( 'score' => (int) round( 100 * $passed / count( $checks ) ), 'checks' => $checks );
+			}
+		}
+
+		new WBTM_SEO();
+	}

--- a/admin/settings-modern/WBTM_Settings_Modern.php
+++ b/admin/settings-modern/WBTM_Settings_Modern.php
@@ -93,11 +93,11 @@
 			 * ------------------------------------------------------------------ */
 
 			/**
-			 * The 4 wizard steps. Each section reuses a classic renderer:
+			 * The wizard steps. Each section reuses a classic renderer:
 			 * [ class, method, title, subtitle ].
 			 */
 			private function get_steps() {
-				return array(
+				$steps = array(
 					array(
 						'id'       => 'general',
 						'label'    => __( 'General Info', 'bus-ticket-booking-with-seat-reservation' ),
@@ -142,6 +142,21 @@
 						),
 					),
 				);
+
+				// The SEO workflow is useful only when its native metadata owner is
+				// active. Omitting it here keeps the stepper, panel count and footer
+				// navigation in sync automatically on sites without an SEO plugin.
+				if ( class_exists( 'WBTM_SEO' ) && WBTM_SEO::provider() ) {
+					$steps[] = array(
+						'id'       => 'seo',
+						'label'    => __( 'SEO', 'bus-ticket-booking-with-seat-reservation' ),
+						'sections' => array(
+							array( 'WBTM_SEO', 'tab_content', __( 'Search Engine Optimization', 'bus-ticket-booking-with-seat-reservation' ), __( 'Optimize this bus using the native fields of your active SEO plugin.', 'bus-ticket-booking-with-seat-reservation' ) ),
+						),
+					);
+				}
+
+				return $steps;
 			}
 
 			/**
@@ -227,6 +242,7 @@
 					'seat'     => $card( 2, '25%' ) . $block( 280 ),
 					'pricing'  => $card( 3, '30%' ) . $card( 2, '25%' ),
 					'advanced' => $card( 3, '35%' ) . $card( 2, '30%' ) . $card( 3, '40%' ),
+					'seo'      => $card( 4, '30%' ) . $card( 3, '25%' ),
 				);
 
 				$inner = isset( $shapes[ $id ] ) ? $shapes[ $id ] : $card( 3, '30%' );

--- a/assets/admin/css/wbtm-bus-edit-modern.css
+++ b/assets/admin/css/wbtm-bus-edit-modern.css
@@ -356,6 +356,29 @@ button.wbtm-bme__btn.wbtm-bme__btn--primary.wbtm-bme__split-caret{
 .wbtm-bme__main{min-width:0;}
 .wbtm-bme__rail{position:sticky;top:84px;display:flex;flex-direction:column;gap:18px;}
 .wbtm-bme__rail-card{background:var(--surface);border:1px solid var(--line);border-radius:var(--radius);box-shadow:var(--shadow-sm);overflow:hidden;}
+.wbtm-bme[data-step="seo"] .wbtm-bme__body{grid-template-columns:1fr;}
+.wbtm-bme[data-step="seo"] .wbtm-bme__rail{display:none;}
+
+/* Provider-neutral SEO step (Rank Math, Yoast SEO, or All in One SEO). */
+.wbtm-seo-editor{padding:0 !important;}
+.wbtm-seo-editor__summary{display:grid;grid-template-columns:auto minmax(0,1fr) auto;gap:16px;align-items:center;padding:20px;border:1px solid var(--line);border-radius:12px;background:linear-gradient(135deg,#fff,#f8fafc);}
+.wbtm-seo-editor__score{width:68px;height:68px;border-radius:50%;display:flex;align-items:center;justify-content:center;flex-direction:column;background:#f1f5f9;border:6px solid #cbd5e1;color:var(--muted);box-sizing:border-box;}
+.wbtm-seo-editor__score strong{font-size:20px;line-height:1;color:inherit;}.wbtm-seo-editor__score span{font-size:9px;line-height:1.3;}
+.wbtm-seo-editor__score--good{color:#15803d;border-color:#22c55e;background:#f0fdf4;}.wbtm-seo-editor__score--ok{color:#a16207;border-color:#eab308;background:#fefce8;}.wbtm-seo-editor__score--bad{color:#dc2626;border-color:#ef4444;background:#fef2f2;}
+.wbtm-seo-editor__provider{display:inline-flex;padding:3px 9px;border-radius:999px;background:#e0e7ff;color:#3730a3;font-size:11px;font-weight:700;}
+.wbtm-seo-editor__summary h3{margin:6px 0 3px;font-size:18px;color:var(--ink);}.wbtm-seo-editor__summary p{margin:0;color:var(--muted);font-size:12px;}
+.wbtm-seo-ai-button{white-space:nowrap;gap:7px;}.wbtm-seo-ai-button.is-loading{opacity:.75;cursor:wait;}.wbtm-seo-ai-button .dashicons{font-size:17px;width:17px;height:17px;}
+.wbtm-seo-editor__ai-note{margin-top:12px;padding:11px 14px;border:1px solid #fde68a;border-radius:9px;background:#fffbeb;color:#92400e;font-size:12px;}.wbtm-seo-editor__ai-note a{color:#92400e;font-weight:700;}
+.wbtm-seo-editor__ai-note--privacy{border-color:#bfdbfe;background:#eff6ff;color:#1e3a8a;}
+.wbtm-seo-editor__grid{display:grid;grid-template-columns:minmax(0,1.6fr) minmax(260px,.8fr);gap:20px;margin-top:20px;}
+.wbtm-seo-editor__fields,.wbtm-seo-editor__audit{padding:20px;border:1px solid var(--line);border-radius:12px;background:#fff;box-shadow:var(--shadow-sm);}
+.wbtm-seo-editor__fields{display:grid;grid-template-columns:1fr auto;gap:8px 12px;align-items:center;}.wbtm-seo-editor__fields label{grid-column:1;font-size:13px;font-weight:700;color:var(--ink);margin-top:7px;}.wbtm-seo-editor__fields .formControl{grid-column:1/-1;width:100%;max-width:none;box-sizing:border-box;}.wbtm-seo-editor__fields textarea.formControl{resize:vertical;}.wbtm-seo-editor__fields .description{grid-column:1/-1;margin:0;color:var(--muted);font-size:11px;}
+.wbtm-seo-editor__counter{grid-column:2;grid-row:auto;color:var(--muted);font-size:11px;font-weight:700;justify-self:end;margin-top:-29px;margin-right:10px;pointer-events:none;}.wbtm-seo-editor__counter.is-good{color:#15803d;}
+.wbtm-seo-editor__audit h4{display:flex;align-items:center;justify-content:space-between;margin:0 0 12px;font-size:14px;color:var(--ink);}.wbtm-seo-editor__audit h4 span{color:var(--blue);}
+.wbtm-seo-editor__check{display:flex;gap:8px;align-items:flex-start;padding:8px 0;border-bottom:1px solid var(--band-line);font-size:12px;color:var(--muted);}.wbtm-seo-editor__check:last-child{border:0;}.wbtm-seo-editor__check .dashicons{font-size:16px;width:16px;height:16px;}.wbtm-seo-editor__check.is-pass .dashicons{color:#16a34a;}.wbtm-seo-editor__check.is-fail .dashicons{color:#d97706;}
+.wbtm-seo-editor__result{margin-top:14px;padding:11px 14px;border-radius:9px;font-size:12px;font-weight:600;}.wbtm-seo-editor__result.is-success{background:#f0fdf4;border:1px solid #86efac;color:#166534;}.wbtm-seo-editor__result.is-error{background:#fef2f2;border:1px solid #fca5a5;color:#991b1b;}
+.wbtm-seo-editor__empty{text-align:center;padding:52px 24px;border:1px dashed var(--line);border-radius:12px;background:#f8fafc;}.wbtm-seo-editor__empty .dashicons{font-size:38px;width:38px;height:38px;color:var(--blue);}.wbtm-seo-editor__empty h3{margin:12px 0 6px;color:var(--ink);}.wbtm-seo-editor__empty p{max-width:580px;margin:0 auto;color:var(--muted);}
+@media(max-width:800px){.wbtm-seo-editor__summary{grid-template-columns:auto 1fr;}.wbtm-seo-ai-button{grid-column:1/-1;justify-self:start;}.wbtm-seo-editor__grid{grid-template-columns:1fr;}}
 
 /* Featured Image card — title, big preview, text-link actions (attachment-style). */
 .wbtm-bme__feat-head{padding:16px 16px 0;font-size:15px;font-weight:800;color:var(--ink);}

--- a/assets/admin/js/wbtm-bus-edit-modern.js
+++ b/assets/admin/js/wbtm-bus-edit-modern.js
@@ -49,6 +49,23 @@
 	var total = parseInt($root.data('total'), 10) || order.length;
 	var cur = 0;
 
+	// SEO title/description counters are shared by manual editing and the PRO
+	// AI generator (which triggers the same input event after filling fields).
+	function updateSeoCounter(counter) {
+		var $counter = $(counter);
+		var $field = $('#' + $counter.data('seo-counter'));
+		if (!$field.length) { return; }
+		var length = Array.from($field.val() || '').length;
+		var min = parseInt($counter.data('good-min'), 10) || 0;
+		var max = parseInt($counter.data('good-max'), 10) || 0;
+		$counter.text(length + '/' + max).toggleClass('is-good', length >= min && length <= max);
+	}
+
+	$root.on('input', '#wbtm-seo-title, #wbtm-seo-description', function () {
+		$root.find('[data-seo-counter="' + this.id + '"]').each(function () { updateSeoCounter(this); });
+	});
+	$root.find('[data-seo-counter]').each(function () { updateSeoCounter(this); });
+
 	function goStep(index) {
 		if (index < 0) { index = 0; }
 		if (index > order.length - 1) { index = order.length - 1; }


### PR DESCRIPTION
Add a provider-neutral SEO adapter for Rank Math, Yoast SEO, and All in One SEO. Read and write each plugin's native focus keyword, title, description, canonical URL, and score data.

Add a dedicated modern-editor SEO step with character counters, readiness checks, canonical controls, provider score context, responsive styling, and a PRO AI extension point. Show the step only when a supported SEO plugin is active.

Refactor the fleet-list SEO column to use the shared adapter so the list and editor use one normalized data source while preserving the existing provider-specific score bands and bulk AIOSEO query behavior.