### PR TITLE
Fix: settings-page sidebar covered the admin-bar notifications dropdown

### DIFF
--- a/admin/WBTM_Global_settings.php
+++ b/admin/WBTM_Global_settings.php
@@ -36,11 +36,12 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 				$page = isset($_GET['page']) ? sanitize_text_field(wp_unslash($_GET['page'])) : '';
 				if ($page !== 'wbtm_settings_page') return;
 
+				$wbtm_gs_css = WBTM_PLUGIN_DIR . '/assets/admin/css/wbtm-global-settings.css';
 				wp_enqueue_style(
 					'wbtm-global-settings',
 					WBTM_PLUGIN_URL . '/assets/admin/css/wbtm-global-settings.css',
 					[],
-					WBTM_VERSION
+					file_exists( $wbtm_gs_css ) ? filemtime( $wbtm_gs_css ) : WBTM_VERSION
 				);
 				wp_enqueue_script(
 					'wbtm-global-settings-js',

--- a/assets/admin/css/wbtm-global-settings.css
+++ b/assets/admin/css/wbtm-global-settings.css
@@ -46,7 +46,10 @@
   display: flex;
   flex-direction: column;
   transition: transform 0.25s ease;
-  z-index: 99999;
+  /* Keep the desktop sticky sidebar BELOW the WP admin bar (z-index 99999) so
+     admin-bar dropdowns (e.g. the notifications panel) are not covered by it.
+     The mobile off-canvas drawer re-raises this in the ≤782px media query. */
+  z-index: 30;
   position: sticky;
   top: 32px;
   align-self: flex-start;
@@ -688,6 +691,8 @@
     left: 0;
     height: 100%;
     transform: translateX(-100%);
+    /* Off-canvas drawer must sit above the mobile overlay (99998) + content. */
+    z-index: 99999;
   }
   .bm-gs__sidebar.bm-gs--open {
     transform: translateX(0);


### PR DESCRIPTION
The Global Settings left nav (.bm-gs__sidebar) used z-index 99999 — the same level as the WP admin bar — so, sitting later in the DOM, it rendered on top of the admin-bar notifications dropdown (which is trapped in #wpadminbar's 99999 stacking context and cannot rise above it).

- Desktop sticky sidebar dropped to z-index 30 (above page content, below the admin bar) so admin-bar dropdowns are no longer covered.
- The mobile off-canvas drawer keeps z-index 99999 (added in the <=782px media query) so it still clears the mobile overlay (99998).
- Enqueue the settings CSS with filemtime cache-busting so the fix is not served stale.