### PR TITLE
Double-decker cabins: per-cabin upper/lower deck support

### DIFF
--- a/admin/WBTM_Booking_List.php
+++ b/admin/WBTM_Booking_List.php
@@ -497,7 +497,7 @@
 						get_post_meta($id, 'wbtm_boarding_point', true),
 						get_post_meta($id, 'wbtm_dropping_point', true),
 						get_post_meta($id, 'wbtm_boarding_time', true) ?: get_post_meta($id, 'wbtm_booking_date', true),
-						get_post_meta($id, 'wbtm_seat', true),
+						$this->seat_label($id),
 						get_post_meta($id, 'wbtm_ticket', true),
 						$fare,
 						$extras,
@@ -566,7 +566,7 @@
 
 					$route = trim($bp . ($dp ? ' → ' . $dp : ''));
 					$cust  = esc_html($name ?: '—') . ($phone ? '<br><span style="color:#777;">' . esc_html($phone) . '</span>' : '');
-					$seatt = esc_html($seat) . ($ticket ? '<br><span style="color:#777;">' . esc_html($ticket) . '</span>' : '');
+					$seatt = esc_html($this->seat_label($id)) . ($ticket ? '<br><span style="color:#777;">' . esc_html($ticket) . '</span>' : '');
 					$exlabel = $this->extra_services_label($id);
 					$excell  = $extras > 0
 						? wp_strip_all_tags(WBTM_Global_Function::format_price($extras)) . ($exlabel ? '<br><span style="color:#777;">' . esc_html($exlabel) . '</span>' : '')
@@ -949,6 +949,20 @@
 				return 'woocommerce';
 			}
 
+			/**
+			 * Deck-aware display label for a booking's stored seat. Shows the cabin
+			 * name and, for a double-decker cabin's upper deck, the "Upper Deck"
+			 * marker (e.g. "Coach A - Upper Deck - U3"). Non-cabin seats unchanged.
+			 */
+			private function seat_label($id) {
+				if (!class_exists('WBTM_Functions')) {
+					return get_post_meta($id, 'wbtm_seat', true);
+				}
+				return WBTM_Functions::format_cabin_seat_label(
+					get_post_meta($id, 'wbtm_seat', true),
+					get_post_meta($id, 'wbtm_cabin_info', true)
+				);
+			}
 			private function source_badge($source) {
 				if ($source === 'standalone') {
 					return '<span class="wbtm-bkl-source wbtm-bkl-source-custom" title="' . esc_attr__('Booked via Custom Payment (no WooCommerce order)', 'bus-ticket-booking-with-seat-reservation') . '"><span class="dashicons dashicons-money-alt"></span>' . esc_html__('Custom', 'bus-ticket-booking-with-seat-reservation') . '</span>';
@@ -1638,7 +1652,7 @@
 					</td>
 					<td data-col="journey_date" data-label="<?php echo esc_attr__('Journey Date', 'bus-ticket-booking-with-seat-reservation'); ?>"<?php echo $this->col_style($vis, 'journey_date'); ?>><?php echo esc_html($journey_date ?: '—'); ?></td>
 					<td data-col="seat_ticket" data-label="<?php echo esc_attr__('Seat / Ticket', 'bus-ticket-booking-with-seat-reservation'); ?>"<?php echo $this->col_style($vis, 'seat_ticket'); ?>>
-						<?php if ($seat) : ?><span class="wbtm-bkl-pill"><?php echo esc_html($seat); ?></span><?php endif; ?>
+						<?php if ($seat) : ?><span class="wbtm-bkl-pill"><?php echo esc_html($this->seat_label($id)); ?></span><?php endif; ?>
 						<?php if ($ticket) : ?><br><small><?php echo esc_html($ticket); ?></small><?php endif; ?>
 					</td>
 					<td data-col="total" data-label="<?php echo esc_attr__('Total', 'bus-ticket-booking-with-seat-reservation'); ?>"<?php echo $this->col_style($vis, 'total'); ?>>
@@ -1961,7 +1975,7 @@
 											<?php endif; ?>
 											<dt><?php esc_html_e('Journey Date', 'bus-ticket-booking-with-seat-reservation'); ?></dt><dd><?php echo esc_html($journey_date ?: '—'); ?></dd>
 											<?php if ($dp_time) : ?><dt><?php esc_html_e('Arrival', 'bus-ticket-booking-with-seat-reservation'); ?></dt><dd><?php echo esc_html($dp_time); ?></dd><?php endif; ?>
-											<dt><?php esc_html_e('Seat', 'bus-ticket-booking-with-seat-reservation'); ?></dt><dd><?php echo $seat ? '<span class="wbtm-bkl-pill">' . esc_html($seat) . '</span>' : '—'; ?></dd>
+											<dt><?php esc_html_e('Seat', 'bus-ticket-booking-with-seat-reservation'); ?></dt><dd><?php echo $seat ? '<span class="wbtm-bkl-pill">' . esc_html($this->seat_label($id)) . '</span>' : '—'; ?></dd>
 											<dt><?php esc_html_e('Ticket Type', 'bus-ticket-booking-with-seat-reservation'); ?></dt><dd><?php echo esc_html($ticket ?: '—'); ?></dd>
 											<dt><?php esc_html_e('Payment Method', 'bus-ticket-booking-with-seat-reservation'); ?></dt><dd><?php echo esc_html($billing_type ? ucfirst($billing_type) : '—'); ?></dd>
 										</dl>
@@ -2015,7 +2029,7 @@
 										</thead>
 										<tbody>
 											<tr>
-												<td><?php echo esc_html($ticket ?: esc_html__('Seat fare', 'bus-ticket-booking-with-seat-reservation')); ?> <?php echo $seat ? '(' . esc_html($seat) . ')' : ''; ?></td>
+												<td><?php echo esc_html($ticket ?: esc_html__('Seat fare', 'bus-ticket-booking-with-seat-reservation')); ?> <?php echo $seat ? '(' . esc_html($this->seat_label($id)) . ')' : ''; ?></td>
 												<td>1</td>
 												<td><?php echo wp_kses_post(WBTM_Global_Function::format_price($fare_line)); ?></td>
 											</tr>

--- a/admin/WBTM_Settings.php
+++ b/admin/WBTM_Settings.php
@@ -450,6 +450,14 @@
 					$cabin_rows = isset($_POST['wbtm_cabin_rows']) ? array_map('sanitize_text_field', wp_unslash($_POST['wbtm_cabin_rows'])) : [];
 					$cabin_cols = isset($_POST['wbtm_cabin_cols']) ? array_map('sanitize_text_field', wp_unslash($_POST['wbtm_cabin_cols'])) : [];
 					$cabin_price_multipliers = isset($_POST['wbtm_cabin_price_multiplier']) ? array_map('sanitize_text_field', wp_unslash($_POST['wbtm_cabin_price_multiplier'])) : [];
+					// Per-cabin upper deck (double-decker coach). upper_enabled is an
+					// indexed checkbox array (like wbtm_cabin_enabled — unchecked
+					// boxes never submit); upper rows/cols are parallel arrays that
+					// stay index-aligned because every cabin always renders one each.
+					$cabin_upper_enabled = isset($_POST['wbtm_cabin_upper_enabled']) ? array_map('sanitize_text_field', wp_unslash($_POST['wbtm_cabin_upper_enabled'])) : [];
+					$cabin_rows_dd = isset($_POST['wbtm_cabin_rows_dd']) ? array_map('sanitize_text_field', wp_unslash($_POST['wbtm_cabin_rows_dd'])) : [];
+					$cabin_cols_dd = isset($_POST['wbtm_cabin_cols_dd']) ? array_map('sanitize_text_field', wp_unslash($_POST['wbtm_cabin_cols_dd'])) : [];
+					$cabin_upper_multipliers = isset($_POST['wbtm_cabin_upper_price_multiplier']) ? array_map('sanitize_text_field', wp_unslash($_POST['wbtm_cabin_upper_price_multiplier'])) : [];
 					$cabin_config = [];
 					for ($i = 0; $i < $cabin_count; $i++) {
 						$cabin_config[] = [
@@ -457,7 +465,11 @@
 							'enabled' => isset($cabin_enabled[$i]) ? 'yes' : 'no',
 							'rows' => intval($cabin_rows[$i] ?? 0),
 							'cols' => intval($cabin_cols[$i] ?? 0),
-							'price_multiplier' => floatval($cabin_price_multipliers[$i] ?? 1.0)
+							'price_multiplier' => floatval($cabin_price_multipliers[$i] ?? 1.0),
+							'upper_enabled' => isset($cabin_upper_enabled[$i]) ? 'yes' : 'no',
+							'upper_rows' => intval($cabin_rows_dd[$i] ?? 0),
+							'upper_cols' => intval($cabin_cols_dd[$i] ?? 0),
+							'upper_price_multiplier' => floatval($cabin_upper_multipliers[$i] ?? 1.0)
 						];
 					}
 					update_post_meta($post_id, 'wbtm_cabin_config', $cabin_config);
@@ -473,6 +485,11 @@
 							// cabin's toggle state is preserved for when it's re-enabled.
 							$enable_rotation = isset($_POST['wbtm_enable_seat_rotation_cabin_' . $cabin_index]) && sanitize_text_field(wp_unslash($_POST['wbtm_enable_seat_rotation_cabin_' . $cabin_index])) ? 'yes' : 'no';
 							update_post_meta($post_id, 'wbtm_enable_seat_rotation_cabin_' . $cabin_index, $enable_rotation);
+							// Upper-deck rotation toggle — saved before the enabled-cabin
+							// skip below (same reasoning as the lower deck above) so a
+							// disabled cabin keeps its upper-deck rotation state.
+							$up_enable_rotation = isset($_POST['wbtm_enable_seat_rotation_cabin_dd_' . $cabin_index]) && sanitize_text_field(wp_unslash($_POST['wbtm_enable_seat_rotation_cabin_dd_' . $cabin_index])) ? 'yes' : 'no';
+							update_post_meta($post_id, 'wbtm_enable_seat_rotation_cabin_dd_' . $cabin_index, $up_enable_rotation);
 							if (($cabin['enabled'] ?? 'yes') !== 'yes')
 								continue;
 							$has_enabled_cabin = true;
@@ -517,6 +534,54 @@
 								}
 							}
 							update_post_meta($post_id, 'wbtm_cabin_seats_info_' . $cabin_index, $cabin_seat_info);
+							// ---- Upper deck of this cabin (double-decker coach) ----
+							// Mirrors the lower-deck grid save above, but reads the
+							// "_dd_" seat inputs and stores under wbtm_cabin_seats_info_dd_{index}.
+							// Its seats add to the same $total_seat accumulator so the bus's
+							// available-seat math counts both decks.
+							if (($cabin['upper_enabled'] ?? 'no') === 'yes') {
+								$up_rows = $cabin['upper_rows'] ?? 0;
+								$up_cols = $cabin['upper_cols'] ?? 0;
+								$cabin_up_seat_info = [];
+								if ($up_rows > 0 && $up_cols > 0) {
+									for ($j = 1; $j <= $up_cols; $j++) {
+										$up_col_infos = isset($_POST['wbtm_cabin_' . $cabin_index . '_dd_seat' . $j])
+											? array_map('sanitize_text_field', wp_unslash((array) $_POST['wbtm_cabin_' . $cabin_index . '_dd_seat' . $j]))
+											: null;
+										$up_col_rotation_infos = isset($_POST['wbtm_cabin_' . $cabin_index . '_dd_seat' . $j . '_rotation'])
+											? array_map('sanitize_text_field', wp_unslash((array) $_POST['wbtm_cabin_' . $cabin_index . '_dd_seat' . $j . '_rotation']))
+											: null;
+										if ($up_col_infos === null) {
+											$up_col_infos = [];
+										} elseif (is_array($up_col_infos)) {
+											$up_col_infos = array_values($up_col_infos);
+										} else {
+											$up_col_infos = [$up_col_infos];
+										}
+										if ($up_col_rotation_infos === null) {
+											$up_col_rotation_infos = [];
+										} elseif (is_array($up_col_rotation_infos)) {
+											$up_col_rotation_infos = array_values($up_col_rotation_infos);
+										} else {
+											$up_col_rotation_infos = [$up_col_rotation_infos];
+										}
+										for ($i = 0; $i < $up_rows; $i++) {
+											if (isset($up_col_infos[$i])) {
+												$seat_value = WBTM_Seat_Configuration::normalize_saved_seat_value($up_col_infos[$i]);
+												$rotation_value = $up_col_rotation_infos[$i] ?? '0';
+												$cabin_up_seat_info[$i]['cabin_' . $cabin_index . '_dd_seat' . $j] = $seat_value;
+												if ($up_enable_rotation == 'yes') {
+													$cabin_up_seat_info[$i]['cabin_' . $cabin_index . '_dd_seat' . $j . '_rotation'] = $rotation_value;
+												}
+												if ($seat_value && !WBTM_Seat_Configuration::is_non_seat_item($seat_value)) {
+													$total_seat++;
+												}
+											}
+										}
+									}
+								}
+								update_post_meta($post_id, 'wbtm_cabin_seats_info_dd_' . $cabin_index, $cabin_up_seat_info);
+							}
 						}
 						if ($has_enabled_cabin) {
 							update_post_meta($post_id, 'wbtm_get_total_seat', $total_seat);

--- a/admin/settings/WBTM_Seat_Configuration.php
+++ b/admin/settings/WBTM_Seat_Configuration.php
@@ -257,6 +257,10 @@
 					foreach ($cabin_config as $index => $cabin) {
 						if (($cabin['enabled'] ?? 'yes') !== 'yes') continue;
 						$cabin_seats = WBTM_Global_Function::get_post_info($post_id, 'wbtm_cabin_seats_info_' . $index, []);
+						if (($cabin['upper_enabled'] ?? 'no') === 'yes') {
+							// Include the upper deck of a double-decker cabin in the capacity count.
+							$cabin_seats = array_merge($cabin_seats, WBTM_Global_Function::get_post_info($post_id, 'wbtm_cabin_seats_info_dd_' . $index, []));
+						}
 						foreach ($cabin_seats as $row) {
 							foreach ($row as $key => $val) {
 								if (strpos($key, '_rotation') !== false) continue;
@@ -676,27 +680,32 @@
                 </tr>
 				<?php
 			}
-			public function render_cabin_seat_plan($post_id, $cabin_index, $rows, $cols) {
+			public function render_cabin_seat_plan($post_id, $cabin_index, $rows, $cols, $dd = false) {
 				if ($rows > 0 && $cols > 0) {
-					$seat_key_prefix = 'cabin_' . $cabin_index . '_seat';
-					$seat_infos = WBTM_Global_Function::get_post_info($post_id, 'wbtm_cabin_seats_info_' . $cabin_index, []);
-					// Independent per cabin — mirrors the lower/upper deck pattern
-					// (wbtm_enable_seat_rotation / wbtm_enable_seat_rotation_dd);
+					// Deck-aware keys: the upper deck of a cabin mirrors the lower
+					// deck but with a "_dd_" infix so seat labels never collide
+					// (e.g. lower cabin_0_seat1 vs upper cabin_0_dd_seat1) and can
+					// be booked independently on both decks of the same coach.
+					$deck_infix = $dd ? '_dd' : '';
+					$seat_key_prefix = 'cabin_' . $cabin_index . $deck_infix . '_seat';
+					$seat_infos = WBTM_Global_Function::get_post_info($post_id, 'wbtm_cabin_seats_info' . $deck_infix . '_' . $cabin_index, []);
+					// Independent per cabin AND per deck — mirrors the lower/upper deck
+					// pattern (wbtm_enable_seat_rotation / wbtm_enable_seat_rotation_dd);
 					// never shared across cabins or with the deck's own setting.
-					$rotation_key = 'wbtm_enable_seat_rotation_cabin_' . $cabin_index;
+					$rotation_key = 'wbtm_enable_seat_rotation_cabin' . $deck_infix . '_' . $cabin_index;
 					$enable_rotation = WBTM_Global_Function::get_post_info($post_id, $rotation_key);
 					$checked_rotation = $enable_rotation == 'yes' ? 'checked' : '';
 					$enable_seat_price_override = self::is_seat_price_override_enabled($post_id);
 					$rotation_class = $enable_rotation == 'yes' ? 'wbtm_enable_rotation' : '';
 					?>
-                    <div class="wbtm_cabin_settings_area <?php echo esc_attr($rotation_class); ?>">
+                    <div class="wbtm_cabin_settings_area <?php echo esc_attr($rotation_class); ?>" data-deck="<?php echo esc_attr($dd ? 'upper' : 'lower'); ?>">
 						<?php $this->render_seat_item_toolbar(); ?>
                         <div class="ovAuto">
                             <table>
                                 <tbody class="wbtm_cabin_item_insert wbtm_sortable_area">
 								<?php for ($i = 0; $i < $rows; $i++) { ?>
 									<?php $row_info = array_key_exists($i, $seat_infos) ? $seat_infos[$i] : []; ?>
-									<?php $this->cabin_seat_plan_row($cols, $cabin_index, $row_info, $enable_seat_price_override); ?>
+									<?php $this->cabin_seat_plan_row($cols, $cabin_index, $row_info, $enable_seat_price_override, $dd); ?>
 								<?php } ?>
                                 </tbody>
                             </table>
@@ -723,7 +732,7 @@
 								?>
                                 <tr class="wbtm_remove_area wbtm_template_row">
 									<?php for ($j = 1; $j <= $cols; $j++) { ?>
-										<?php $key = 'cabin_' . $cabin_index . '_seat' . $j; ?>
+										<?php $key = 'cabin_' . $cabin_index . $deck_infix . '_seat' . $j; ?>
                                         <th>
                                                                 <div class="wbtm_seat_container">
                                                 <label>
@@ -761,10 +770,11 @@
 					<?php
 				}
 			}
-			public function cabin_seat_plan_row($cols, $cabin_index, $row_info = [], $enable_seat_price_override = true) {
-				$seat_key_prefix = 'cabin_' . $cabin_index . '_seat';
+			public function cabin_seat_plan_row($cols, $cabin_index, $row_info = [], $enable_seat_price_override = true, $dd = false) {
+				$deck_infix = $dd ? '_dd' : '';
+				$seat_key_prefix = 'cabin_' . $cabin_index . $deck_infix . '_seat';
 				$post_id = get_the_ID();
-				$enable_rotation = WBTM_Global_Function::get_post_info($post_id, 'wbtm_enable_seat_rotation_cabin_' . $cabin_index);
+				$enable_rotation = WBTM_Global_Function::get_post_info($post_id, 'wbtm_enable_seat_rotation_cabin' . $deck_infix . '_' . $cabin_index);
 				?>
                 <tr class="wbtm_remove_area">
 					<?php for ($j = 1; $j <= $cols; $j++) { ?>
@@ -813,21 +823,26 @@
 			 * it's a one-time generation aid, never saved to post meta, so it's
 			 * deliberately excluded from form submission entirely.
 			 */
-			public function render_cabin_seat_template_picker($index, $seat_row = 0, $seat_column = 0) {
+			public function render_cabin_seat_template_picker($index, $seat_row = 0, $seat_column = 0, $dd = false) {
 				if (!self::has_seat_toolbar_features()) {
 					return;
 				}
 				$templates   = self::get_seat_templates();
 				$schemes     = self::get_seat_numbering_schemes();
 				$aisle_title = __('Choose aisle position after column (Left to Right). 0 = no automatic aisle.', 'bus-ticket-booking-with-seat-reservation');
+				// Deck-aware field names/classes so a cabin's upper deck picker
+				// never collides with its lower deck picker in the same panel.
+				$dd_c        = $dd ? '_dd' : '';
+				$rows_name   = $dd ? 'wbtm_cabin_rows_dd[]' : 'wbtm_cabin_rows[]';
+				$cols_name   = $dd ? 'wbtm_cabin_cols_dd[]' : 'wbtm_cabin_cols[]';
 				?>
-				<div class="wbtm_seat_template_picker wbtm_cabin_seat_template_picker" data-cabin-index="<?php echo esc_attr($index); ?>">
+				<div class="wbtm_seat_template_picker wbtm_cabin_seat_template_picker<?php echo esc_attr($dd_c); ?>" data-cabin-index="<?php echo esc_attr($index); ?>" data-deck="<?php echo esc_attr($dd ? 'upper' : 'lower'); ?>">
 					<div class="_dFlex_fdColumn">
 						<label>
 							<?php esc_html_e('Seat Template', 'bus-ticket-booking-with-seat-reservation'); ?>
 						</label>
 						<span><?php esc_html_e('Generate a complete seat layout in one click, then edit freely as usual.', 'bus-ticket-booking-with-seat-reservation'); ?></span>
-						<select class="formControl wbtm_cabin_seat_template_select">
+						<select class="formControl wbtm_cabin_seat_template_select<?php echo esc_attr($dd_c); ?>">
 							<option value=""><?php esc_html_e('-- No template --', 'bus-ticket-booking-with-seat-reservation'); ?></option>
 							<?php foreach ($templates as $key => $tpl) : ?>
 								<option value="<?php echo esc_attr($key); ?>"><?php echo esc_html($tpl['label']); ?></option>
@@ -840,7 +855,7 @@
 							<?php esc_html_e('Seat Numbering', 'bus-ticket-booking-with-seat-reservation'); ?>
 						</label>
 						<span><?php esc_html_e('How seat labels are generated when the template is applied.', 'bus-ticket-booking-with-seat-reservation'); ?></span>
-						<select class="formControl wbtm_cabin_seat_numbering_select">
+						<select class="formControl wbtm_cabin_seat_numbering_select<?php echo esc_attr($dd_c); ?>">
 							<?php foreach ($schemes as $key => $label) : ?>
 								<option value="<?php echo esc_attr($key); ?>"><?php echo esc_html($label); ?></option>
 							<?php endforeach; ?>
@@ -851,24 +866,24 @@
 						<label class="mp_zero">
 							<?php esc_html_e('Seat Rows', 'bus-ticket-booking-with-seat-reservation'); ?>
 						</label>
-						<input type="number" min="0" pattern="[0-9]*" step="1" class="formControl max_300 wbtm_number_validation" name="wbtm_cabin_rows[]" placeholder="Ex: 10" value="<?php echo esc_attr($seat_row); ?>"/>
+						<input type="number" min="0" pattern="[0-9]*" step="1" class="formControl max_300 wbtm_number_validation" name="<?php echo esc_attr($rows_name); ?>" placeholder="Ex: 10" value="<?php echo esc_attr($seat_row); ?>"/>
 					</div>
 					<div class="divider"></div>
 					<div class="_dFlex_justifyBetween_alignCenter">
 						<label class="mp_zero">
 							<?php esc_html_e('Seat Columns', 'bus-ticket-booking-with-seat-reservation'); ?>
 						</label>
-						<input type="number" min="0" pattern="[0-9]*" step="1" class="formControl max_300 wbtm_number_validation" name="wbtm_cabin_cols[]" placeholder="Ex: 4" value="<?php echo esc_attr($seat_column); ?>"/>
+						<input type="number" min="0" pattern="[0-9]*" step="1" class="formControl max_300 wbtm_number_validation" name="<?php echo esc_attr($cols_name); ?>" placeholder="Ex: 4" value="<?php echo esc_attr($seat_column); ?>"/>
 					</div>
 					<div class="divider"></div>
 					<div class="_dFlex_justifyBetween_alignCenter">
 						<label class="mp_zero" title="<?php echo esc_attr($aisle_title); ?>">
 							<?php esc_html_e('Aisle Position', 'bus-ticket-booking-with-seat-reservation'); ?>
 						</label>
-						<input type="number" min="0" pattern="[0-9]*" step="1" class="formControl max_300 wbtm_number_validation wbtm_cabin_aisle_after_col" placeholder="Ex: 2 (0=none)" value="0" title="<?php echo esc_attr($aisle_title); ?>"/>
+						<input type="number" min="0" pattern="[0-9]*" step="1" class="formControl max_300 wbtm_number_validation wbtm_cabin_aisle_after_col<?php echo esc_attr($dd_c); ?>" placeholder="Ex: 2 (0=none)" value="0" title="<?php echo esc_attr($aisle_title); ?>"/>
 					</div>
 					<div class="divider"></div>
-					<button type="button" class="_themeButton_xs_mT_xs wbtm_apply_cabin_seat_template">
+					<button type="button" class="_themeButton_xs_mT_xs wbtm_apply_cabin_seat_template<?php echo esc_attr($dd_c); ?>">
 						<span class="fas fa-magic"></span>
 						<span class="mL_xs"><?php esc_html_e('Apply Template', 'bus-ticket-booking-with-seat-reservation'); ?></span>
 					</button>
@@ -921,9 +936,9 @@
                                         <!-- Cabin fields that should be hidden when disabled -->
                                         <div class="wbtm_cabin_fields">
                                             <div class="_dFlex_justifyBetween_alignCenter">
-                                                <label><?php esc_html_e('Price Multiplier', 'bus-ticket-booking-with-seat-reservation'); ?></label>
-                                                <input type="number" min="0" step="0.01" class="formControl max_200" name="wbtm_cabin_price_multiplier[]" placeholder="Ex: 1.0" value="<?php echo esc_attr($cabin['price_multiplier'] ?? 1.0); ?>"/>
-                                                <span class="help-text"><?php esc_html_e('1.0 = same price, 1.2 = 20% higher, 0.8 = 20% lower', 'bus-ticket-booking-with-seat-reservation'); ?></span>
+                                                <label><?php esc_html_e('Price Multiplier (Lower Deck)', 'bus-ticket-booking-with-seat-reservation'); ?></label>
+                                                <input type="number" min="0" step="0.01" inputmode="decimal" class="formControl max_200" name="wbtm_cabin_price_multiplier[]" placeholder="Ex: 1.2" value="<?php echo esc_attr($cabin['price_multiplier'] ?? 1.0); ?>"/>
+                                                <span class="help-text"><?php esc_html_e('Decimals allowed. 1.0 = same as base price, 1.2 = 20% higher, 0.8 = 20% lower.', 'bus-ticket-booking-with-seat-reservation'); ?></span>
                                             </div>
                                             <div class="divider"></div>
 											<?php $this->render_cabin_seat_template_picker($index, $cabin['rows'] ?? 0, $cabin['cols'] ?? 0); ?>
@@ -935,7 +950,7 @@
                                     </div>
                                     <div class="col_6 wbtm_cabin_fields">
                                         <div class="wbtm_cabin_seat_preview" data-cabin-index="<?php echo esc_attr($index); ?>">
-                                            <label><?php echo esc_html(sprintf('Cabin %d Preview', $index + 1)); ?></label>
+                                            <label><?php echo esc_html(sprintf('Cabin %d Lower Deck Preview', $index + 1)); ?></label>
                                             <div class="wbtm_cabin_seat_plan">
 												<?php
 													$cabin_rows = $cabin['rows'] ?? 0;
@@ -944,6 +959,56 @@
 														$this->render_cabin_seat_plan($post_id, $index, $cabin_rows, $cabin_cols);
 													}
 												?>
+                                            </div>
+                                        </div>
+                                    </div>
+                                </div>
+                                <?php
+									// Per-cabin Upper Deck (double-decker coach). Kept inside
+									// .wbtm_cabin_fields so it hides with the rest when the cabin
+									// is disabled; the inner .wbtm_cabin_upper_fields toggles on
+									// the cabin's own "Enable Upper Deck" switch. Mirrors the
+									// bus-level Lower/Upper deck pattern, scoped per cabin.
+									$cabin_upper_enabled = ($cabin['upper_enabled'] ?? 'no') == 'yes';
+								?>
+                                <div class="wbtm_cabin_fields">
+                                    <div class="divider"></div>
+                                    <div class="_dFlex_justifyBetween_alignCenter">
+                                        <div class="_dFlex_fdColumn">
+                                            <label><?php esc_html_e('Enable Upper Deck', 'bus-ticket-booking-with-seat-reservation'); ?></label>
+                                            <span><?php esc_html_e('Turn on to add an upper deck to this cabin/coach (double-decker).', 'bus-ticket-booking-with-seat-reservation'); ?></span>
+                                        </div>
+										<?php WBTM_Custom_Layout::switch_button('wbtm_cabin_upper_enabled[' . $index . ']', $cabin_upper_enabled ? 'checked' : ''); ?>
+                                    </div>
+                                    <div class="wbtm_cabin_upper_fields" style="display: <?php echo esc_attr($cabin_upper_enabled ? 'block' : 'none'); ?>;">
+                                        <div class="divider"></div>
+                                        <div class="_dFlex_justifyBetween_alignCenter">
+                                            <label><?php esc_html_e('Price Multiplier (Upper Deck)', 'bus-ticket-booking-with-seat-reservation'); ?></label>
+                                            <input type="number" min="0" step="0.01" inputmode="decimal" class="formControl max_200" name="wbtm_cabin_upper_price_multiplier[]" placeholder="Ex: 1.5" value="<?php echo esc_attr($cabin['upper_price_multiplier'] ?? 1.0); ?>"/>
+                                            <span class="help-text"><?php esc_html_e('Set the upper deck price independently. Decimals allowed. 1.0 = same as base, 1.5 = 50% higher, 0.8 = 20% lower.', 'bus-ticket-booking-with-seat-reservation'); ?></span>
+                                        </div>
+                                        <div class="divider"></div>
+                                        <div class="_dFlex">
+                                            <div class="col_6 _bR">
+												<?php $this->render_cabin_seat_template_picker($index, $cabin['upper_rows'] ?? 0, $cabin['upper_cols'] ?? 0, true); ?>
+                                                <button type="button" class="_themeButton_xs_mT_xs wbtm_generate_cabin_seats_dd" data-cabin-index="<?php echo esc_attr($index); ?>">
+                                                    <span class="fas fa-plus-square"></span>
+                                                    <span class="mL_xs"><?php esc_html_e('Generate Upper Deck Seat Plan', 'bus-ticket-booking-with-seat-reservation'); ?></span>
+                                                </button>
+                                            </div>
+                                            <div class="col_6">
+                                                <div class="wbtm_cabin_seat_preview" data-cabin-index="<?php echo esc_attr($index); ?>">
+                                                    <label><?php echo esc_html(sprintf('Cabin %d Upper Deck Preview', $index + 1)); ?></label>
+                                                    <div class="wbtm_cabin_seat_plan_dd">
+														<?php
+															$cabin_up_rows = $cabin['upper_rows'] ?? 0;
+															$cabin_up_cols = $cabin['upper_cols'] ?? 0;
+															if ($cabin_up_rows > 0 && $cabin_up_cols > 0) {
+																$this->render_cabin_seat_plan($post_id, $index, $cabin_up_rows, $cabin_up_cols, true);
+															}
+														?>
+                                                    </div>
+                                                </div>
                                             </div>
                                         </div>
                                     </div>
@@ -998,10 +1063,11 @@
 				$row         = isset( $_POST['row'] ) ? intval( wp_unslash( $_POST['row'] ) ) : 0;
 				$column      = isset( $_POST['column'] ) ? intval( wp_unslash( $_POST['column'] ) ) : 0;
 				$cabin_index = isset( $_POST['cabin_index'] ) ? intval( wp_unslash( $_POST['cabin_index'] ) ) : -1;
+				$dd          = isset( $_POST['deck'] ) && sanitize_text_field( wp_unslash( $_POST['deck'] ) ) === 'upper';
 				if ( ! $post_id || ! $row || ! $column || $cabin_index < 0 ) {
 					wp_send_json_error( 'Invalid parameters' );
 				}
-				$this->render_cabin_seat_plan( $post_id, $cabin_index, $row, $column );
+				$this->render_cabin_seat_plan( $post_id, $cabin_index, $row, $column, $dd );
 				die();
 			}
 		}

--- a/assets/admin/css/wbtm-bus-edit-modern.css
+++ b/assets/admin/css/wbtm-bus-edit-modern.css
@@ -825,6 +825,8 @@ button.wbtm-bme__btn.wbtm-bme__btn--primary.wbtm-bme__split-caret{
 .wbtm-bme.wbtm_style .wbtm_seat_type_card_desc{display:block;font-size:12px;color:#64748b;}
 .wbtm-bme.wbtm_style .wbtm_seat_type_card_check{display:flex;align-items:center;justify-content:center;top:14px;right:14px;width:22px;height:22px;border:0;box-shadow:0 0 0 2px #fff;color:transparent;background:transparent;font-size:10px;line-height:1;}
 .wbtm-bme.wbtm_style .wbtm_seat_type_card_check .fas{display:inline-flex;align-items:center;justify-content:center;line-height:1;}
+.wbtm-bme.wbtm_style .wbtm_seat_type_card_disabled,
+.wbtm-bme.wbtm_style .wbtm_seat_type_card_disabled:hover{cursor:not-allowed;opacity:0.55;border-color:var(--line);background:var(--bg);box-shadow:none;}
 .wbtm-bme.wbtm_style .wbtm_seat_type_card_active{border-color:var(--brand);background:var(--brand-soft);box-shadow:none;}
 .wbtm-bme.wbtm_style .wbtm_seat_type_card_active .wbtm_seat_type_card_icon{background:var(--brand);color:#fff;}
 .wbtm-bme.wbtm_style .wbtm_seat_type_card_active .wbtm_seat_type_card_check{background:var(--brand);color:#fff;}

--- a/assets/admin/wbtm_admin.js
+++ b/assets/admin/wbtm_admin.js
@@ -171,6 +171,8 @@
                 let value = parseInt(target.val()) + 1;
                 target.val(value);
                 parent.find('[name="wbtm_seat_rows_hidden"]').val(value);
+                // Bind drag-and-drop + badges on the freshly cloned row's cells.
+                $(document).trigger("wbtm_seat_plan_dom_updated");
             }
         }
     );
@@ -247,6 +249,8 @@
                 let value = parseInt(target.val()) + 1;
                 target.val(value);
                 parent.find('[name="wbtm_seat_rows_dd_hidden"]').val(value);
+                // Bind drag-and-drop + badges on the freshly cloned row's cells.
+                $(document).trigger("wbtm_seat_plan_dom_updated");
             }
         }
     );

--- a/assets/frontend/wbtm.css
+++ b/assets/frontend/wbtm.css
@@ -3102,3 +3102,35 @@ div.wbtm_loader_xs {
   border-color: #c62828;
   color: #c62828;
 }
+
+/* Lower/Upper deck switch inside a double-decker cabin/coach */
+.wbtm_style .wbtm_cabin_deck_tabs {
+  display: flex;
+  gap: 6px;
+  padding: 10px 12px 0;
+}
+.wbtm_style .wbtm_cabin_deck_tab {
+  flex: 1 1 auto;
+  padding: 8px 12px;
+  border: 1px solid #d7dce3;
+  border-bottom: none;
+  border-radius: 8px 8px 0 0;
+  background: #f4f6f9;
+  color: #55606e;
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: background .15s ease, color .15s ease;
+}
+.wbtm_style .wbtm_cabin_deck_tab:hover {
+  background: #eaeef3;
+}
+.wbtm_style .wbtm_cabin_deck_tab.wbtm_cabin_deck_tab_active {
+  background: #fff;
+  color: #1f2733;
+  border-color: #c9d2dc;
+  box-shadow: 0 -2px 0 0 #2d7ff9 inset;
+}
+.wbtm_style .wbtm_deck_pane {
+  border-top: 1px solid #e4e9ef;
+}

--- a/assets/global/wbtm_global.js
+++ b/assets/global/wbtm_global.js
@@ -595,22 +595,39 @@
 				});
 			}
 
-			// Handle multi-cabin seat plans
+			// Handle multi-cabin seat plans (lower deck + optional upper deck).
+			// A cabin can be a double-decker coach: selected seats are collected
+			// per deck pane and written to that deck's own hidden inputs so the
+			// server can rebuild the deck-scoped "cabin_{i}[_dd]_{seat}" identifier.
 			parent.find('.wbtm_cabin_section').each(function () {
 				let cabin_section = $(this);
 				let cabin_index = cabin_section.find('.wbtm_cabin_seat_plan').attr('data-cabin-index');
 				if (cabin_index !== undefined) {
+					// Lower deck
 					let cabin_target = parent.find('[name="wbtm_selected_seat_cabin_' + cabin_index + '"]');
 					let cabin_target_type = parent.find('[name="wbtm_selected_seat_type_cabin_' + cabin_index + '"]');
 					let seats = '';
 					let seats_type = '';
-					cabin_section.find('.seat_available.seat_selected').each(function () {
+					cabin_section.find('.wbtm_deck_pane_lower .seat_available.seat_selected').each(function () {
 						seats = seats ? seats + ',' + $(this).attr('data-seat_name') : $(this).attr('data-seat_name');
 						seats_type = seats_type ? seats_type + ',' + $(this).attr('data-seat_type') : $(this).attr('data-seat_type');
-					}).promise().done(function () {
-						cabin_target.val(seats);
-						cabin_target_type.val(seats_type);
 					});
+					cabin_target.val(seats);
+					cabin_target_type.val(seats_type);
+
+					// Upper deck (only present on double-decker cabins)
+					let cabin_target_dd = parent.find('[name="wbtm_selected_seat_cabin_dd_' + cabin_index + '"]');
+					if (cabin_target_dd.length) {
+						let cabin_target_dd_type = parent.find('[name="wbtm_selected_seat_type_cabin_dd_' + cabin_index + '"]');
+						let seats_up = '';
+						let seats_up_type = '';
+						cabin_section.find('.wbtm_deck_pane_upper .seat_available.seat_selected').each(function () {
+							seats_up = seats_up ? seats_up + ',' + $(this).attr('data-seat_name') : $(this).attr('data-seat_name');
+							seats_up_type = seats_up_type ? seats_up_type + ',' + $(this).attr('data-seat_type') : $(this).attr('data-seat_type');
+						});
+						cabin_target_dd.val(seats_up);
+						cabin_target_dd_type.val(seats_up_type);
+					}
 				}
 			});
 
@@ -843,6 +860,20 @@
 			cabin_section.removeClass('collapsed').addClass('expanded');
 			arrow.text('▲'); // Show up arrow when expanded
 		}
+	});
+
+	// Handle Lower/Upper deck switch inside a double-decker cabin — shows the
+	// chosen deck's seat pane and hides the other. Selection state is preserved
+	// because both panes stay in the DOM (just hidden), so seats picked on one
+	// deck remain selected when switching back.
+	$(document).on('click', '.wbtm_cabin_deck_tab', function () {
+		let tab = $(this);
+		let deck = tab.attr('data-deck');
+		let plan = tab.closest('.wbtm_cabin_seat_plan');
+		plan.find('.wbtm_cabin_deck_tab').removeClass('wbtm_cabin_deck_tab_active');
+		tab.addClass('wbtm_cabin_deck_tab_active');
+		plan.find('.wbtm_deck_pane').hide();
+		plan.find('.wbtm_deck_pane[data-deck="' + deck + '"]').show();
 	});
 
 	// Initialize cabin arrows and classes on page load

--- a/inc/WBTM_Booking_Controller.php
+++ b/inc/WBTM_Booking_Controller.php
@@ -208,8 +208,8 @@ if ( ! class_exists( 'WBTM_Booking_Controller' ) ) {
 						if ( $cabin_mode_enabled === 'yes' && ! empty( $cabin_config ) ) {
 							foreach ( $cabin_config as $cabin_index => $cabin ) {
 								if ( ( $cabin['enabled'] ?? 'yes' ) === 'yes' && ( $cabin['rows'] ?? 0 ) > 0 && ( $cabin['cols'] ?? 0 ) > 0 ) {
-									$key_name = 'wbtm_selected_seat_cabin_' . $cabin_index;
-									if ( ! empty( $_POST[ $key_name ] ) ) {
+									// Detect a selection on either deck of a double-decker cabin.
+									if ( ! empty( $_POST[ 'wbtm_selected_seat_cabin_' . $cabin_index ] ) || ! empty( $_POST[ 'wbtm_selected_seat_cabin_dd_' . $cabin_index ] ) ) {
 										$has_cabin_seats = true;
 										break;
 									}

--- a/inc/WBTM_Cart_Helper.php
+++ b/inc/WBTM_Cart_Helper.php
@@ -157,7 +157,14 @@ if ( ! class_exists( 'WBTM_Cart_Helper' ) ) {
 							continue;
 						}
 						$cabin_index = array_key_exists( 'cabin_index', $seat_info ) ? $seat_info['cabin_index'] : '';
-						$check_seat  = ( $cabin_index !== '' ) ? 'cabin_' . $cabin_index . '_' . $seat_name : $seat_name;
+						// Prefer the pre-built deck-scoped identifier (lower vs upper
+						// deck of a double-decker cabin); fall back to the legacy
+						// lower-deck form for entries that predate it.
+						if ( ! empty( $seat_info['seat_identifier'] ) ) {
+							$check_seat = $seat_info['seat_identifier'];
+						} else {
+							$check_seat = ( $cabin_index !== '' ) ? 'cabin_' . $cabin_index . '_' . $seat_name : $seat_name;
+						}
 						if ( WBTM_Query::query_total_booked( $post_id, $bp, $dp, $date, '', $check_seat ) > 0 ) {
 							return new WP_Error(
 								'wbtm_seat_unavailable',
@@ -198,11 +205,25 @@ if ( ! class_exists( 'WBTM_Cart_Helper' ) ) {
 				foreach ( $cabin_config as $cabin_index => $cabin ) {
 					if ( ( $cabin['enabled'] ?? 'yes' ) !== 'yes' )
 						continue;
-					$key_name = 'wbtm_selected_seat_cabin_' . $cabin_index;
-					$selected_seats = isset( $_POST[ $key_name ] ) ? sanitize_text_field( wp_unslash( $_POST[ $key_name ] ) ) : '';
-					$key_name_ = 'wbtm_selected_seat_type_cabin_' . $cabin_index;
-					$selected_seat_types = isset( $_POST[ $key_name_ ] ) ? sanitize_text_field( wp_unslash( $_POST[ $key_name_ ] ) ) : '';
-					if ( $selected_seats ) {
+					$price_multiplier = $cabin['price_multiplier'] ?? 1.0;
+					// A cabin can be a double-decker coach: gather selections from
+					// both its lower deck and (when present) its upper deck. Each
+					// resulting entry carries a deck-scoped seat_identifier so the
+					// two decks never collide downstream (availability/cart/order).
+					$deck_sources = [
+						[ 'is_upper' => false, 'seat_key' => 'wbtm_selected_seat_cabin_' . $cabin_index, 'type_key' => 'wbtm_selected_seat_type_cabin_' . $cabin_index ],
+						[ 'is_upper' => true,  'seat_key' => 'wbtm_selected_seat_cabin_dd_' . $cabin_index, 'type_key' => 'wbtm_selected_seat_type_cabin_dd_' . $cabin_index ],
+					];
+					$upper_multiplier = isset( $cabin['upper_price_multiplier'] ) ? (float) $cabin['upper_price_multiplier'] : 1.0;
+					foreach ( $deck_sources as $deck_source ) {
+						$selected_seats = isset( $_POST[ $deck_source['seat_key'] ] ) ? sanitize_text_field( wp_unslash( $_POST[ $deck_source['seat_key'] ] ) ) : '';
+						if ( ! $selected_seats ) {
+							continue;
+						}
+						$is_upper = $deck_source['is_upper'];
+						// Each deck is priced by its own multiplier (upper can differ from lower).
+						$deck_multiplier = $is_upper ? $upper_multiplier : $price_multiplier;
+						$selected_seat_types = isset( $_POST[ $deck_source['type_key'] ] ) ? sanitize_text_field( wp_unslash( $_POST[ $deck_source['type_key'] ] ) ) : '';
 						$seat_names = explode( ',', $selected_seats );
 						$seat_types = $selected_seat_types ? explode( ',', $selected_seat_types ) : [];
 						foreach ( $seat_names as $seat_index => $seat_name ) {
@@ -211,16 +232,18 @@ if ( ! class_exists( 'WBTM_Cart_Helper' ) ) {
 							if ( $base_price === false || $base_price < 0 ) {
 								$base_price = 0;
 							}
-							$price_multiplier = $cabin['price_multiplier'] ?? 1.0;
-							$ticket_price = floatval( $base_price ) * floatval( $price_multiplier );
+							$ticket_price = floatval( $base_price ) * floatval( $deck_multiplier );
 							$cabin_seats[] = [
 								'cabin_index' => $cabin_index,
 								'cabin_name' => $cabin['name'] ?? 'Cabin ' . ( $cabin_index + 1 ),
+								'deck' => $is_upper ? 'upper' : 'lower',
+								'is_upper' => $is_upper,
 								'seat_name' => $seat_name,
+								'seat_identifier' => WBTM_Functions::cabin_seat_identifier( $cabin_index, $seat_name, $is_upper ),
 								'seat_type' => $seat_type,
 								'ticket_name' => WBTM_Functions::get_ticket_name( $seat_type, $post_id ),
 								'ticket_price' => $ticket_price,
-								'price_multiplier' => $cabin['price_multiplier'] ?? 1.0
+								'price_multiplier' => $deck_multiplier
 							];
 						}
 					}

--- a/inc/WBTM_Dependencies.php
+++ b/inc/WBTM_Dependencies.php
@@ -92,7 +92,8 @@
 				wp_enqueue_style('wbtm_global', WBTM_PLUGIN_URL . '/assets/global/wbtm_global.css', array(), WBTM_VERSION);
 				wp_enqueue_style('mage-icon', WBTM_PLUGIN_URL . '/assets/mage-icon/css/mage-icon.css', array(), WBTM_VERSION);
 				wp_enqueue_style('wbtm_bus_left_filter', WBTM_PLUGIN_URL . '/assets/global/wbtm_bus_left_filter.css', array(), WBTM_VERSION);
-				wp_enqueue_script('wbtm_global', WBTM_PLUGIN_URL . '/assets/global/wbtm_global.js', array('jquery'), WBTM_VERSION, true);
+				$wbtm_global_js = WBTM_PLUGIN_DIR . '/assets/global/wbtm_global.js';
+				wp_enqueue_script('wbtm_global', WBTM_PLUGIN_URL . '/assets/global/wbtm_global.js', array('jquery'), file_exists($wbtm_global_js) ? filemtime($wbtm_global_js) : WBTM_VERSION, true);
 				wp_enqueue_script('wbtm_bus_left_filter', WBTM_PLUGIN_URL . '/assets/global/wbtm_bus_left_filter.js', array('jquery'), WBTM_VERSION, true);
 				do_action('wbtm_add_common_script');
 			}
@@ -171,7 +172,8 @@
 				do_action('wbtm_add_admin_script');
 			}
 			public function frontend_enqueue() {
-				wp_enqueue_style('wbtm', WBTM_PLUGIN_URL . '/assets/frontend/wbtm.css', array(), WBTM_VERSION);
+				$wbtm_css = WBTM_PLUGIN_DIR . '/assets/frontend/wbtm.css';
+				wp_enqueue_style('wbtm', WBTM_PLUGIN_URL . '/assets/frontend/wbtm.css', array(), file_exists($wbtm_css) ? filemtime($wbtm_css) : WBTM_VERSION);
 				wp_enqueue_style('wtbm_search', WBTM_PLUGIN_URL . '/assets/frontend/wtbm_search.css', array(), WBTM_VERSION);
 				wp_enqueue_style('wtbm_single_bus_details', WBTM_PLUGIN_URL . '/assets/frontend/wtbm_single_bus_details.css', array(), WBTM_VERSION);
 				wp_enqueue_script('wtbm_single_bus_details', WBTM_PLUGIN_URL . '/assets/frontend/wtbm_single_bus_details.js', array('jquery'), WBTM_VERSION, true);

--- a/inc/WBTM_Functions.php
+++ b/inc/WBTM_Functions.php
@@ -1551,6 +1551,98 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 			}
 
 			/**
+			 * Canonical booking identifier for a cabin seat. Lower deck stays
+			 * "cabin_{index}_{seat}" (unchanged, backward compatible); the upper
+			 * deck of a double-decker cabin uses "cabin_{index}_dd_{seat}" so a
+			 * seat labelled the same on both decks never collides for
+			 * availability, holds, cart, or stored order meta.
+			 *
+			 * @param int|string $cabin_index Cabin position.
+			 * @param string     $seat_name   Seat label (e.g. A1).
+			 * @param bool       $is_upper    True for the cabin's upper deck.
+			 * @return string
+			 */
+			public static function cabin_seat_identifier( $cabin_index, $seat_name, $is_upper = false ) {
+				return 'cabin_' . $cabin_index . ( $is_upper ? '_dd_' : '_' ) . $seat_name;
+			}
+
+			/**
+			 * Parse a stored cabin seat value into its parts. Handles both decks:
+			 *   "cabin_0_A1"     -> [ cabin_index=0, is_upper=false, seat=A1 ]
+			 *   "cabin_0_dd_A1"  -> [ cabin_index=0, is_upper=true,  seat=A1 ]
+			 * Returns null for a non-cabin seat (plain label like "A1").
+			 *
+			 * @param string $stored_seat
+			 * @return array|null
+			 */
+			public static function parse_cabin_seat( $stored_seat ) {
+				// The optional "dd_" group marks the upper deck of a double-decker cabin.
+				if ( preg_match( '/^cabin_(\d+)_(dd_)?(.+)$/', (string) $stored_seat, $m ) ) {
+					return array(
+						'cabin_index' => (int) $m[1],
+						'is_upper'    => $m[2] !== '',
+						'seat'        => $m[3],
+					);
+				}
+				return null;
+			}
+
+			/**
+			 * Human-friendly display label for a stored seat value, deck-aware.
+			 * Non-cabin seats are returned unchanged. Cabin seats become
+			 * "Coach A - Upper Deck - A1" (upper) or "Coach A - A1" (lower).
+			 *
+			 * @param string $stored_seat Stored wbtm_seat value.
+			 * @param array  $cabin_info  Optional wbtm_cabin_info (cabin_name/is_upper).
+			 * @param string $sep         Separator between parts.
+			 * @return string
+			 */
+			public static function format_cabin_seat_label( $stored_seat, $cabin_info = array(), $sep = ' - ' ) {
+				$parts = self::parse_cabin_seat( $stored_seat );
+				if ( ! $parts ) {
+					return (string) $stored_seat;
+				}
+				// Prefer the stored deck flag when present (survives even if the
+				// identifier format ever changes); fall back to the parsed "dd_".
+				$is_upper = $parts['is_upper'];
+				if ( is_array( $cabin_info ) && array_key_exists( 'is_upper', $cabin_info ) ) {
+					$is_upper = ! empty( $cabin_info['is_upper'] );
+				}
+				$cabin_name = ( is_array( $cabin_info ) && ! empty( $cabin_info['cabin_name'] ) )
+					? $cabin_info['cabin_name']
+					: sprintf( __( 'Cabin %d', 'bus-ticket-booking-with-seat-reservation' ), $parts['cabin_index'] + 1 );
+				$bits = array( $cabin_name );
+				if ( $is_upper ) {
+					$bits[] = __( 'Upper Deck', 'bus-ticket-booking-with-seat-reservation' );
+				}
+				$bits[] = $parts['seat'];
+				return implode( $sep, $bits );
+			}
+
+			/**
+			 * Just the seat label with a deck suffix but no cabin name — for
+			 * surfaces that already print the cabin name separately.
+			 * "A1" (lower) or "A1 (Upper Deck)" (upper). Non-cabin seats unchanged.
+			 *
+			 * @param string $stored_seat
+			 * @param array  $cabin_info
+			 * @return string
+			 */
+			public static function cabin_seat_short_label( $stored_seat, $cabin_info = array() ) {
+				$parts = self::parse_cabin_seat( $stored_seat );
+				if ( ! $parts ) {
+					return (string) $stored_seat;
+				}
+				$is_upper = $parts['is_upper'];
+				if ( is_array( $cabin_info ) && array_key_exists( 'is_upper', $cabin_info ) ) {
+					$is_upper = ! empty( $cabin_info['is_upper'] );
+				}
+				return $is_upper
+					? $parts['seat'] . ' (' . __( 'Upper Deck', 'bus-ticket-booking-with-seat-reservation' ) . ')'
+					: $parts['seat'];
+			}
+
+			/**
 			 * @param string $storage_key From seat_price_override_storage_key().
 			 * @param string $ticket_type_id Ticket type id (slug) as used in wbtm_ticket_types.
 			 * @return float|null Override amount in store raw price units, or null to use route fare.
@@ -1672,10 +1764,13 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 								foreach ( $cabin_seat_infos as $seat_info ) {
 									$cart_seat_name = array_key_exists( 'seat_name', $seat_info ) ? $seat_info['seat_name'] : '';
 									$cabin_index = array_key_exists( 'cabin_index', $seat_info ) ? $seat_info['cabin_index'] : '';
-													
-									// Create cabin-specific identifier for comparison
-									$cabin_seat_identifier = 'cabin_' . $cabin_index . '_' . $cart_seat_name;
-													
+
+									// Deck-scoped identifier (lower vs upper deck of a
+									// double-decker cabin), with legacy fallback.
+									$cabin_seat_identifier = ! empty( $seat_info['seat_identifier'] )
+										? $seat_info['seat_identifier']
+										: 'cabin_' . $cabin_index . '_' . $cart_seat_name;
+
 									if ( $cabin_seat_identifier == $seat_name ) {
 										return true;
 									}

--- a/inc/WBTM_Seat_Hold.php
+++ b/inc/WBTM_Seat_Hold.php
@@ -100,10 +100,13 @@
 
 			/**
 			 * Cabin-aware seat identifier used by both the booking records and the
-			 * hold keys: cabin_{index}_{seat} for cabin seats, plain name otherwise.
+			 * hold keys: cabin_{index}_{seat} for cabin seats (cabin_{index}_dd_{seat}
+			 * for a double-decker cabin's upper deck), plain name otherwise.
 			 */
-			public static function seat_identifier($seat_name, $cabin_index = '') {
-				return ($cabin_index !== '' && $cabin_index !== null) ? 'cabin_' . $cabin_index . '_' . $seat_name : $seat_name;
+			public static function seat_identifier($seat_name, $cabin_index = '', $is_upper = false) {
+				return ($cabin_index !== '' && $cabin_index !== null)
+					? 'cabin_' . $cabin_index . ($is_upper ? '_dd_' : '_') . $seat_name
+					: $seat_name;
 			}
 
 			/* ================= read API ================= */
@@ -151,7 +154,9 @@
 						continue;
 					}
 					$cabin_index = isset($seat_info['cabin_index']) ? $seat_info['cabin_index'] : '';
-					$identifier = self::seat_identifier($seat_name, $cabin_index);
+					$identifier = !empty($seat_info['seat_identifier'])
+						? $seat_info['seat_identifier']
+						: self::seat_identifier($seat_name, $cabin_index, !empty($seat_info['is_upper']));
 					if (self::is_held_by_other($bus_id, $date, $identifier, $token)) {
 						$conflicts[] = $identifier;
 					}
@@ -276,7 +281,9 @@
 						continue;
 					}
 					$cabin_index = isset($seat_info['cabin_index']) ? $seat_info['cabin_index'] : '';
-					$seats[] = self::seat_identifier($seat_name, $cabin_index);
+					$seats[] = !empty($seat_info['seat_identifier'])
+						? $seat_info['seat_identifier']
+						: self::seat_identifier($seat_name, $cabin_index, !empty($seat_info['is_upper']));
 				}
 				if (!empty($seats)) {
 					self::release_seats($bus_id, $date, $seats, $token);

--- a/inc/WBTM_Woocommerce.php
+++ b/inc/WBTM_Woocommerce.php
@@ -105,8 +105,11 @@
 								foreach ($cabin_seats as $seat_info) {
 									$seat_name = array_key_exists('seat_name', $seat_info) ? $seat_info['seat_name'] : '';
 									$cabin_index = array_key_exists('cabin_index', $seat_info) ? $seat_info['cabin_index'] : '';
-									// Create cabin-specific seat identifier to prevent cross-cabin conflicts
-									$cabin_seat_identifier = 'cabin_' . $cabin_index . '_' . $seat_name;
+									// Create cabin-specific seat identifier to prevent cross-cabin
+									// (and cross-deck, for double-decker cabins) conflicts.
+									$cabin_seat_identifier = !empty($seat_info['seat_identifier'])
+										? $seat_info['seat_identifier']
+										: 'cabin_' . $cabin_index . '_' . $seat_name;
 									if ($seat_name && WBTM_Query::query_total_booked($post_id, $start_route, $end_route, $date, '', $cabin_seat_identifier) > 0) {
 										WC()->cart->remove_cart_item($key);
 //									wc_add_notice(sprintf(__("Seat %s in %s has already been booked by another user. Please choose another seat.", 'bus-ticket-booking-with-seat-reservation'), $seat_name, $seat_info['cabin_name']), 'error');
@@ -303,9 +306,10 @@
 							// Check if any cabin has seats selected
 							foreach ($cabin_config as $cabin_index => $cabin) {
 								if (($cabin['enabled'] ?? 'yes') === 'yes' && ($cabin['rows'] ?? 0) > 0 && ($cabin['cols'] ?? 0) > 0) {
-									$key_name = 'wbtm_selected_seat_cabin_' . $cabin_index;
-									$selected_seats = isset($_POST[$key_name]) ? sanitize_text_field(wp_unslash($_POST[$key_name])) : '';
-									if (!empty($selected_seats)) {
+									// Detect a selection on either deck of a double-decker cabin.
+									$lower_sel = isset($_POST['wbtm_selected_seat_cabin_' . $cabin_index]) ? sanitize_text_field(wp_unslash($_POST['wbtm_selected_seat_cabin_' . $cabin_index])) : '';
+									$upper_sel = isset($_POST['wbtm_selected_seat_cabin_dd_' . $cabin_index]) ? sanitize_text_field(wp_unslash($_POST['wbtm_selected_seat_cabin_dd_' . $cabin_index])) : '';
+									if (!empty($lower_sel) || !empty($upper_sel)) {
 										$has_cabin_seats_selected = true;
 										break;
 									}
@@ -409,11 +413,22 @@
 					foreach ($cabin_config as $cabin_index => $cabin) {
 						if (($cabin['enabled'] ?? 'yes') !== 'yes')
 							continue;
-						$key_name = 'wbtm_selected_seat_cabin_' . $cabin_index;
-						$selected_seats = isset($_POST[$key_name]) ? sanitize_text_field(wp_unslash($_POST[$key_name])) : '';
-						if ($selected_seats) {
+						$price_multiplier = $cabin['price_multiplier'] ?? 1.0;
+						$upper_multiplier = isset($cabin['upper_price_multiplier']) ? (float) $cabin['upper_price_multiplier'] : 1.0;
+						// Sum both decks of a double-decker cabin (lower + upper), each priced
+						// by its own multiplier.
+						$deck_keys = [
+							'wbtm_selected_seat_cabin_' . $cabin_index    => [ 'type' => 'wbtm_selected_seat_type_cabin_' . $cabin_index, 'mult' => $price_multiplier ],
+							'wbtm_selected_seat_cabin_dd_' . $cabin_index => [ 'type' => 'wbtm_selected_seat_type_cabin_dd_' . $cabin_index, 'mult' => $upper_multiplier ],
+						];
+						foreach ($deck_keys as $key_name => $deck_meta) {
+							$selected_seats = isset($_POST[$key_name]) ? sanitize_text_field(wp_unslash($_POST[$key_name])) : '';
+							if (!$selected_seats) {
+								continue;
+							}
+							$key_name_ = $deck_meta['type'];
+							$deck_multiplier = $deck_meta['mult'];
 							$seat_names = explode(',', $selected_seats);
-							$key_name_ = 'wbtm_selected_seat_type_cabin_' . $cabin_index;
 							$seat_types = isset($_POST[$key_name_]) ? sanitize_text_field(wp_unslash($_POST[$key_name_])) : '';
 							$seat_types = $seat_types ? explode(',', $seat_types) : [];
 							foreach ($seat_names as $seat_index => $seat_name) {
@@ -422,8 +437,7 @@
 								if ($base === false || $base < 0) {
 									$base = 0;
 								}
-								$price_multiplier = $cabin['price_multiplier'] ?? 1.0;
-								$total_price += floatval($base) * floatval($price_multiplier);
+								$total_price += floatval($base) * floatval($deck_multiplier);
 							}
 						}
 					}
@@ -644,8 +658,11 @@
 									foreach ($cabin_seat_infos as $seat_info) {
 										$seat_name = array_key_exists('seat_name', $seat_info) ? $seat_info['seat_name'] : '';
 										$cabin_index = array_key_exists('cabin_index', $seat_info) ? $seat_info['cabin_index'] : '';
-										// Create cabin-specific seat identifier to prevent cross-cabin conflicts
-										$cabin_seat_identifier = 'cabin_' . $cabin_index . '_' . $seat_name;
+										// Create cabin-specific seat identifier to prevent cross-cabin
+										// (and cross-deck, for double-decker cabins) conflicts.
+										$cabin_seat_identifier = !empty($seat_info['seat_identifier'])
+											? $seat_info['seat_identifier']
+											: 'cabin_' . $cabin_index . '_' . $seat_name;
 										if ($seat_name && WBTM_Query::query_total_booked($post_id, $start_route, $end_route, $date, '', $cabin_seat_identifier) > 0) {
 											WC()->cart->empty_cart();
 											wc_add_notice(esc_html__("Sorry, Your Selected seat Already Booked by another user", 'bus-ticket-booking-with-seat-reservation'), 'error');
@@ -944,13 +961,21 @@
 								// Save cabin information for cabin/coach bookings to display in passenger list
 								// Fix cabin seat storage: use cabin-specific seat identifier for proper availability tracking
 								if (array_key_exists('cabin_name', $ticket_info) && array_key_exists('cabin_index', $ticket_info)) {
+									// Preserve the deck (lower/upper) so the passenger list,
+									// PDF, email and exports can show it for double-decker cabins.
+									$cabin_is_upper = !empty($ticket_info['is_upper']);
 									$data['wbtm_cabin_info'] = [
 										'cabin_name' => $ticket_info['cabin_name'],
 										'cabin_index' => $ticket_info['cabin_index'],
+										'deck' => $cabin_is_upper ? 'upper' : 'lower',
+										'is_upper' => $cabin_is_upper,
 										'price_multiplier' => $ticket_info['price_multiplier'] ?? 1.0
 									];
-									// Store cabin-specific seat identifier to prevent cross-cabin conflicts
-									$data['wbtm_seat'] = 'cabin_' . $ticket_info['cabin_index'] . '_' . (isset($ticket_info['seat_name']) ? $ticket_info['seat_name'] : $t_seat);
+									// Store the deck-scoped seat identifier to prevent cross-cabin
+									// AND cross-deck conflicts (availability tracking keys on this).
+									$data['wbtm_seat'] = !empty($ticket_info['seat_identifier'])
+										? $ticket_info['seat_identifier']
+										: WBTM_Functions::cabin_seat_identifier($ticket_info['cabin_index'], (isset($ticket_info['seat_name']) ? $ticket_info['seat_name'] : $t_seat), $cabin_is_upper);
 								} else {
 									// Fixed by Shahnur — full bus booking rows without seat_name warning 2026-05-07 12:55 PM
 									// Legacy seat storage for non-cabin bookings

--- a/mp_global/WBTM_Global_File_Load.php
+++ b/mp_global/WBTM_Global_File_Load.php
@@ -99,9 +99,12 @@
 				wp_enqueue_script('jquery.timepicker.min', WBTM_GLOBAL_PLUGIN_URL.'/assets/time_picker/jquery.timepicker.min.js', array('jquery'), 1, true);
 				//=====================//
 				wp_enqueue_script('form-field-dependency', WBTM_GLOBAL_PLUGIN_URL . '/assets/admin/form-field-dependency.js', array('jquery'), null, false);
-				// admin setting global
-				wp_enqueue_script('wbtm_admin_settings', WBTM_GLOBAL_PLUGIN_URL . '/assets/admin/wbtm_admin_settings.js', array('jquery'), WBTM_VERSION, true);
-				wp_enqueue_style('wbtm_admin_settings', WBTM_GLOBAL_PLUGIN_URL . '/assets/admin/wbtm_admin_settings.css', array(), WBTM_VERSION);
+				// admin setting global — versioned by filemtime() (not WBTM_VERSION) so
+				// edits are never served stale from the browser cache between releases.
+				$admin_settings_js  = WBTM_GLOBAL_PLUGIN_DIR . '/assets/admin/wbtm_admin_settings.js';
+				$admin_settings_css = WBTM_GLOBAL_PLUGIN_DIR . '/assets/admin/wbtm_admin_settings.css';
+				wp_enqueue_script('wbtm_admin_settings', WBTM_GLOBAL_PLUGIN_URL . '/assets/admin/wbtm_admin_settings.js', array('jquery'), file_exists($admin_settings_js) ? filemtime($admin_settings_js) : WBTM_VERSION, true);
+				wp_enqueue_style('wbtm_admin_settings', WBTM_GLOBAL_PLUGIN_URL . '/assets/admin/wbtm_admin_settings.css', array(), file_exists($admin_settings_css) ? filemtime($admin_settings_css) : WBTM_VERSION);
 				// Global toast notifications (window.wbtmToast) — available on every gated
 				// plugin admin screen so any settings/list-table script can call it instead
 				// of rolling its own status text or notice box. Versioned by filemtime()

--- a/mp_global/assets/admin/wbtm_admin_settings.css
+++ b/mp_global/assets/admin/wbtm_admin_settings.css
@@ -248,6 +248,13 @@ div.wbtm_style .info_text span {margin: 0 5px 0 0;}
 	font-size: 11px;
 	color: transparent;
 }
+.wbtm_seat_type_card_disabled,
+.wbtm_seat_type_card_disabled:hover {
+	cursor: not-allowed;
+	opacity: 0.55;
+	border-color: #e2e8f0;
+	background: #f8fafc;
+}
 .wbtm_seat_type_card_active {
 	border-color: #22c55e;
 	box-shadow: 0 0 0 1px #22c55e;

--- a/mp_global/assets/admin/wbtm_admin_settings.js
+++ b/mp_global/assets/admin/wbtm_admin_settings.js
@@ -440,9 +440,9 @@ function wbtm_load_sortable_datepicker(parent, item) {
 
                                     <div class="wbtm_cabin_fields">
                                         <div class="_dFlex_justifyBetween_alignCenter">
-                                            <label>Price Multiplier</label>
-                                            <input type="number" min="0" step="0.01" class="formControl max_200" name="wbtm_cabin_price_multiplier[]" placeholder="Ex: 1.0" value="1.0"/>
-                                            <span class="help-text">1.0 = same price, 1.2 = 20% higher, 0.8 = 20% lower</span>
+                                            <label>Price Multiplier (Lower Deck)</label>
+                                            <input type="number" min="0" step="0.01" inputmode="decimal" class="formControl max_200" name="wbtm_cabin_price_multiplier[]" placeholder="Ex: 1.2" value="1.0"/>
+                                            <span class="help-text">Decimals allowed. 1.0 = same as base price, 1.2 = 20% higher, 0.8 = 20% lower.</span>
                                         </div>
                                         <div class="divider"></div>
 
@@ -488,9 +488,81 @@ function wbtm_load_sortable_datepicker(parent, item) {
                                 </div>
                                 <div class="col_6">
                                     <div class="wbtm_cabin_seat_preview" data-cabin-index="${i}">
-                                        <label>Cabin ${i + 1} Preview</label>
+                                        <label>Cabin ${i + 1} Lower Deck Preview</label>
                                         <div class="wbtm_cabin_seat_plan">
                                             <!-- Seat plan will be generated here -->
+                                        </div>
+                                    </div>
+                                </div>
+                            </div>
+                            <div class="wbtm_cabin_fields">
+                                <div class="divider"></div>
+                                <div class="_dFlex_justifyBetween_alignCenter">
+                                    <div class="_dFlex_fdColumn">
+                                        <label>Enable Upper Deck</label>
+                                        <span>Turn on to add an upper deck to this cabin/coach (double-decker).</span>
+                                    </div>
+                                    <label class="roundSwitchLabel">
+                                        <input type="checkbox" name="wbtm_cabin_upper_enabled[${i}]">
+                                        <span class="roundSwitch" data-collapse-target="#wbtm_cabin_upper_enabled[${i}]"></span>
+                                    </label>
+                                </div>
+                                <div class="wbtm_cabin_upper_fields" style="display: none;">
+                                    <div class="divider"></div>
+                                    <div class="_dFlex_justifyBetween_alignCenter">
+                                        <label>Price Multiplier (Upper Deck)</label>
+                                        <input type="number" min="0" step="0.01" inputmode="decimal" class="formControl max_200" name="wbtm_cabin_upper_price_multiplier[]" placeholder="Ex: 1.5" value="1.0"/>
+                                        <span class="help-text">Set the upper deck price independently. Decimals allowed. 1.0 = same as base, 1.5 = 50% higher, 0.8 = 20% lower.</span>
+                                    </div>
+                                    <div class="divider"></div>
+                                    <div class="_dFlex">
+                                        <div class="col_6 _bR">
+                                            <div class="wbtm_seat_template_picker wbtm_cabin_seat_template_picker_dd" data-cabin-index="${i}" data-deck="upper">
+                                                <div class="_dFlex_fdColumn">
+                                                    <label>Seat Template</label>
+                                                    <span>Generate a complete seat layout in one click, then edit freely as usual.</span>
+                                                    <select class="formControl wbtm_cabin_seat_template_select_dd">${templateOptions}</select>
+                                                </div>
+                                                <div class="divider"></div>
+                                                <div class="_dFlex_fdColumn">
+                                                    <label>Seat Numbering</label>
+                                                    <span>How seat labels are generated when the template is applied.</span>
+                                                    <select class="formControl wbtm_cabin_seat_numbering_select_dd">${numberingOptions}</select>
+                                                </div>
+                                                <div class="divider"></div>
+                                                <div class="_dFlex_justifyBetween_alignCenter">
+                                                    <label class="mp_zero">Seat Rows</label>
+                                                    <input type="number" min="0" pattern="[0-9]*" step="1" class="formControl max_300 wbtm_number_validation" name="wbtm_cabin_rows_dd[]" placeholder="Ex: 10" value="0"/>
+                                                </div>
+                                                <div class="divider"></div>
+                                                <div class="_dFlex_justifyBetween_alignCenter">
+                                                    <label class="mp_zero">Seat Columns</label>
+                                                    <input type="number" min="0" pattern="[0-9]*" step="1" class="formControl max_300 wbtm_number_validation" name="wbtm_cabin_cols_dd[]" placeholder="Ex: 4" value="0"/>
+                                                </div>
+                                                <div class="divider"></div>
+                                                <div class="_dFlex_justifyBetween_alignCenter">
+                                                    <label class="mp_zero" title="${aisleTitle}">Aisle Position</label>
+                                                    <input type="number" min="0" pattern="[0-9]*" step="1" class="formControl max_300 wbtm_number_validation wbtm_cabin_aisle_after_col_dd" placeholder="Ex: 2 (0=none)" value="0" title="${aisleTitle}"/>
+                                                </div>
+                                                <div class="divider"></div>
+                                                <button type="button" class="_themeButton_xs_mT_xs wbtm_apply_cabin_seat_template_dd">
+                                                    <span class="fas fa-magic"></span>
+                                                    <span class="mL_xs">Apply Template</span>
+                                                </button>
+                                                <div class="divider"></div>
+                                            </div>
+                                            <button type="button" class="_themeButton_xs_mT_xs wbtm_generate_cabin_seats_dd" data-cabin-index="${i}">
+                                                <span class="fas fa-plus-square"></span>
+                                                <span class="mL_xs">Generate Upper Deck Seat Plan</span>
+                                            </button>
+                                        </div>
+                                        <div class="col_6">
+                                            <div class="wbtm_cabin_seat_preview" data-cabin-index="${i}">
+                                                <label>Cabin ${i + 1} Upper Deck Preview</label>
+                                                <div class="wbtm_cabin_seat_plan_dd">
+                                                    <!-- Upper deck seat plan will be generated here -->
+                                                </div>
+                                            </div>
                                         </div>
                                     </div>
                                 </div>
@@ -500,6 +572,7 @@ function wbtm_load_sortable_datepicker(parent, item) {
                 `;
                 cabin_list.append(cabin_html);
                 wbtmToggleCabinSeatTemplateMode(cabin_list.find('.wbtm_cabin_item[data-cabin-index="' + i + '"] .wbtm_cabin_seat_template_picker'));
+                wbtmToggleCabinSeatTemplateMode(cabin_list.find('.wbtm_cabin_item[data-cabin-index="' + i + '"] .wbtm_cabin_seat_template_picker_dd'));
             }
         } else if (current_cabin_count > cabin_count) {
             // Remove excess cabins
@@ -507,25 +580,46 @@ function wbtm_load_sortable_datepicker(parent, item) {
         }
     });
 
+    // Deck-aware selectors/field names for a cabin's lower vs upper deck.
+    // A cabin can be a double-decker coach: its upper deck mirrors the lower
+    // deck but uses "_dd" field names/classes and a "cabin_{i}_dd_seat{j}"
+    // seat key so both decks are configured and booked independently.
+    function wbtmCabinDeckSel(dd) {
+        return {
+            dd: !!dd,
+            rowsName: dd ? 'wbtm_cabin_rows_dd[]' : 'wbtm_cabin_rows[]',
+            colsName: dd ? 'wbtm_cabin_cols_dd[]' : 'wbtm_cabin_cols[]',
+            plan: dd ? '.wbtm_cabin_seat_plan_dd' : '.wbtm_cabin_seat_plan',
+            picker: dd ? '.wbtm_cabin_seat_template_picker_dd' : '.wbtm_cabin_seat_template_picker',
+            applyBtn: dd ? '.wbtm_apply_cabin_seat_template_dd' : '.wbtm_apply_cabin_seat_template',
+            genBtn: dd ? '.wbtm_generate_cabin_seats_dd' : '.wbtm_generate_cabin_seats',
+            tplSelect: dd ? '.wbtm_cabin_seat_template_select_dd' : '.wbtm_cabin_seat_template_select',
+            numSelect: dd ? '.wbtm_cabin_seat_numbering_select_dd' : '.wbtm_cabin_seat_numbering_select',
+            aisle: dd ? '.wbtm_cabin_aisle_after_col_dd' : '.wbtm_cabin_aisle_after_col',
+            deckParam: dd ? 'upper' : 'lower',
+            seatBase: function (ci, j) { return 'cabin_' + ci + (dd ? '_dd' : '') + '_seat' + j; }
+        };
+    }
+
     // Generate cabin seat plan — SAME AJAX action + rendering
     // (WBTM_Seat_Configuration::render_cabin_seat_plan(), via the
     // wbtm_create_cabin_seat_plan handler) the deck's own "Generate Bus
     // Seat" button uses, so cabins get the full toolbar (drag-and-drop
     // Door/Toilet/Driver/etc.), rotation controls, and per-seat price
     // override button — not just a bare client-built grid.
-    $(document).on('click', '.wbtm_generate_cabin_seats', function() {
-        let button = $(this);
+    function wbtmGenerateCabinSeats(button, dd) {
+        let s = wbtmCabinDeckSel(dd);
         let cabin_item = button.closest('.wbtm_cabin_item');
         let cabin_index = button.attr('data-cabin-index');
-        let row = parseInt(cabin_item.find('input[name="wbtm_cabin_rows[]"]').val()) || 0;
-        let column = parseInt(cabin_item.find('input[name="wbtm_cabin_cols[]"]').val()) || 0;
+        let row = parseInt(cabin_item.find('input[name="' + s.rowsName + '"]').val()) || 0;
+        let column = parseInt(cabin_item.find('input[name="' + s.colsName + '"]').val()) || 0;
 
         if (row <= 0 || column <= 0) {
             alert((typeof wbtm_admin_var !== 'undefined' && wbtm_admin_var.seat_row_col_error) ? wbtm_admin_var.seat_row_col_error : 'Number of rows & columns must be greater than 0');
             return;
         }
 
-        let target = cabin_item.find('.wbtm_cabin_seat_plan');
+        let target = cabin_item.find(s.plan);
         let post_id = $('[name="wbtm_post_id"]').val();
 
         $.ajax({
@@ -537,6 +631,7 @@ function wbtm_load_sortable_datepicker(parent, item) {
                 row: row,
                 column: column,
                 cabin_index: cabin_index,
+                deck: s.deckParam,
                 nonce: wbtm_admin_var.nonce
             },
             beforeSend: function () {
@@ -545,13 +640,13 @@ function wbtm_load_sortable_datepicker(parent, item) {
             success: function (data) {
                 target.html(data);
                 // Numbered per whichever "Seat Numbering" scheme is currently
-                // selected for THIS cabin, with an optional single aisle at
+                // selected for THIS cabin/deck, with an optional single aisle at
                 // the chosen "Aisle Position" — same convenience the deck's
                 // plain "Generate Bus Seat" button already offers.
                 if (window.wbtmSeatNumbering) {
-                    let picker = cabin_item.find('.wbtm_cabin_seat_template_picker');
-                    let numbering = picker.find('.wbtm_cabin_seat_numbering_select').val() || 'sequential';
-                    let aislePos = parseInt(picker.find('.wbtm_cabin_aisle_after_col').val()) || 0;
+                    let picker = cabin_item.find(s.picker);
+                    let numbering = picker.find(s.numSelect).val() || 'sequential';
+                    let aislePos = parseInt(picker.find(s.aisle).val()) || 0;
                     let pattern = window.wbtmSeatNumbering.buildAislePattern(column, aislePos);
                     window.wbtmSeatNumbering.fill(target, pattern, numbering);
                 }
@@ -561,7 +656,9 @@ function wbtm_load_sortable_datepicker(parent, item) {
                 console.log(response);
             }
         });
-    });
+    }
+    $(document).on('click', '.wbtm_generate_cabin_seats', function() { wbtmGenerateCabinSeats($(this), false); });
+    $(document).on('click', '.wbtm_generate_cabin_seats_dd', function() { wbtmGenerateCabinSeats($(this), true); });
 
     // Apply a predefined seat template to one cabin — cabin-scoped
     // counterpart to applySeatTemplate() in wbtm_admin.js. Kept separate
@@ -570,10 +667,12 @@ function wbtm_load_sortable_datepicker(parent, item) {
     // per-cabin-item DOM scoping instead of the deck's single scoped field
     // per picker.
     function applyCabinSeatTemplate($picker) {
+        let dd = $picker.data('deck') === 'upper';
+        let s = wbtmCabinDeckSel(dd);
         let cabinIndex = $picker.data('cabin-index');
         let cabinItem = $picker.closest('.wbtm_cabin_item');
-        let templateKey = $picker.find('.wbtm_cabin_seat_template_select').val();
-        let numbering = $picker.find('.wbtm_cabin_seat_numbering_select').val();
+        let templateKey = $picker.find(s.tplSelect).val();
+        let numbering = $picker.find(s.numSelect).val();
         let templates = (typeof wbtm_admin_var !== 'undefined' && wbtm_admin_var.seat_templates) ? wbtm_admin_var.seat_templates : {};
         let pattern = templateKey ? templates[templateKey] : null;
 
@@ -582,7 +681,7 @@ function wbtm_load_sortable_datepicker(parent, item) {
             return;
         }
 
-        let row = parseInt(cabinItem.find('input[name="wbtm_cabin_rows[]"]').val());
+        let row = parseInt(cabinItem.find('input[name="' + s.rowsName + '"]').val());
         let column = pattern.length;
 
         if (!(row > 0)) {
@@ -592,9 +691,9 @@ function wbtm_load_sortable_datepicker(parent, item) {
 
         // Columns are derived from the template — reflect that back into the
         // (still fully editable) Seat Columns field before generating.
-        cabinItem.find('input[name="wbtm_cabin_cols[]"]').val(column);
+        cabinItem.find('input[name="' + s.colsName + '"]').val(column);
 
-        let target = cabinItem.find('.wbtm_cabin_seat_plan');
+        let target = cabinItem.find(s.plan);
         let post_id = $('[name="wbtm_post_id"]').val();
 
         $.ajax({
@@ -606,6 +705,7 @@ function wbtm_load_sortable_datepicker(parent, item) {
                 row: row,
                 column: column,
                 cabin_index: cabinIndex,
+                deck: s.deckParam,
                 nonce: wbtm_admin_var.nonce
             },
             beforeSend: function () {
@@ -627,6 +727,9 @@ function wbtm_load_sortable_datepicker(parent, item) {
     $(document).on('click', '.wbtm_apply_cabin_seat_template', function () {
         applyCabinSeatTemplate($(this).closest('.wbtm_cabin_seat_template_picker'));
     });
+    $(document).on('click', '.wbtm_apply_cabin_seat_template_dd', function () {
+        applyCabinSeatTemplate($(this).closest('.wbtm_cabin_seat_template_picker_dd'));
+    });
 
     // Toggle between "no template" mode (Seat Columns + Aisle Position +
     // Generate Seat Plan button) and "template chosen" mode (those two
@@ -635,12 +738,14 @@ function wbtm_load_sortable_datepicker(parent, item) {
     // wbtmToggleSeatTemplateMode() in wbtm_admin.js.
     function wbtmToggleCabinSeatTemplateMode($picker) {
         if (!$picker || !$picker.length) { return; }
-        let hasTemplate = !!$picker.find('.wbtm_cabin_seat_template_select').val();
-        let $generateBtn = $picker.siblings('.wbtm_generate_cabin_seats');
-        let $applyBtn = $picker.find('.wbtm_apply_cabin_seat_template');
-        let $colsRow = $picker.find('input[name="wbtm_cabin_cols[]"]').closest('._dFlex_justifyBetween_alignCenter');
-        let $aisleRow = $picker.find('.wbtm_cabin_aisle_after_col').closest('._dFlex_justifyBetween_alignCenter');
-        let $rowsRow = $picker.find('input[name="wbtm_cabin_rows[]"]').closest('._dFlex_justifyBetween_alignCenter');
+        let dd = $picker.data('deck') === 'upper';
+        let s = wbtmCabinDeckSel(dd);
+        let hasTemplate = !!$picker.find(s.tplSelect).val();
+        let $generateBtn = $picker.siblings(s.genBtn);
+        let $applyBtn = $picker.find(s.applyBtn);
+        let $colsRow = $picker.find('input[name="' + s.colsName + '"]').closest('._dFlex_justifyBetween_alignCenter');
+        let $aisleRow = $picker.find(s.aisle).closest('._dFlex_justifyBetween_alignCenter');
+        let $rowsRow = $picker.find('input[name="' + s.rowsName + '"]').closest('._dFlex_justifyBetween_alignCenter');
 
         $generateBtn.toggle(!hasTemplate);
         $applyBtn.toggle(hasTemplate);
@@ -652,16 +757,19 @@ function wbtm_load_sortable_datepicker(parent, item) {
     $(document).on('change', '.wbtm_cabin_seat_template_select', function () {
         wbtmToggleCabinSeatTemplateMode($(this).closest('.wbtm_cabin_seat_template_picker'));
     });
+    $(document).on('change', '.wbtm_cabin_seat_template_select_dd', function () {
+        wbtmToggleCabinSeatTemplateMode($(this).closest('.wbtm_cabin_seat_template_picker_dd'));
+    });
 
     function wbtmInitCabinSeatTemplateToggles() {
-        $('.wbtm_cabin_seat_template_picker').each(function () {
+        $('.wbtm_cabin_seat_template_picker, .wbtm_cabin_seat_template_picker_dd').each(function () {
             wbtmToggleCabinSeatTemplateMode($(this));
         });
     }
 
-    // Handle row deletion for cabin seat plans
-    $(document).on('click', '.wbtm_cabin_seat_plan .wbtm_item_remove', function() {
-        let button = $(this);
+    // Handle row deletion for cabin seat plans (lower + upper deck)
+    function wbtmRemoveCabinRow(button, dd) {
+        let s = wbtmCabinDeckSel(dd);
         let cabin_item = button.closest('.wbtm_cabin_item');
         let cabin_index = cabin_item.attr('data-cabin-index');
 
@@ -670,7 +778,7 @@ function wbtm_load_sortable_datepicker(parent, item) {
             return;
         }
 
-        let delete_rows_input = cabin_item.find('input[name="wbtm_cabin_rows[]"]');
+        let delete_rows_input = cabin_item.find('input[name="' + s.rowsName + '"]');
         if (delete_rows_input.length > 0) {
             let current_rows = parseInt(delete_rows_input.val()) || 0;
 
@@ -681,11 +789,13 @@ function wbtm_load_sortable_datepicker(parent, item) {
 
         // Remove the table row
         button.closest('tr').remove();
-    });
+    }
+    $(document).on('click', '.wbtm_cabin_seat_plan .wbtm_item_remove', function() { wbtmRemoveCabinRow($(this), false); });
+    $(document).on('click', '.wbtm_cabin_seat_plan_dd .wbtm_item_remove', function() { wbtmRemoveCabinRow($(this), true); });
 
-    // Handle adding new rows for cabin seat plans
-    $(document).on('click', '.wbtm_cabin_seat_plan .wbtm_add_item', function() {
-        let button = $(this);
+    // Handle adding new rows for cabin seat plans (lower + upper deck)
+    function wbtmAddCabinRow(button, dd) {
+        let s = wbtmCabinDeckSel(dd);
         let cabin_item = button.closest('.wbtm_cabin_item');
         let cabin_index = cabin_item.attr('data-cabin-index');
 
@@ -694,9 +804,8 @@ function wbtm_load_sortable_datepicker(parent, item) {
             return;
         }
 
-        let hidden_content = cabin_item.find('.wbtm_cabin_hidden_content');
-        let seat_plan_area = cabin_item.find('.wbtm_cabin_seat_plan tbody');
-        let cols_input = cabin_item.find('input[name="wbtm_cabin_cols[]"]');
+        let seat_plan_area = cabin_item.find(s.plan + ' tbody');
+        let cols_input = cabin_item.find('input[name="' + s.colsName + '"]');
         let cols = parseInt(cols_input.val()) || 0;
 
         if (cols <= 0) {
@@ -707,25 +816,26 @@ function wbtm_load_sortable_datepicker(parent, item) {
         // Generate new row HTML directly
         let new_row = '<tr class="wbtm_remove_area">';
         for (let j = 1; j <= cols; j++) {
+            let sk = s.seatBase(cabin_index, j);
             new_row += `
                 <th>
                     <div class="wbtm_seat_container">
                         <label>
                             <input type="text" class="formControl wbtm_id_validation"
-                                name="wbtm_cabin_${cabin_index}_seat${j}[]"
+                                name="wbtm_${sk}[]"
                                 placeholder="Blank"
                                 value=""
                             />
                         </label>
                         <div class="wbtm_seat_rotation_controls">
-                            <button type="button" class="wbtm_rotate_seat _whiteButton_xs" 
-                                    data-seat="cabin_${cabin_index}_seat${j}" 
+                            <button type="button" class="wbtm_rotate_seat _whiteButton_xs"
+                                    data-seat="${sk}"
                                     data-rotation="0"
                                     title="Rotate Seat">
                                 <span class="fas fa-redo"></span>
                             </button>
-                            <input type="hidden" name="wbtm_cabin_${cabin_index}_seat${j}_rotation[]" 
-                                   value="0" 
+                            <input type="hidden" name="wbtm_${sk}_rotation[]"
+                                   value="0"
                                    class="wbtm_rotation_value" />
                         </div>
                     </div>
@@ -750,12 +860,20 @@ function wbtm_load_sortable_datepicker(parent, item) {
         seat_plan_area.append(new_row);
 
         // Update the row count
-        let add_rows_input = cabin_item.find('input[name="wbtm_cabin_rows[]"]');
+        let add_rows_input = cabin_item.find('input[name="' + s.rowsName + '"]');
         if (add_rows_input.length > 0) {
             let current_rows = parseInt(add_rows_input.val()) || 0;
             add_rows_input.val(current_rows + 1);
         }
-    });
+
+        // The freshly appended cells have no jQuery-UI droppable yet, so the
+        // drag-and-drop toolbar (door/toilet/driver/…) would not work on the new
+        // row. Fire the same event the AJAX seat generators use so initDragDrop()
+        // (in wbtm_admin.js) binds draggable/droppable + badges on the new cells.
+        $(document).trigger('wbtm_seat_plan_dom_updated');
+    }
+    $(document).on('click', '.wbtm_cabin_seat_plan .wbtm_add_item', function() { wbtmAddCabinRow($(this), false); });
+    $(document).on('click', '.wbtm_cabin_seat_plan_dd .wbtm_add_item', function() { wbtmAddCabinRow($(this), true); });
 
     // Handle cabin enable/disable toggle (individual cabins)
     function toggleCabinFields(checkbox) {
@@ -808,6 +926,26 @@ function wbtm_load_sortable_datepicker(parent, item) {
                 traditional_seat_plan.slideDown(300);
             }
         }
+
+        // Multiple cabin/coach mode requires a seat plan, so lock the
+        // "Without Seat Plan" choice while it is on and release it when off.
+        syncSeatTypeCardsCabinLock(checkbox.is(':checked'));
+    }
+
+    // Enable/disable the "Without Seat Plan" seat-type card (and its hidden
+    // <select> option) based on whether cabin/coach mode is active. Keeps the
+    // UI honest instead of letting the card be clicked only to bounce back
+    // with an alert.
+    function syncSeatTypeCardsCabinLock(isCabinModeOn) {
+        let without_card = $('.wbtm_seat_type_card[data-seat-type-card="wbtm_without_seat_plan"]');
+        let without_opt  = $('select[name="wbtm_seat_type_conf"] option[value="wbtm_without_seat_plan"]');
+        if (isCabinModeOn) {
+            without_card.addClass('wbtm_seat_type_card_disabled').attr('aria-disabled', 'true');
+            without_opt.prop('disabled', true);
+        } else {
+            without_card.removeClass('wbtm_seat_type_card_disabled').removeAttr('aria-disabled');
+            without_opt.prop('disabled', false);
+        }
     }
 
     // Reflects the real <select name="wbtm_seat_type_conf"> value (kept in the
@@ -822,6 +960,10 @@ function wbtm_load_sortable_datepicker(parent, item) {
     // wired to its change event (collapse sections, cabin-mode coupling below)
     // keeps working unchanged.
     $(document).on('click', '.wbtm_seat_type_card', function () {
+        // Ignore clicks on a card locked by cabin/coach mode.
+        if ($(this).hasClass('wbtm_seat_type_card_disabled')) {
+            return;
+        }
         let value = $(this).data('seat-type-card');
         let $select = $('select[name="wbtm_seat_type_conf"]');
         if ($select.val() !== value) {
@@ -868,6 +1010,18 @@ function wbtm_load_sortable_datepicker(parent, item) {
         }
         // Reset the flag
         $(this).removeData('programmatic-change');
+    });
+
+    // Handle per-cabin "Enable Upper Deck" toggle — reveals/hides that cabin's
+    // upper-deck seat-plan builder (double-decker coach). Independent of the
+    // cabin-enable toggle above (which hides the whole cabin's fields).
+    $(document).on('change', 'input[name^="wbtm_cabin_upper_enabled"]', function() {
+        let upper_fields = $(this).closest('.wbtm_cabin_item').find('.wbtm_cabin_upper_fields');
+        if ($(this).is(':checked')) {
+            upper_fields.slideDown(200);
+        } else {
+            upper_fields.slideUp(200);
+        }
     });
 
     // Handle master cabin mode enable checkbox change

--- a/readme.txt
+++ b/readme.txt
@@ -58,8 +58,8 @@ Experience efficient booking management with our unique plugin. Website owners e
 * **Dynamic Intermediate Route Allocation**
 Leverage our unique feature for fluid transitions. Seats become instantly available for the next customer upon drop-off or arrival, ensuring an efficient booking process.
 
-* **Cabin Booking Fucntionalities for train**
-You can add cabin for each train and sell cabin based seat selling also for train.
+* **Cabin & Double-Decker Coach Booking (New)**
+Add multiple cabins or coaches to a train or bus and sell seats cabin by cabin. Each cabin can now be double-decker too — give it an Upper Deck alongside its Lower Deck, design each deck with the full seat editor, and price the two decks independently. Passengers switch between Lower and Upper Deck with a tab and pick their seat on either level, and the chosen deck is shown on every ticket, list, PDF and export.
 
 
 * **Automated Email Notifications**
@@ -412,3 +412,17 @@ Seat number rotation stopped
 
 **Booking List**
 * New "Booked by" badge marks counter / admin-created bookings with the staff member's name, so they're easy to tell apart from customers' own checkouts
+
+**Double-Decker Cabins (New)**
+* Cabins and coaches can now be double-decker — each cabin gets its own optional Upper Deck alongside its Lower Deck, perfect for double-decker buses and train carriages
+* Build each deck independently with the full seat editor (seat templates, drag-and-drop doors/toilets/driver, rotation and add/remove rows) in both the classic and modern bus editors
+* Set a different price for each deck — separate Lower Deck and Upper Deck price multipliers per cabin, so an upper-deck seat can cost more (or less) than a lower-deck one
+* On the booking page, passengers switch between Lower Deck and Upper Deck with a simple tab inside the cabin and pick seats on either deck
+* Upper- and lower-deck seats are tracked separately end-to-end, so the same seat number on each deck never clashes for availability, holds, cart or orders
+* The chosen deck is shown everywhere the seat appears — Booking List, Passenger List, PDF tickets, thermal tickets, email, admin counter orders, the booking calendar and CSV exports (e.g. "Coach A - Upper Deck - 3")
+* Fully backward compatible — existing single-deck cabins and all past bookings are unchanged; a cabin only becomes double-decker when you turn its Upper Deck on
+
+**Seat Editor Improvements**
+* "Without Seat Plan" can no longer be selected while Multiple Cabin/Coach mode is on (cabins require a seat plan) — the option is clearly disabled instead of silently reverting
+* Drag-and-drop now works immediately on freshly added seat rows in the cabin and deck editors
+* Admin and booking-page assets are versioned by file change time, so editor and seat-plan updates are never served from a stale browser cache

--- a/templates/layout/cabin_seat_grid.php
+++ b/templates/layout/cabin_seat_grid.php
@@ -1,0 +1,149 @@
+<?php
+	/*
+	* @Author 		MagePeople Team
+	* Copyright: 	mage-people.com
+	*
+	* Renders ONE deck of a cabin's seat grid (lower or upper). Extracted from
+	* seat_plan.php so a double-decker cabin/coach can render both decks with a
+	* single source of truth. Expects these variables already in scope from the
+	* caller (seat_plan.php cabin loop):
+	*   $post_id, $start_route, $end_route, $date, $ticket_infos, $seat_booked,
+	*   $wbtm_pl, $enable_rotation
+	* plus these per-deck parameters set immediately before the require:
+	*   $wbtm_grid_cabin_index      int    cabin position (0-based)
+	*   $wbtm_grid_cols             int    columns for THIS deck
+	*   $wbtm_grid_seat_infos       array  saved seat rows for THIS deck
+	*   $wbtm_grid_price_multiplier float  cabin price multiplier
+	*   $wbtm_grid_deck             string 'lower' | 'upper'
+	*/
+	if (!defined('ABSPATH')) {
+		die;
+	}
+	// phpcs:disable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+	$wbtm_grid_is_upper = ($wbtm_grid_deck === 'upper');
+	// Upper deck seats live under a distinct "cabin_{i}_dd_{seat}" identifier so
+	// a seat labelled "A1" on the upper deck never collides with "A1" on the
+	// lower deck of the same coach — for booked/in-cart checks AND client-side
+	// disambiguation via data-cabin_index.
+	$wbtm_grid_id_prefix        = 'cabin_' . $wbtm_grid_cabin_index . ($wbtm_grid_is_upper ? '_dd_' : '_');
+	$wbtm_grid_data_cabin_index = $wbtm_grid_is_upper ? ($wbtm_grid_cabin_index . '_dd') : $wbtm_grid_cabin_index;
+	?>
+	<table>
+		<thead>
+		<tr>
+			<th colspan="<?php echo esc_attr($wbtm_grid_cols); ?>">
+				<div class="wbtm_cabin_direction">
+					<span class="wbtm_direction_text"><?php esc_html_e('Front', 'bus-ticket-booking-with-seat-reservation'); ?></span>
+				</div>
+			</th>
+		</tr>
+		</thead>
+		<tbody>
+		<?php foreach ($wbtm_grid_seat_infos as $row_index => $seat_info): ?>
+			<tr>
+				<?php foreach ($seat_info as $seat_key => $seat_name): ?>
+					<?php
+					// Skip rotation keys (they end with _rotation)
+					if (strpos($seat_key, '_rotation') !== false) {
+						continue;
+					}
+					$seat_name = wbtm_normalize_seat_value_check($seat_name);
+					?>
+					<?php if ($seat_name): ?>
+						<?php if (wbtm_is_non_seat_item_check($seat_name)):
+							$ns_data = wbtm_get_non_seat_data_check($seat_name);
+							?>
+							<?php if (strtolower(trim($seat_name)) === 'aisle'): ?>
+								<td class="wbtm_aisle_blank"></td>
+							<?php else: ?>
+								<td class="wbtm_non_seat_item" title="<?php echo esc_attr($ns_data['label']); ?>">
+									<span class="wbtm_non_seat_icon fas <?php echo esc_attr($ns_data['icon']); ?>"></span>
+									<span class="wbtm_non_seat_label"><?php echo esc_html($ns_data['label']); ?></span>
+								</td>
+							<?php endif; ?>
+						<?php else: ?>
+							<?php
+							$rotation = 0;
+							if ($enable_rotation == 'yes' && isset($seat_info[$seat_key . '_rotation'])) {
+								$rotation = intval($seat_info[$seat_key . '_rotation']);
+							}
+							$rotation_class = $rotation > 0 ? 'wbtm_seat_rotated_' . $rotation : '';
+
+							$cabin_seat_identifier = $wbtm_grid_id_prefix . $seat_name;
+							// Lower deck keeps the legacy bare-name fallback (older
+							// bookings/cart entries predate cabin identifiers); the
+							// upper deck is new, so it matches ONLY on its own
+							// deck-scoped identifier to avoid cross-deck collisions.
+							$is_booked = in_array($cabin_seat_identifier, $seat_booked)
+								|| (!$wbtm_grid_is_upper && in_array($seat_name, $seat_booked));
+							$is_in_cart = !$is_booked && (
+								WBTM_Functions::check_seat_in_cart($post_id, $start_route, $end_route, $date, $cabin_seat_identifier)
+								|| (!$wbtm_grid_is_upper && WBTM_Functions::check_seat_in_cart($post_id, $start_route, $end_route, $date, $seat_name))
+							);
+							$cell_base_cabin = WBTM_Functions::get_seat_price($post_id, $start_route, $end_route, $ticket_infos[0]['type'], false, $wbtm_pl, $seat_name, $wbtm_grid_cabin_index, $date);
+							if ($cell_base_cabin === false) {
+								$cell_base_cabin = 0;
+							}
+							$cabin_price = floatval($cell_base_cabin) * floatval($wbtm_grid_price_multiplier);
+							?>
+							<th>
+								<div class="mp_seat_item <?php echo esc_attr($rotation_class); ?>">
+									<?php if ($is_booked): ?>
+										<div class="mp_seat seat_booked" title="<?php echo esc_html( WBTM_Translations::text_already_sold() . ' : ' . esc_attr($seat_name) ); ?>">
+											<div class="seat_visual"></div>
+											<div class="seat_number"><?php echo esc_html($seat_name); ?></div>
+										</div>
+									<?php elseif ($is_in_cart): ?>
+										<div class="mp_seat seat_in_cart" title="<?php echo esc_html( WBTM_Translations::text_already_in_cart() . ' :  ' . esc_attr($seat_name) ); ?>">
+											<div class="seat_visual"></div>
+											<div class="seat_number"><?php echo esc_html($seat_name); ?></div>
+										</div>
+									<?php else: ?>
+										<div class="mp_seat seat_available" title="<?php echo esc_attr(WBTM_Translations::text_available_seat()) . '  : ' . esc_attr($seat_name); ?>"
+											 data-seat_name="<?php echo esc_attr($seat_name); ?>"
+											 data-seat_label="<?php echo esc_attr($ticket_infos[0]['name']); ?>"
+											 data-seat_type="<?php echo esc_attr($ticket_infos[0]['type']); ?>"
+											 data-seat_price="<?php echo esc_attr($cabin_price); ?>"
+											 data-cabin_index="<?php echo esc_attr($wbtm_grid_data_cabin_index); ?>"
+										>
+											<div class="seat_visual"></div>
+											<div class="seat_number"><?php echo esc_html($seat_name); ?></div>
+										</div>
+										<?php if (sizeof($ticket_infos) > 1): ?>
+											<div class="wbtm_seat_item_list">
+												<ul class="mp_list">
+													<?php foreach ($ticket_infos as $key => $ticket_info): ?>
+														<?php
+														$cell_t_cabin = WBTM_Functions::get_seat_price($post_id, $start_route, $end_route, $ticket_info['type'], false, $wbtm_pl, $seat_name, $wbtm_grid_cabin_index, $date);
+														if ($cell_t_cabin === false) {
+															$cell_t_cabin = 0;
+														}
+														$ticket_price = floatval($cell_t_cabin) * floatval($wbtm_grid_price_multiplier);
+														?>
+														<li class="justifyBetween"
+															data-seat_label="<?php echo esc_attr($ticket_info['name']); ?>"
+															data-seat_type="<?php echo esc_attr($ticket_info['type']); ?>"
+															data-seat_price="<?php echo esc_attr($ticket_price); ?>"
+														>
+															<span><?php echo esc_html($ticket_info['name']); ?></span>
+															-
+															<span><?php echo wp_kses_post( WBTM_Global_Function::format_price( $ticket_price ) ); ?></span>
+														</li>
+													<?php endforeach; ?>
+												</ul>
+											</div>
+										<?php endif; ?>
+									<?php endif; ?>
+								</div>
+							</th>
+						<?php endif; ?>
+					<?php else: ?>
+						<td></td>
+					<?php endif; ?>
+				<?php endforeach; ?>
+			</tr>
+		<?php endforeach; ?>
+		</tbody>
+	</table>
+	<?php
+	// phpcs:enable WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound

--- a/templates/layout/seat_plan.php
+++ b/templates/layout/seat_plan.php
@@ -213,6 +213,26 @@
                                     <div class="wbtm_cabin_seat_plan ovAuto" style="<?php echo $wbtm_cabin_is_first ? '' : 'display: none;'; ?>" aria-expanded="<?php echo $wbtm_cabin_is_first ? 'true' : 'false'; ?>" role="region" aria-labelledby="cabin-<?php echo esc_attr($cabin_index); ?>-title" data-cabin-index="<?php echo esc_attr($cabin_index); ?>">
                                         <input type="hidden" name="wbtm_selected_seat_cabin_<?php echo esc_attr($cabin_index); ?>" value=""/>
                                         <input type="hidden" name="wbtm_selected_seat_type_cabin_<?php echo esc_attr($cabin_index); ?>" value=""/>
+                                        <?php
+                                            // Upper deck of this cabin (double-decker coach), if configured.
+                                            // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+                                            $wbtm_cabin_has_upper    = (($cabin['upper_enabled'] ?? 'no') === 'yes');
+                                            // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+                                            $cabin_up_cols           = intval($cabin['upper_cols'] ?? 0);
+                                            // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+                                            $cabin_up_seat_infos     = $wbtm_cabin_has_upper ? WBTM_Global_Function::get_post_info($post_id, 'wbtm_cabin_seats_info_dd_' . $cabin_index, []) : [];
+                                            // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+                                            $wbtm_cabin_render_upper = ($wbtm_cabin_has_upper && $cabin_up_cols > 0 && !empty($cabin_up_seat_infos));
+                                        ?>
+                                        <?php if ($wbtm_cabin_render_upper): ?>
+                                            <input type="hidden" name="wbtm_selected_seat_cabin_dd_<?php echo esc_attr($cabin_index); ?>" value=""/>
+                                            <input type="hidden" name="wbtm_selected_seat_type_cabin_dd_<?php echo esc_attr($cabin_index); ?>" value=""/>
+                                            <div class="wbtm_cabin_deck_tabs">
+                                                <button type="button" class="wbtm_cabin_deck_tab wbtm_cabin_deck_tab_active" data-deck="lower"><?php esc_html_e('Lower Deck', 'bus-ticket-booking-with-seat-reservation'); ?></button>
+                                                <button type="button" class="wbtm_cabin_deck_tab" data-deck="upper"><?php esc_html_e('Upper Deck', 'bus-ticket-booking-with-seat-reservation'); ?></button>
+                                            </div>
+                                        <?php endif; ?>
+                                        <div class="wbtm_deck_pane wbtm_deck_pane_lower" data-deck="lower">
                                         <table>
                                             <thead>
                                             <tr>
@@ -339,6 +359,25 @@
                                             <?php endforeach; ?>
                                             </tbody>
                                         </table>
+                                        </div>
+                                        <?php if ($wbtm_cabin_render_upper): ?>
+                                        <div class="wbtm_deck_pane wbtm_deck_pane_upper" data-deck="upper" style="display: none;">
+                                            <?php
+                                                // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+                                                $wbtm_grid_cabin_index      = $cabin_index;
+                                                // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+                                                $wbtm_grid_cols             = $cabin_up_cols;
+                                                // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+                                                $wbtm_grid_seat_infos       = $cabin_up_seat_infos;
+                                                // Upper deck is priced by its OWN multiplier so it can differ from the lower deck.
+                                                // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+                                                $wbtm_grid_price_multiplier = isset($cabin['upper_price_multiplier']) ? floatval($cabin['upper_price_multiplier']) : 1.0;
+                                                // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+                                                $wbtm_grid_deck             = 'upper';
+                                                require WBTM_Functions::template_path('layout/cabin_seat_grid.php');
+                                            ?>
+                                        </div>
+                                        <?php endif; ?>
                                         <?php wbtm_render_seat_legend_check(); ?>
                                     </div>
                                 </div>
@@ -472,7 +511,7 @@
                             </table>
                         </div>
                     <?php } ?>
-                    <?php if ($show_upper_desk == 'yes' && sizeof($seat_infos_dd) > 0) { ?>
+                    <?php if (!$has_cabin_seat_plan && $show_upper_desk == 'yes' && sizeof($seat_infos_dd) > 0) { ?>
                         <div class="wbtm_seat_plan_upper ovAuto">
                             <input type="hidden" name="wbtm_selected_seat_dd" value=""/>
                             <input type="hidden" name="wbtm_selected_seat_dd_type" value=""/>


### PR DESCRIPTION
Cabins (coaches) can now be double-decker, each with an optional upper deck alongside its lower deck — configured, booked, priced and displayed end-to-end.

Admin editor:
- Per-cabin "Enable Upper Deck" toggle + full upper-deck seat builder (template picker, generate, drag-drop toolbar, add/remove rows) in both the classic and modern editors, and for newly-added cabins.
- Separate "Price Multiplier (Lower Deck)" and "Price Multiplier (Upper Deck)" so each deck can be priced independently (decimals + clearer instructions).

Data + booking pipeline:
- New meta wbtm_cabin_seats_info_dd_{i}; cabin_config gains upper_enabled/ upper_rows/upper_cols/upper_price_multiplier.
- Upper-deck seats use a deck-scoped identifier cabin_{i}_dd_{seat} (lower stays cabin_{i}_{seat}, so existing data is untouched) — threaded through capture, availability, seat holds, cart, pricing and order storage.
- Capacity (count_actual_seats) now counts both decks.

Frontend:
- Lower/Upper deck tabs inside a double-decker cabin (new cabin_seat_grid.php partial); collision-free booked/in-cart marking per deck.
- Fix: the non-cabin upper deck no longer renders while in cabin mode.

Also included (seat editor):
- "Without Seat Plan" card is disabled while cabin mode is on.
- Drag-and-drop binds on freshly added seat rows (cabin + both decks).
- filemtime cache-busting for the admin settings and frontend assets so edits are never served stale between releases.