### PR TITLE
Keep seat holds alive through cart/checkout + fixed countdown

### DIFF
--- a/assets/frontend/wbtm_cart_hold.js
+++ b/assets/frontend/wbtm_cart_hold.js
@@ -1,0 +1,157 @@
+/**
+ * Seat-hold countdown for the cart and checkout pages.
+ *
+ * On the booking page the countdown badge lives next to the seat plan. Once the
+ * seats are in the cart, the customer moves to the cart/checkout page where that
+ * badge no longer exists — so this standalone, dependency-free widget shows the
+ * same "your seats are held for MM:SS" reassurance there.
+ *
+ * The deadline is a FIXED moment stored server-side in the WooCommerce session
+ * (WBTM_Seat_Hold::cart_hold_deadline), so the countdown keeps ticking toward
+ * the same instant across page reloads instead of restarting. `expires` and
+ * `now` are both server timestamps; the initial remaining time is derived from
+ * them and then ticked down against the local wall clock, which makes it immune
+ * to any difference between the browser's clock and the server's.
+ *
+ * Self-contained on purpose (no jQuery, injects its own styles): the booking
+ * page assets are not loaded on cart/checkout, and the block cart / checkout
+ * render a React DOM we cannot rely on.
+ */
+(function () {
+	'use strict';
+
+	var cfg = window.wbtm_cart_hold;
+	if (!cfg || !cfg.expires) {
+		return;
+	}
+
+	// True seconds left at the moment the page was rendered, from the server's
+	// own clock — then counted down locally so a skewed browser clock can't throw
+	// it off.
+	var initialRemaining = Math.round(cfg.expires - (cfg.now || cfg.expires));
+	var localStart = Date.now();
+
+	function remainingNow() {
+		return initialRemaining - Math.floor((Date.now() - localStart) / 1000);
+	}
+
+	function injectStyles() {
+		if (document.getElementById('wbtm-cart-hold-style')) {
+			return;
+		}
+		var css =
+			'.wbtm-cart-hold{display:flex;align-items:center;gap:8px;justify-content:center;' +
+			'margin:0 0 16px;padding:10px 14px;border-radius:8px;background:#e8f4e8;' +
+			'border:1px solid #2e7d32;color:#1b5e20;font-weight:600;font-size:14px;' +
+			'line-height:1.4;text-align:center;}' +
+			'.wbtm-cart-hold__time{font-variant-numeric:tabular-nums;}' +
+			'.wbtm-cart-hold.is-urgent{background:#fff4e5;border-color:#e65100;color:#b34700;}' +
+			'.wbtm-cart-hold.is-expired{background:#fdecea;border-color:#c62828;color:#b71c1c;}' +
+			'.wbtm-cart-hold svg{flex:none;}';
+		var style = document.createElement('style');
+		style.id = 'wbtm-cart-hold-style';
+		style.appendChild(document.createTextNode(css));
+		document.head.appendChild(style);
+	}
+
+	// Insert the banner at the top of whatever cart/checkout container exists —
+	// classic markup first, then the block equivalents, then a safe fallback.
+	function mountPoint() {
+		var selectors = [
+			'.woocommerce-checkout .woocommerce-notices-wrapper',
+			'.woocommerce-cart .woocommerce-notices-wrapper',
+			'form.woocommerce-checkout',
+			'form.woocommerce-cart-form',
+			'.wc-block-checkout',
+			'.wc-block-cart',
+			'.woocommerce'
+		];
+		for (var i = 0; i < selectors.length; i++) {
+			var el = document.querySelector(selectors[i]);
+			if (el) {
+				return el;
+			}
+		}
+		return null;
+	}
+
+	function clockIcon() {
+		return '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" ' +
+			'stroke-width="2" stroke-linecap="round" stroke-linejoin="round">' +
+			'<circle cx="12" cy="12" r="10"/><polyline points="12 6 12 12 16 14"/></svg>';
+	}
+
+	function format(remaining) {
+		var m = Math.floor(remaining / 60);
+		var s = remaining % 60;
+		return ('0' + m).slice(-2) + ':' + ('0' + s).slice(-2);
+	}
+
+	var banner = null;
+	var timeEl = null;
+	var timer = null;
+
+	function ensureBanner() {
+		if (banner && document.body.contains(banner)) {
+			return banner;
+		}
+		var host = mountPoint();
+		if (!host) {
+			return null;
+		}
+		injectStyles();
+		banner = document.createElement('div');
+		banner.className = 'wbtm-cart-hold';
+		banner.setAttribute('role', 'status');
+		banner.innerHTML = clockIcon() +
+			'<span>' + (cfg.label || 'Your seats are held for') +
+			' <span class="wbtm-cart-hold__time"></span></span>';
+		host.insertBefore(banner, host.firstChild);
+		timeEl = banner.querySelector('.wbtm-cart-hold__time');
+		return banner;
+	}
+
+	function showExpired() {
+		if (timer) {
+			window.clearInterval(timer);
+			timer = null;
+		}
+		if (!ensureBanner()) {
+			return;
+		}
+		banner.classList.remove('is-urgent');
+		banner.classList.add('is-expired');
+		banner.innerHTML = clockIcon() + '<span>' +
+			(cfg.expired || 'Your seat hold has expired. Please review your seats.') + '</span>';
+	}
+
+	function tick() {
+		var remaining = remainingNow();
+		if (remaining <= 0) {
+			showExpired();
+			return;
+		}
+		if (!ensureBanner() || !timeEl) {
+			return;
+		}
+		timeEl.textContent = format(remaining);
+		banner.classList.toggle('is-urgent', remaining < 60);
+	}
+
+	function start() {
+		if (remainingNow() <= 0) {
+			// Already lapsed before the page even rendered — just show the notice,
+			// never reload (that would loop while the seats sit in the cart).
+			showExpired();
+			return;
+		}
+		tick();
+		timer = window.setInterval(tick, 1000);
+	}
+
+	if (document.readyState === 'loading') {
+		document.addEventListener('DOMContentLoaded', start);
+	} else {
+		start();
+	}
+}());

--- a/assets/global/wbtm_global.js
+++ b/assets/global/wbtm_global.js
@@ -1649,7 +1649,15 @@
 	function wbtm_hold_badge(parent) {
 		var badge = parent.find('.wbtm_hold_badge');
 		if (!badge.length) {
-			var summary = parent.find('.wbtm_selected_seat_details');
+			// The redesigned layout hides .wbtm_selected_seat_details (display:none)
+			// and shows the .wbtm_booking_summary_preview card instead, so a badge
+			// appended to the old table would never be seen. Prefer the visible
+			// summary card, falling back to the classic table for layouts (e.g. the
+			// without-seat-plan flow or theme overrides) that have no preview card.
+			var summary = parent.find('.wbtm_booking_summary_preview');
+			if (!summary.length) {
+				summary = parent.find('.wbtm_selected_seat_details');
+			}
 			if (!summary.length) {
 				return $();
 			}

--- a/inc/WBTM_Seat_Hold.php
+++ b/inc/WBTM_Seat_Hold.php
@@ -41,6 +41,9 @@
 			const INDEX_PREFIX = 'wbtm_hold_index_';
 			const CACHE_GROUP = 'wbtm_holds';
 			const MAX_SEATS_PER_REQUEST = 50;
+			// WooCommerce-session keys for the fixed cart-hold countdown window.
+			const SESSION_DEADLINE = 'wbtm_seat_hold_deadline';
+			const SESSION_FINGERPRINT = 'wbtm_seat_hold_fp';
 
 			public function __construct() {
 				add_action('wp_ajax_wbtm_hold_seats', array($this, 'ajax_hold_seats'));
@@ -48,6 +51,19 @@
 				add_action('wp_ajax_wbtm_release_seats', array($this, 'ajax_release_seats'));
 				add_action('wp_ajax_nopriv_wbtm_release_seats', array($this, 'ajax_release_seats'));
 				add_filter('wbtm_query_seat_booked', array($this, 'filter_query_seat_booked'), 10, 5);
+				// Keep seats reserved for the whole cart -> checkout window, not just
+				// while they are being selected. The JS hold is set at selection time
+				// and would otherwise age out while the customer is on the cart or
+				// checkout page (classic OR block), letting another visitor grab the
+				// seat. Refreshing on every cart load — which the block Store API also
+				// triggers — closes that gap for both flows.
+				add_action('woocommerce_cart_loaded_from_session', array($this, 'refresh_cart_holds'), 20);
+				// Drop a seat's hold as soon as it leaves the cart, so a removed seat
+				// does not stay blocked to others for the rest of the TTL.
+				add_action('woocommerce_cart_item_removed', array($this, 'release_removed_cart_item'), 10, 2);
+				// Show the held-for countdown on the cart and checkout pages too (the
+				// booking-page badge is gone by then). Works for classic and block.
+				add_action('wp_enqueue_scripts', array($this, 'enqueue_cart_hold_notice'), 20);
 			}
 
 			/* ================= settings / token ================= */
@@ -171,12 +187,17 @@
 			 * Seats already held by ANOTHER token are skipped and reported as
 			 * conflicts; the caller's own existing holds are simply refreshed.
 			 *
+			 * @param int|null $ttl Explicit lifetime in seconds. Defaults to the full
+			 *                      configured hold duration. The cart refresh passes the
+			 *                      time left until a fixed deadline so a plain reload
+			 *                      keeps the countdown to that deadline instead of
+			 *                      restarting the clock.
 			 * @return array {held: string[], conflicts: string[]}
 			 */
-			public static function hold_seats($bus_id, $date, $seats, $token) {
+			public static function hold_seats($bus_id, $date, $seats, $token, $ttl = null) {
 				$held = array();
 				$conflicts = array();
-				$ttl = self::get_ttl_seconds();
+				$ttl = ($ttl === null) ? self::get_ttl_seconds() : (int) $ttl;
 				if ($ttl <= 0 || !$token) {
 					return array('held' => $held, 'conflicts' => $conflicts);
 				}
@@ -217,7 +238,11 @@
 						$index_changed = true;
 					}
 				}
-				if ($index_changed) {
+				// Refresh the index transient whenever anything was held — not only when
+				// its membership changed — so a repeated refresh (cart/checkout window)
+				// keeps the index alive alongside the per-seat transients instead of
+				// letting it expire first.
+				if ($index_changed || !empty($held)) {
 					set_transient(self::index_key($bus_id, $date), $index, $ttl);
 				}
 				return array('held' => $held, 'conflicts' => $conflicts);
@@ -288,6 +313,237 @@
 				if (!empty($seats)) {
 					self::release_seats($bus_id, $date, $seats, $token);
 				}
+			}
+
+			/* ================= cart-window holds ================= */
+
+			/**
+			 * Seat identifiers held by a single WooCommerce cart item — regular seats
+			 * plus cabin/deck seats — keyed by "{bus_id}|{Y-m-d}". Mirrors the shape
+			 * WBTM_Functions::check_seat_in_cart() reads so both agree on identifiers.
+			 *
+			 * @return array<string,array{bus_id:int|string,date:string,seats:string[]}>
+			 */
+			private static function cart_item_hold_map($cart_item) {
+				$map = array();
+				if (!is_array($cart_item) || empty($cart_item['wbtm_bus_id'])) {
+					return $map;
+				}
+				$bus_id   = $cart_item['wbtm_bus_id'];
+				$raw_date = isset($cart_item['wbtm_bp_time']) ? $cart_item['wbtm_bp_time'] : '';
+				if (!$raw_date) {
+					return $map;
+				}
+				$date  = self::normalize_date($raw_date);
+				$key   = $bus_id . '|' . $date;
+				$seats = array();
+
+				if (!empty($cart_item['wbtm_seats']) && is_array($cart_item['wbtm_seats'])) {
+					foreach ($cart_item['wbtm_seats'] as $seat_info) {
+						if (is_array($seat_info) && !empty($seat_info['seat_name'])) {
+							$seats[] = $seat_info['seat_name'];
+						}
+					}
+				}
+				if (!empty($cart_item['wbtm_cabin_seats']) && is_array($cart_item['wbtm_cabin_seats'])) {
+					foreach ($cart_item['wbtm_cabin_seats'] as $seat_info) {
+						if (!is_array($seat_info)) {
+							continue;
+						}
+						if (!empty($seat_info['seat_identifier'])) {
+							$seats[] = $seat_info['seat_identifier'];
+						} elseif (isset($seat_info['cabin_index'], $seat_info['seat_name'])) {
+							$seats[] = 'cabin_' . $seat_info['cabin_index'] . '_' . $seat_info['seat_name'];
+						}
+					}
+				}
+				if (!empty($seats)) {
+					$map[$key] = array('bus_id' => $bus_id, 'date' => $date, 'seats' => $seats);
+				}
+				return $map;
+			}
+
+			/**
+			 * Refresh the current visitor's holds for every seat sitting in their
+			 * WooCommerce cart, so a seat stays reserved to others for as long as it
+			 * is in the cart — through the whole cart -> checkout window, on both the
+			 * classic and block (Store API) flows. Once the order is placed the
+			 * booking record takes over and release_booked_seats() clears these.
+			 *
+			 * Uses the existing hold token (never mints a new one): the seat is only
+			 * in the cart because the visitor already selected it, which set the
+			 * cookie. Bailing without a token avoids a headers-already-sent cookie
+			 * write that could split the hold across two tokens.
+			 */
+			public function refresh_cart_holds() {
+				static $done = false;
+				if ($done) {
+					return; // The cart-loaded hook can fire more than once per request.
+				}
+				if (!self::is_enabled() || is_admin() || !self::is_wc_ready()) {
+					return;
+				}
+				$token = self::get_token();
+				if (!$token) {
+					return;
+				}
+				$done     = true;
+				$trips    = self::collect_cart_trips();
+				$deadline = self::cart_hold_deadline($trips);
+				// Nothing to hold, or the fixed window already lapsed — do NOT re-hold,
+				// or the seats would be reserved forever by simply reloading the page.
+				if ($deadline <= time()) {
+					return;
+				}
+				// Align every seat's transient to the shared deadline so a reload keeps
+				// counting down to the same moment instead of resetting to a full TTL.
+				$ttl = $deadline - time();
+				foreach ($trips as $trip) {
+					self::hold_seats($trip['bus_id'], $trip['date'], array_values(array_unique($trip['seats'])), $token, $ttl);
+				}
+			}
+
+			/**
+			 * Collect the bus seats currently in the WooCommerce cart, grouped by
+			 * "{bus_id}|{Y-m-d}". Shared by the hold refresh, the deadline window and
+			 * the cart/checkout countdown so all three agree on the same seat set.
+			 *
+			 * @return array<string,array{bus_id:int|string,date:string,seats:string[]}>
+			 */
+			private static function collect_cart_trips() {
+				$trips = array();
+				if (!self::is_wc_ready()) {
+					return $trips;
+				}
+				foreach (WC()->cart->get_cart() as $cart_item) {
+					foreach (self::cart_item_hold_map($cart_item) as $key => $trip) {
+						if (!isset($trips[$key])) {
+							$trips[$key] = $trip;
+						} else {
+							$trips[$key]['seats'] = array_merge($trips[$key]['seats'], $trip['seats']);
+						}
+					}
+				}
+				return $trips;
+			}
+
+			/**
+			 * The fixed moment the current cart's seat hold lapses, stored in the
+			 * WooCommerce session so it survives page reloads. The window starts once,
+			 * when bus seats first appear in the cart, and only restarts when the seat
+			 * set actually changes (fingerprint) — never on a plain reload. Returns 0
+			 * when there are no held seats.
+			 *
+			 * @param array $trips Output of collect_cart_trips().
+			 * @return int Unix timestamp, or 0.
+			 */
+			private static function cart_hold_deadline($trips) {
+				static $cache = null;
+				if ($cache !== null) {
+					return $cache;
+				}
+				if (!self::is_wc_ready() || !isset(WC()->session) || !WC()->session) {
+					return 0;
+				}
+				$session = WC()->session;
+				if (empty($trips)) {
+					// No bus seats: clear any stale window so the next add starts fresh.
+					$session->__unset(self::SESSION_DEADLINE);
+					$session->__unset(self::SESSION_FINGERPRINT);
+					$cache = 0;
+					return 0;
+				}
+				// Fingerprint the exact seat set so the window restarts only on a real
+				// selection change, not on a reload.
+				$parts = array();
+				foreach ($trips as $key => $trip) {
+					$seats = array_values(array_unique($trip['seats']));
+					sort($seats);
+					$parts[] = $key . ':' . implode(',', $seats);
+				}
+				sort($parts);
+				$fingerprint = md5(implode('|', $parts));
+				$stored_fp   = (string) $session->get(self::SESSION_FINGERPRINT, '');
+				$deadline    = (int) $session->get(self::SESSION_DEADLINE, 0);
+				if ($fingerprint !== $stored_fp || $deadline <= 0) {
+					$deadline = time() + self::get_ttl_seconds();
+					$session->set(self::SESSION_DEADLINE, $deadline);
+					$session->set(self::SESSION_FINGERPRINT, $fingerprint);
+				}
+				$cache = $deadline;
+				return $deadline;
+			}
+
+			/**
+			 * Release the caller's holds for a seat removed from the cart, so it does
+			 * not stay blocked to others for the rest of the TTL.
+			 *
+			 * @param string $cart_item_key Removed item key.
+			 * @param object $cart          The cart the item was removed from.
+			 */
+			public function release_removed_cart_item($cart_item_key, $cart) {
+				if (!self::is_enabled()) {
+					return;
+				}
+				$token = self::get_token();
+				if (!$token) {
+					return;
+				}
+				$removed = isset($cart->removed_cart_contents[$cart_item_key])
+					? $cart->removed_cart_contents[$cart_item_key]
+					: null;
+				if (!is_array($removed)) {
+					return;
+				}
+				foreach (self::cart_item_hold_map($removed) as $trip) {
+					self::release_seats($trip['bus_id'], $trip['date'], array_values(array_unique($trip['seats'])), $token);
+				}
+			}
+
+			/** WooCommerce cart is loaded and usable this request. */
+			private static function is_wc_ready() {
+				return function_exists('WC') && WC() && isset(WC()->cart) && WC()->cart;
+			}
+
+			/**
+			 * Enqueue the held-seats countdown on the cart and checkout pages. Both
+			 * is_cart()/is_checkout() are true for the block cart/checkout too, since
+			 * those still live on the designated WooCommerce pages, so one enqueue
+			 * covers both flows. The script is dependency-free and injects its own
+			 * styles, because the booking-page assets are not loaded here.
+			 */
+			public function enqueue_cart_hold_notice() {
+				if (!self::is_enabled() || is_admin()) {
+					return;
+				}
+				$on_cart_or_checkout = ( function_exists('is_cart') && is_cart() )
+					|| ( function_exists('is_checkout') && is_checkout() );
+				if (!$on_cart_or_checkout) {
+					return;
+				}
+				$trips = self::collect_cart_trips();
+				if (empty($trips)) {
+					return;
+				}
+				// The same fixed deadline the hold transients are aligned to, read from
+				// the session — so the countdown shows the true time left and does not
+				// restart on reload.
+				$deadline = self::cart_hold_deadline($trips);
+				$rel      = '/assets/frontend/wbtm_cart_hold.js';
+				$path     = WBTM_PLUGIN_DIR . $rel;
+				wp_enqueue_script(
+					'wbtm-cart-hold',
+					WBTM_PLUGIN_URL . $rel,
+					array(),
+					file_exists($path) ? filemtime($path) : WBTM_VERSION,
+					true
+				);
+				wp_localize_script('wbtm-cart-hold', 'wbtm_cart_hold', array(
+					'expires' => $deadline,
+					'now'     => time(),
+					'label'   => __('Your seats are held for', 'bus-ticket-booking-with-seat-reservation'),
+					'expired' => __('Your seat hold has expired. Please review your seats.', 'bus-ticket-booking-with-seat-reservation'),
+				));
 			}
 
 			/* ================= availability integration ================= */


### PR DESCRIPTION
The seat hold was only set at seat-selection time, so it aged out during the cart -> checkout window (the exact period that matters) and another visitor could grab the seat. It also had no visible timer once the seat left the booking page. Fixes both, for classic AND block cart/checkout.

inc/WBTM_Seat_Hold.php
- refresh_cart_holds() on woocommerce_cart_loaded_from_session keeps every in-cart seat reserved for as long as it is in the cart. The block Store API also fires this hook, so one path covers both flows.
- Fixed hold window: the deadline (now + duration) is stored in the WooCommerce session, fingerprinted to the exact seat set, so a plain reload keeps counting down to the same instant instead of restarting; changing the seats starts a fresh window; a lapsed window is never revived by reloading.
- hold_seats() takes an optional TTL so the per-seat transients expire exactly at that deadline; the index transient TTL now refreshes alongside them.
- release_removed_cart_item() drops a seat's hold as soon as it leaves the cart.
- enqueue_cart_hold_notice() ships the countdown on the cart/checkout pages with the real deadline plus the server clock (immune to browser clock skew).

assets/frontend/wbtm_cart_hold.js (new)
- Dependency-free, self-styling countdown for cart/checkout; inserts itself into the classic or block container; shows an expired notice with no reload loop.

assets/global/wbtm_global.js
- Booking-page hold badge now attaches to the visible Booking Summary card; the old .wbtm_selected_seat_details table it used is display:none in the redesign, so the badge was invisible.