### PR TITLE
fix(cart): self-heal broken bus→hidden product link (Book Now "Cart error" 400)

### DIFF
--- a/admin/WBTM_Hidden_Product.php
+++ b/admin/WBTM_Hidden_Product.php
@@ -108,8 +108,21 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 			}
 			/**********************/
 			public function create_hidden_wc_product( $post_id) {
+				return self::create_hidden_wc_product_for( $post_id );
+			}
+			/**
+			 * Create a fresh hidden WC product for a bus and return its ID.
+			 *
+			 * Static twin of create_hidden_wc_product() so the self-healing helpers
+			 * below (and the AJAX add-to-cart controller) can (re)build the mirror
+			 * product and get its ID back without needing a class instance.
+			 *
+			 * @param int $bus_id wbtm_bus post ID.
+			 * @return int New product ID, or 0 on failure.
+			 */
+			public static function create_hidden_wc_product_for( $bus_id ) {
 				$new_post = array(
-					'post_title'    => get_the_title( $post_id ),
+					'post_title'    => get_the_title( $bus_id ),
 					'post_content'  => '',
 					'post_name'     => uniqid(),
 					'post_category' => array(),
@@ -117,15 +130,137 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 					'post_status'   => 'publish',
 					'post_type'     => 'product'
 				);
-				$pid      = wp_insert_post( $new_post );
-				update_post_meta( $post_id, 'link_wc_product', $pid );
-				update_post_meta( $pid, 'link_wbtm_bus', $post_id );
-				update_post_meta( $pid, '_price', 0.01 );
-				update_post_meta( $pid, '_sold_individually', 'yes' );
-				update_post_meta( $pid, '_virtual', 'yes' );
-				$terms = array( 'exclude-from-catalog', 'exclude-from-search' );
-				wp_set_object_terms( $pid, $terms, 'product_visibility' );
-				update_post_meta( $post_id, 'check_if_run_once', true );
+				$pid = wp_insert_post( $new_post );
+				if ( is_wp_error( $pid ) || ! $pid ) {
+					return 0;
+				}
+				update_post_meta( $bus_id, 'link_wc_product', $pid );
+				update_post_meta( $pid, 'link_wbtm_bus', $bus_id );
+				self::ensure_product_is_purchasable( $pid, $bus_id );
+				update_post_meta( $bus_id, 'check_if_run_once', true );
+				return (int) $pid;
+			}
+			/**
+			 * Force a hidden product into a state WooCommerce will accept in the cart:
+			 * published, priced, in stock, virtual, sold individually and excluded from
+			 * catalog/search. Only writes what is needed so it is cheap to call.
+			 *
+			 * @param int $product_id WC product ID.
+			 * @param int $bus_id     Owning wbtm_bus ID (to restore the back-link).
+			 * @return void
+			 */
+			public static function ensure_product_is_purchasable( $product_id, $bus_id = 0 ) {
+				$product_id = (int) $product_id;
+				if ( ! $product_id ) {
+					return;
+				}
+				if ( get_post_status( $product_id ) !== 'publish' ) {
+					wp_update_post( array( 'ID' => $product_id, 'post_status' => 'publish' ) );
+				}
+				$price = get_post_meta( $product_id, '_price', true );
+				if ( $price === '' || $price === null ) {
+					update_post_meta( $product_id, '_price', 0.01 );
+					update_post_meta( $product_id, '_regular_price', 0.01 );
+				}
+				update_post_meta( $product_id, '_stock_status', 'instock' );
+				update_post_meta( $product_id, '_manage_stock', 'no' );
+				update_post_meta( $product_id, '_virtual', 'yes' );
+				update_post_meta( $product_id, '_sold_individually', 'yes' );
+				wp_set_object_terms( $product_id, array( 'exclude-from-catalog', 'exclude-from-search' ), 'product_visibility' );
+				if ( $bus_id && ! get_post_meta( $product_id, 'link_wbtm_bus', true ) ) {
+					update_post_meta( $product_id, 'link_wbtm_bus', (int) $bus_id );
+				}
+				if ( function_exists( 'wc_delete_product_transients' ) ) {
+					wc_delete_product_transients( $product_id );
+				}
+			}
+			/**
+			 * Ensure a bus has a valid, purchasable hidden WC product and return its ID.
+			 *
+			 * Self-healing entry point used by the "Book Now" AJAX handler. Sites where
+			 * buses were imported/migrated (or where the mirror product was deleted) end
+			 * up with a missing/broken link_wc_product, which otherwise fails add-to-cart
+			 * with a generic "Cart error" (400). This rebuilds the link on demand:
+			 *   1. link resolves to a purchasable product -> return it (no writes),
+			 *   2. product exists but isn't buyable -> repair its meta,
+			 *   3. link lost but a back-linked orphan product exists -> re-adopt it,
+			 *   4. nothing exists -> create a fresh hidden product.
+			 *
+			 * @param int $bus_id wbtm_bus post ID.
+			 * @return int Linked WC product ID, or 0 if it could not be ensured.
+			 */
+			public static function ensure_hidden_wc_product( $bus_id ) {
+				$bus_id = (int) $bus_id;
+				if ( ! $bus_id || ! function_exists( 'wc_get_product' ) || get_post_type( $bus_id ) !== WBTM_Functions::get_cpt() ) {
+					return 0;
+				}
+				$product_id = (int) WBTM_Global_Function::get_post_info( $bus_id, 'link_wc_product' );
+				// Happy path: link already resolves to a buyable product — do nothing.
+				if ( $product_id && get_post_type( $product_id ) === 'product' && get_post_status( $product_id ) !== 'trash' ) {
+					$product = wc_get_product( $product_id );
+					if ( $product && $product->is_purchasable() && $product->is_in_stock() ) {
+						return $product_id;
+					}
+					// Product exists but isn't buyable (lost price/stock/visibility) — repair.
+					self::ensure_product_is_purchasable( $product_id, $bus_id );
+					return $product_id;
+				}
+				// Link missing/broken: re-adopt an orphan product that still back-links here.
+				$existing = get_posts( array(
+					'post_type'      => 'product',
+					'post_status'    => array( 'publish', 'pending', 'draft', 'private' ),
+					'posts_per_page' => 1,
+					'fields'         => 'ids',
+					'meta_query'     => array(
+						array(
+							'key'   => 'link_wbtm_bus',
+							'value' => $bus_id,
+						),
+					),
+				) );
+				if ( ! empty( $existing ) ) {
+					$product_id = (int) $existing[0];
+					update_post_meta( $bus_id, 'link_wc_product', $product_id );
+					self::ensure_product_is_purchasable( $product_id, $bus_id );
+					return $product_id;
+				}
+				// Nothing to adopt — build a new mirror product.
+				return (int) self::create_hidden_wc_product_for( $bus_id );
+			}
+			/**
+			 * Bulk-repair every published bus's hidden product link in one pass.
+			 *
+			 * Run once on a site whose buses lost their mirror products (the cause of
+			 * "Cart error" on Book Now), e.g. via WP-CLI:
+			 *   wp eval 'print_r( WBTM_Hidden_Product::repair_all_hidden_products() );'
+			 *
+			 * @return array{checked:int,repaired:int,created:int,links:array<int,int>}
+			 */
+			public static function repair_all_hidden_products() {
+				$result = array( 'checked' => 0, 'repaired' => 0, 'created' => 0, 'links' => array() );
+				if ( ! function_exists( 'wc_get_product' ) ) {
+					return $result;
+				}
+				$buses = get_posts( array(
+					'post_type'      => WBTM_Functions::get_cpt(),
+					'post_status'    => 'publish',
+					'numberposts'    => -1,
+					'fields'         => 'ids',
+				) );
+				foreach ( $buses as $bus_id ) {
+					$result['checked']++;
+					$before       = (int) WBTM_Global_Function::get_post_info( $bus_id, 'link_wc_product' );
+					$valid_before = $before && get_post_type( $before ) === 'product' && get_post_status( $before ) !== 'trash';
+					$pid          = self::ensure_hidden_wc_product( $bus_id );
+					if ( $pid && ! $valid_before ) {
+						$result['repaired']++;
+						if ( $pid !== $before ) {
+							$result['created']++;
+						}
+						$result['links'][ $bus_id ] = $pid;
+					}
+				}
+				return $result;
 			}
 			public function count_hidden_wc_product( $post_id ): int {
 				$args = array(

--- a/inc/WBTM_Booking_Controller.php
+++ b/inc/WBTM_Booking_Controller.php
@@ -113,6 +113,22 @@ if ( ! class_exists( 'WBTM_Booking_Controller' ) ) {
 				: '';
 
 			$product_id = WBTM_Global_Function::get_post_info( $post_id, 'link_wc_product' );
+			// Self-heal the bus <-> hidden-product link. Sites where buses were imported
+			// or migrated (or where the mirror WC product was deleted) end up with a
+			// missing/broken link_wc_product, which made Book Now fail below with a generic
+			// "Cart error" (400) even though the data was fine on the origin site. Rebuild
+			// the mirror product on demand so add-to-cart succeeds instead of dying.
+			if ( class_exists( 'WBTM_Hidden_Product' ) ) {
+				$link_valid = $product_id
+					&& get_post_type( $product_id ) === 'product'
+					&& get_post_status( $product_id ) !== 'trash';
+				if ( ! $link_valid ) {
+					$healed_product_id = WBTM_Hidden_Product::ensure_hidden_wc_product( $post_id );
+					if ( $healed_product_id ) {
+						$product_id = $healed_product_id;
+					}
+				}
+			}
 			$booking_mode = isset( $_POST['wbtm_booking_mode'] ) ? sanitize_key( wp_unslash( $_POST['wbtm_booking_mode'] ) ) : '';
 			$bp           = sanitize_text_field( wp_unslash( $_POST['wbtm_bp_place'] ?? '' ) );
 			$dp           = sanitize_text_field( wp_unslash( $_POST['wbtm_dp_place'] ?? '' ) );
@@ -259,7 +275,30 @@ if ( ! class_exists( 'WBTM_Booking_Controller' ) ) {
 					}
 				}
 
-				wp_send_json_error( 'Cart error', 400 );
+				// Surface the real reason instead of the opaque "Cart error". When
+				// add_to_cart() fails it records a WooCommerce error notice (e.g. product
+				// not purchasable); relay it so the failure is diagnosable in the browser.
+				$reason = '';
+				if ( function_exists( 'wc_get_notices' ) ) {
+					$error_notices = wc_get_notices( 'error' );
+					if ( ! empty( $error_notices ) ) {
+						$messages = array_map(
+							static function ( $n ) {
+								return is_array( $n ) && isset( $n['notice'] ) ? $n['notice'] : (string) $n;
+							},
+							$error_notices
+						);
+						$reason = trim( wp_strip_all_tags( implode( ' ', $messages ) ) );
+						wc_clear_notices();
+					}
+				}
+				if ( ! $product_id ) {
+					$reason = esc_html__( 'This bus is not available for booking right now. Please contact the site administrator.', 'bus-ticket-booking-with-seat-reservation' );
+				}
+				wp_send_json_error(
+					$reason !== '' ? $reason : esc_html__( 'Could not add this ticket to the cart. Please try again.', 'bus-ticket-booking-with-seat-reservation' ),
+					400
+				);
 			} finally {
 				if ( $lock_acquired ) {
 					WBTM_Cart_Helper::release_trip_lock( $post_id, $bp, $dp, $date );


### PR DESCRIPTION
## Problem
Selecting a seat and clicking **Book Now** failed with a `400 Bad Request` on `admin-ajax.php` and a **"Cart error"** alert. It reproduced on a client's site but not on our own local — a data problem, not a code-per-machine one.

## Root cause
Every `wbtm_bus` is mirrored to a hidden WooCommerce product whose ID is stored in the bus's `link_wc_product` meta. `WBTM_Booking_Controller::wbtm_ajax_add_to_cart()` adds *that* product to the cart:

```php
$product_id = get_post_info( $post_id, 'link_wc_product' ); // empty/broken on client
if ( $product_id ) { $added = WC()->cart->add_to_cart(...); if ($added) {...} }
wp_send_json_error( 'Cart error', 400 ); // falls through to here
```

On sites where buses were **imported/migrated** (or the mirror product was deleted), `link_wc_product` is empty or dangling, so `$product_id` is falsy, `add_to_cart()` never runs, and the handler emits the opaque `Cart error` 400.

## Fix
- **Self-heal at booking time** (`inc/WBTM_Booking_Controller.php`): if the link is missing/broken, rebuild the hidden product on demand before add-to-cart. Also covers future imports.
- **`WBTM_Hidden_Product` helpers** (`admin/WBTM_Hidden_Product.php`):
  - `ensure_hidden_wc_product()` — reuse a valid link → repair an un-buyable product → **re-adopt an orphaned product via its `link_wbtm_bus` back-link (no duplicates)** → else create fresh.
  - `create_hidden_wc_product_for()` / `ensure_product_is_purchasable()` — static, reusable; instance `create_hidden_wc_product()` now delegates to them.
  - `repair_all_hidden_products()` — one-shot bulk relink of every bus.
- **Better error** — relays the real WooCommerce notice instead of `Cart error`, so any remaining edge case is diagnosable.

## Fix an already-broken site
```bash
wp eval 'print_r( WBTM_Hidden_Product::repair_all_hidden_products() );'
```
(Optional — the self-heal repairs each bus on its first Book Now anyway.)

## Testing (verified via wp eval on a live install)
- Empty `link_wc_product` → re-adopts orphan product, **no duplicate**.
- Dangling link (product deleted) → re-adopts/rebuilds, purchasable.
- Bus with no product at all → creates a fresh purchasable one; second call idempotent.
- `repair_all_hidden_products()` on healthy data → `checked=10, repaired=0` (no-op, correct).
- Both files pass `php -l`.

## Scope / safety
Happy path unchanged (zero writes when the link is already valid). No changes to UI, pricing, or the standalone/full-bus flows — the heal only runs when the link is actually broken.