### PR TITLE
Ticket sale cut-off + Bus Stop rename migration

### DIFF
--- a/admin/WBTM_Global_settings.php
+++ b/admin/WBTM_Global_settings.php
@@ -450,7 +450,7 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 						'booking' => [
 							'icon'     => 'fas fa-calendar-check',
 							'label'    => __('Booking behavior', 'bus-ticket-booking-with-seat-reservation'),
-							'field_names' => ['set_book_status', 'label', 'slug', 'icon', 'bus_buffer_time'],
+							'field_names' => ['set_book_status', 'label', 'slug', 'icon', 'bus_buffer_time', 'ticket_sale_cutoff_enable', 'ticket_sale_cutoff_type', 'ticket_sale_cutoff_hours', 'ticket_sale_cutoff_days_before', 'ticket_sale_cutoff_clock'],
 						],
 						'search' => [
 							'icon'     => 'fas fa-search',
@@ -1181,6 +1181,59 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 							'type'        => 'number',
 							'default'     => 0,
 							'placeholder' => esc_html__( 'Ex:50', 'bus-ticket-booking-with-seat-reservation' ),
+						),
+						// Ticket sale cut-off: stop selling a set time before each departure so
+						// operators have time to plan routes. Enforced in search results and at
+						// checkout. Supports either a fixed number of hours before departure, or a
+						// specific clock time on a day before departure ("10 PM the night before").
+						array(
+							'name'    => 'ticket_sale_cutoff_enable',
+							'label'   => esc_html__( 'Ticket Sale Cut-off', 'bus-ticket-booking-with-seat-reservation' ),
+							'desc'    => esc_html__( 'Automatically stop selling tickets a set time before each departure, so you have time to plan routes. Applies to search results and checkout. Default: disabled.', 'bus-ticket-booking-with-seat-reservation' ),
+							'type'    => 'select',
+							'default' => 'disable',
+							'options' => array(
+								'disable' => esc_html__( 'Disable', 'bus-ticket-booking-with-seat-reservation' ),
+								'enable'  => esc_html__( 'Enable', 'bus-ticket-booking-with-seat-reservation' ),
+							),
+						),
+						array(
+							'name'    => 'ticket_sale_cutoff_type',
+							'label'   => esc_html__( 'Cut-off Type', 'bus-ticket-booking-with-seat-reservation' ),
+							'desc'    => esc_html__( 'Choose how the cut-off is measured. Only applies when the cut-off is enabled.', 'bus-ticket-booking-with-seat-reservation' ),
+							'type'    => 'select',
+							'default' => 'hours',
+							'options' => array(
+								'hours' => esc_html__( 'Fixed hours before departure', 'bus-ticket-booking-with-seat-reservation' ),
+								'clock' => esc_html__( 'Specific time before departure', 'bus-ticket-booking-with-seat-reservation' ),
+							),
+						),
+						array(
+							'name'        => 'ticket_sale_cutoff_hours',
+							'label'       => esc_html__( 'Hours Before Departure', 'bus-ticket-booking-with-seat-reservation' ),
+							'desc'        => esc_html__( 'Used with "Fixed hours before departure". Example: 12 = sales close 12 hours before the bus departs.', 'bus-ticket-booking-with-seat-reservation' ),
+							'type'        => 'number',
+							'default'     => 12,
+							'min'         => 0,
+							'step'        => 0.5,
+							'placeholder' => esc_html__( 'Ex: 12', 'bus-ticket-booking-with-seat-reservation' ),
+						),
+						array(
+							'name'        => 'ticket_sale_cutoff_days_before',
+							'label'       => esc_html__( 'Days Before Departure', 'bus-ticket-booking-with-seat-reservation' ),
+							'desc'        => esc_html__( 'Used with "Specific time before departure". Example: 1 = the day before departure. Combine with the cut-off time below for "10:00 PM the night before".', 'bus-ticket-booking-with-seat-reservation' ),
+							'type'        => 'number',
+							'default'     => 1,
+							'min'         => 0,
+							'placeholder' => esc_html__( 'Ex: 1', 'bus-ticket-booking-with-seat-reservation' ),
+						),
+						array(
+							'name'        => 'ticket_sale_cutoff_clock',
+							'label'       => esc_html__( 'Cut-off Time (HH:MM, 24h)', 'bus-ticket-booking-with-seat-reservation' ),
+							'desc'        => esc_html__( 'Used with "Specific time before departure". Example: 22:00 with 1 day before = sales close at 10:00 PM the night before departure.', 'bus-ticket-booking-with-seat-reservation' ),
+							'type'        => 'text',
+							'default'     => '22:00',
+							'placeholder' => '22:00',
 						),
 						array(
 							'name'    => 'show_hide_view_seats_button',

--- a/admin/WBTM_Taxonomy.php
+++ b/admin/WBTM_Taxonomy.php
@@ -8,8 +8,23 @@
 	} // Cannot access pages directly.
 	if (!class_exists('WBTM_Taxonomy')) {
 		class WBTM_Taxonomy {
+			/**
+			 * Old bus-stop term names captured on 'edit_terms' (before the DB update),
+			 * keyed by term id, so the rename can be detected and migrated on the
+			 * following 'edited_wbtm_bus_stops'.
+			 *
+			 * @var array<int,string>
+			 */
+			private $stop_rename_old_names = array();
 			public function __construct() {
 				add_action('init', [$this, 'taxonomy']);
+				// Keep bus route/pricing config (and existing bookings) in sync when a
+				// Bus Stop is renamed. Stops are referenced by NAME throughout, so a
+				// rename would otherwise orphan every route/fare that used the old name
+				// (the stop appears "unconfigured") AND make existing bookings on that
+				// stop invisible to the availability query — a silent double-booking.
+				add_action('edit_terms', [$this, 'wbtm_capture_stop_old_name'], 10, 2);
+				add_action('edited_wbtm_bus_stops', [$this, 'wbtm_migrate_stop_rename'], 10, 1);
 			}
 			public function taxonomy() {
 				$name = WBTM_Functions::get_name();
@@ -228,6 +243,147 @@
                 register_taxonomy( 'wbtm_bus_feature', 'wbtm_bus', $bus_feature_args );
 
             }
+			/**
+			 * Remember a bus-stop term's current name just before it is updated, so
+			 * wbtm_migrate_stop_rename() can tell whether the name actually changed.
+			 *
+			 * @param int    $term_id  Term being edited.
+			 * @param string $taxonomy Its taxonomy.
+			 */
+			public function wbtm_capture_stop_old_name( $term_id, $taxonomy ) {
+				if ( 'wbtm_bus_stops' !== $taxonomy ) {
+					return;
+				}
+				$term = get_term( (int) $term_id, 'wbtm_bus_stops' );
+				if ( $term && ! is_wp_error( $term ) ) {
+					$this->stop_rename_old_names[ (int) $term_id ] = $term->name;
+				}
+			}
+			/**
+			 * When a bus stop is renamed, migrate every reference to the old name —
+			 * across all buses' route/fare configuration and all existing bookings —
+			 * to the new name, so nothing has to be reconfigured and availability
+			 * keeps counting the renamed stop's bookings.
+			 *
+			 * @param int $term_id Renamed term id.
+			 */
+			public function wbtm_migrate_stop_rename( $term_id ) {
+				$term_id = (int) $term_id;
+				if ( ! isset( $this->stop_rename_old_names[ $term_id ] ) ) {
+					return;
+				}
+				$old_name = $this->stop_rename_old_names[ $term_id ];
+				unset( $this->stop_rename_old_names[ $term_id ] );
+				$term = get_term( $term_id, 'wbtm_bus_stops' );
+				if ( ! $term || is_wp_error( $term ) ) {
+					return;
+				}
+				$new_name = $term->name;
+				// Strict compare: a case-only rename (Berlin -> berlin) still needs
+				// migrating because the editor's stop <select> matches case-sensitively.
+				if ( $old_name === '' || $old_name === $new_name ) {
+					return;
+				}
+				$bus_ids = get_posts( array(
+					'post_type'      => WBTM_Functions::get_cpt(),
+					'post_status'    => 'any',
+					'posts_per_page' => -1,
+					'fields'         => 'ids',
+				) );
+				foreach ( $bus_ids as $bus_id ) {
+					$this->wbtm_rename_stop_in_bus_config( (int) $bus_id, $old_name, $new_name );
+				}
+				$this->wbtm_rename_stop_in_bookings( $old_name, $new_name );
+			}
+			/**
+			 * Replace a stop name in one bus's route + fare configuration meta.
+			 */
+			private function wbtm_rename_stop_in_bus_config( $bus_id, $old_name, $new_name ) {
+				$is_old = static function ( $value ) use ( $old_name ) {
+					return is_string( $value ) && 0 === strcasecmp( trim( $value ), trim( $old_name ) );
+				};
+				// Route legs: rows keyed by 'place'.
+				foreach ( array( 'wbtm_route_info', 'wbtm_return_route_info' ) as $key ) {
+					$rows = get_post_meta( $bus_id, $key, true );
+					if ( is_array( $rows ) && $rows ) {
+						$changed = false;
+						foreach ( $rows as $i => $row ) {
+							if ( is_array( $row ) && isset( $row['place'] ) && $is_old( $row['place'] ) ) {
+								$rows[ $i ]['place'] = $new_name;
+								$changed            = true;
+							}
+						}
+						if ( $changed ) {
+							update_post_meta( $bus_id, $key, $rows );
+						}
+					}
+				}
+				// Fare rows: boarding/dropping stop names.
+				$prices = get_post_meta( $bus_id, 'wbtm_bus_prices', true );
+				if ( is_array( $prices ) && $prices ) {
+					$changed = false;
+					foreach ( $prices as $i => $row ) {
+						if ( ! is_array( $row ) ) {
+							continue;
+						}
+						if ( isset( $row['wbtm_bus_bp_price_stop'] ) && $is_old( $row['wbtm_bus_bp_price_stop'] ) ) {
+							$prices[ $i ]['wbtm_bus_bp_price_stop'] = $new_name;
+							$changed                                = true;
+						}
+						if ( isset( $row['wbtm_bus_dp_price_stop'] ) && $is_old( $row['wbtm_bus_dp_price_stop'] ) ) {
+							$prices[ $i ]['wbtm_bus_dp_price_stop'] = $new_name;
+							$changed                                = true;
+						}
+					}
+					if ( $changed ) {
+						update_post_meta( $bus_id, 'wbtm_bus_prices', $prices );
+					}
+				}
+				// Flat stop-name arrays (boarding list, dropping list, route order).
+				foreach ( array( 'wbtm_bus_bp_stops', 'wbtm_bus_next_stops', 'wbtm_route_direction' ) as $key ) {
+					$list = get_post_meta( $bus_id, $key, true );
+					if ( is_array( $list ) && $list ) {
+						$changed = false;
+						foreach ( $list as $i => $value ) {
+							if ( $is_old( $value ) ) {
+								$list[ $i ] = $new_name;
+								$changed    = true;
+							}
+						}
+						if ( $changed ) {
+							update_post_meta( $bus_id, $key, $list );
+						}
+					}
+				}
+			}
+			/**
+			 * Repoint existing bookings from the old stop name to the new one.
+			 *
+			 * Availability (WBTM_Query::query_total_booked) matches bookings to a route
+			 * by wbtm_boarding_point / wbtm_dropping_point, so leaving these on the old
+			 * name after the route was migrated would drop those seats from the count
+			 * and allow them to be sold twice.
+			 */
+			private function wbtm_rename_stop_in_bookings( $old_name, $new_name ) {
+				foreach ( array( 'wbtm_boarding_point', 'wbtm_dropping_point' ) as $meta_key ) {
+					$booking_ids = get_posts( array(
+						'post_type'      => 'wbtm_bus_booking',
+						'post_status'    => 'any',
+						'posts_per_page' => -1,
+						'fields'         => 'ids',
+						'meta_query'     => array(
+							array(
+								'key'     => $meta_key,
+								'value'   => $old_name,
+								'compare' => '=',
+							),
+						),
+					) );
+					foreach ( $booking_ids as $booking_id ) {
+						update_post_meta( (int) $booking_id, $meta_key, $new_name );
+					}
+				}
+			}
 		}
 		new WBTM_Taxonomy();
 	}

--- a/assets/admin/js/wbtm-global-settings.js
+++ b/assets/admin/js/wbtm-global-settings.js
@@ -124,6 +124,25 @@
 			});
 		});
 
+		// ── Ticket Sale Cut-off: reveal only the fields relevant to the chosen mode.
+		// Hidden when the cut-off is disabled; "Hours before" shows the hours field,
+		// "Specific time before" shows the days-before + cut-off-time fields.
+		var $cutoffEnable = $('select[name="wbtm_general_settings[ticket_sale_cutoff_enable]"]');
+		if ($cutoffEnable.length) {
+			var $cutoffType = $('select[name="wbtm_general_settings[ticket_sale_cutoff_type]"]');
+			var applyCutoffVisibility = function () {
+				var enabled = $cutoffEnable.val() === 'enable';
+				var type    = $cutoffType.val();
+				$('.wbtm-field-ticket_sale_cutoff_type').toggle(enabled);
+				$('.wbtm-field-ticket_sale_cutoff_hours').toggle(enabled && type === 'hours');
+				$('.wbtm-field-ticket_sale_cutoff_days_before').toggle(enabled && type === 'clock');
+				$('.wbtm-field-ticket_sale_cutoff_clock').toggle(enabled && type === 'clock');
+			};
+			$cutoffEnable.on('change', applyCutoffVisibility);
+			$cutoffType.on('change', applyCutoffVisibility);
+			applyCutoffVisibility();
+		}
+
 		// Activate the tab the admin was last on (e.g. before clicking Save, which
 		// does a full page reload via a real form POST), falling back to the
 		// server-provided default when nothing was remembered yet or the

--- a/inc/WBTM_Cart_Helper.php
+++ b/inc/WBTM_Cart_Helper.php
@@ -114,6 +114,16 @@ if ( ! class_exists( 'WBTM_Cart_Helper' ) ) {
 			if ( get_post_type( $post_id ) != WBTM_Functions::get_cpt() ) {
 				return true;
 			}
+			// Enforce the ticket-sale cut-off (and past-departure): a departure whose
+			// sale deadline has passed can't be booked, even via a crafted request that
+			// bypasses the hidden search UI. Covers the WooCommerce, Standalone and
+			// backend (counter) flows, since they all validate through this method.
+			if ( $date && ! WBTM_Functions::is_ticket_sale_open( $date ) ) {
+				return new WP_Error(
+					'wbtm_sale_closed',
+					esc_html__( 'Ticket sales for this trip are closed.', 'bus-ticket-booking-with-seat-reservation' )
+				);
+			}
 			$booking_mode = $booking_mode === 'full_bus' ? 'full_bus' : 'seat';
 			// Reject segments with no fare configured so they can't be booked at 0,
 			// even via a crafted request that bypasses the hidden UI. Full-bus pricing

--- a/inc/WBTM_Functions.php
+++ b/inc/WBTM_Functions.php
@@ -1094,7 +1094,9 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 										$bp_date = $info['time'];
 									}
 									if ( $bp_date && strtolower( (string) $end_route ) === strtolower( (string) $info['place'] ) && ( $ignore_types || $info['type'] == 'dp' || $info['type'] == 'both' ) ) {
-										$slice_time = self::slice_buffer_time( $bp_date );
+										// Ticket-sale deadline = operational buffer AND the optional
+										// admin "Ticket Sale Cut-off" (whichever closes sales first).
+										$slice_time = self::ticket_sale_deadline( $bp_date );
 										if ( strtotime( $now_full ) < strtotime( $slice_time ) ) {
 											$seat_type  = WBTM_Global_Function::get_post_info( $post_id, 'wbtm_seat_type_conf' );
 											if ( $seat_type == 'wbtm_seat_plan' && class_exists( 'WBTM_Seat_Configuration' ) ) {
@@ -1459,6 +1461,74 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 					$date = gmdate( 'Y-m-d H:i', strtotime( $date ) - $buffer_time );
 				}
 				return $date;
+			}
+			/**
+			 * Latest moment a ticket for a given departure may be sold.
+			 *
+			 * Combines the existing operational buffer (slice_buffer_time) with the
+			 * optional, admin-configurable "Ticket Sale Cut-off" (General Settings ->
+			 * Booking behavior). The cut-off lets operators stop sales a set time before
+			 * each departure so they have time to plan routes — either a fixed number of
+			 * hours before departure, or a specific clock time on a day before departure
+			 * ("10 PM the night before"). Whichever comes first (buffer or cut-off) wins.
+			 * When the cut-off is disabled this returns exactly the buffer-adjusted
+			 * departure, so existing behaviour is unchanged.
+			 *
+			 * @param string $bp_date Departure/boarding datetime (Y-m-d H:i or parseable).
+			 * @return string Deadline as 'Y-m-d H:i', or '' when the departure is unparseable.
+			 */
+			public static function ticket_sale_deadline( $bp_date ) {
+				$departure_ts = strtotime( (string) $bp_date );
+				if ( ! $departure_ts ) {
+					return '';
+				}
+				$deadline_ts = strtotime( self::slice_buffer_time( $bp_date ) );
+				$cutoff_ts   = self::ticket_sale_cutoff_ts( $departure_ts );
+				if ( $cutoff_ts !== null && $cutoff_ts < $deadline_ts ) {
+					$deadline_ts = $cutoff_ts;
+				}
+				return gmdate( 'Y-m-d H:i', $deadline_ts );
+			}
+			/**
+			 * Whether ticket sales for a given departure are still open right now.
+			 *
+			 * @param string $bp_date Departure/boarding datetime.
+			 * @return bool True when sales are open (or the deadline can't be determined).
+			 */
+			public static function is_ticket_sale_open( $bp_date ) {
+				$deadline = self::ticket_sale_deadline( $bp_date );
+				if ( $deadline === '' ) {
+					return true;
+				}
+				return strtotime( current_time( 'Y-m-d H:i' ) ) < strtotime( $deadline );
+			}
+			/**
+			 * Resolve the configured ticket-sale cut-off to a unix timestamp for a
+			 * specific departure, or null when the cut-off is disabled/misconfigured.
+			 *
+			 * @param int $departure_ts Departure unix timestamp.
+			 * @return int|null
+			 */
+			private static function ticket_sale_cutoff_ts( $departure_ts ) {
+				if ( 'enable' !== WBTM_Global_Function::get_settings( 'wbtm_general_settings', 'ticket_sale_cutoff_enable', 'disable' ) ) {
+					return null;
+				}
+				$type = WBTM_Global_Function::get_settings( 'wbtm_general_settings', 'ticket_sale_cutoff_type', 'hours' );
+				if ( 'clock' === $type ) {
+					$days  = max( 0, (int) WBTM_Global_Function::get_settings( 'wbtm_general_settings', 'ticket_sale_cutoff_days_before', 1 ) );
+					$clock = trim( (string) WBTM_Global_Function::get_settings( 'wbtm_general_settings', 'ticket_sale_cutoff_clock', '22:00' ) );
+					if ( ! preg_match( '/^([01]?\d|2[0-3]):([0-5]\d)$/', $clock, $m ) ) {
+						return null;
+					}
+					$cutoff_day = gmdate( 'Y-m-d', strtotime( "-{$days} day", $departure_ts ) );
+					return strtotime( $cutoff_day . ' ' . sprintf( '%02d:%02d', (int) $m[1], (int) $m[2] ) );
+				}
+				// Fixed hours before departure.
+				$hours = (float) WBTM_Global_Function::get_settings( 'wbtm_general_settings', 'ticket_sale_cutoff_hours', 12 );
+				if ( $hours <= 0 ) {
+					return null;
+				}
+				return $departure_ts - (int) round( $hours * 3600 );
 			}
 			//==========================//
 			/**


### PR DESCRIPTION
Ticket Sale Cut-off (General Settings > Booking behavior): stop selling a set time before each departure — either fixed hours before, or a specific clock time on a day before ("10 PM the night before"). Enforced in search results and at checkout (WooCommerce, Standalone and counter). Disabled by default. The settings JS reveals only the cut-off fields relevant to the chosen mode.

Bus Stop rename migration: renaming a wbtm_bus_stops term now rewrites the old name to the new one across every bus route/fare config AND existing bookings, so nothing has to be reconfigured and availability keeps counting the renamed stop bookings (prevents silent double-booking).