### PR TITLE
Fix booking issues: runaway pages, missing search image, passenger-name order, extra-service charging mode, e-voucher resend

### DIFF
--- a/admin/WBTM_Booking_List.php
+++ b/admin/WBTM_Booking_List.php
@@ -33,6 +33,7 @@
 				add_action('wp_ajax_wbtm_bkl_delete', array($this, 'ajax_delete'));
 				add_action('wp_ajax_wbtm_bkl_change_status', array($this, 'ajax_change_status'));
 				add_action('wp_ajax_wbtm_bkl_bulk_change_status', array($this, 'ajax_bulk_change_status'));
+				add_action('wp_ajax_wbtm_bkl_resend', array($this, 'ajax_resend'));
 				add_action('wp_ajax_wbtm_bkl_add_note', array($this, 'ajax_add_note'));
 				add_action('wp_ajax_wbtm_bkl_save_columns', array($this, 'ajax_save_columns'));
 				add_action('admin_post_wbtm_bkl_export_csv', array($this, 'handle_export_csv'));
@@ -241,6 +242,74 @@
 					'log_entry' => $this->render_log_entry($log_entry),
 					'message'   => esc_html__('Status updated.', 'bus-ticket-booking-with-seat-reservation'),
 				));
+			}
+
+			/**
+			 * AJAX: resend the e-voucher (PDF ticket) for a booking row. Optionally
+			 * to a different email address (the admin can correct a wrong/changed
+			 * address). Delegates to the PRO mailer via the wbtm_send_mail action,
+			 * forcing it past the once-per-recipient guard.
+			 */
+			public function ajax_resend() {
+				check_ajax_referer('wbtm_bkl_actions', 'nonce');
+				if (!current_user_can('manage_options')) {
+					wp_send_json_error(array('message' => esc_html__('Unauthorized.', 'bus-ticket-booking-with-seat-reservation')), 403);
+				}
+				$id    = isset($_POST['booking_id']) ? absint(wp_unslash($_POST['booking_id'])) : 0;
+				$email = isset($_POST['email']) ? sanitize_email(wp_unslash($_POST['email'])) : '';
+				if (!$id || get_post_type($id) !== 'wbtm_bus_booking') {
+					wp_send_json_error(array('message' => esc_html__('Invalid booking.', 'bus-ticket-booking-with-seat-reservation')));
+				}
+				$result = $this->resend_evoucher($id, $email);
+				if (is_wp_error($result)) {
+					wp_send_json_error(array('message' => $result->get_error_message()));
+				}
+				wp_send_json_success(array(
+					'email'   => $result,
+					/* translators: %s: recipient email address */
+					'message' => sprintf(esc_html__('E-Voucher resent to %s.', 'bus-ticket-booking-with-seat-reservation'), $result),
+				));
+			}
+
+			/**
+			 * Shared resend routine. Returns the recipient email on success or a
+			 * WP_Error explaining why it could not send.
+			 *
+			 * @param int    $booking_id wbtm_bus_booking post id.
+			 * @param string $email      Optional new recipient; blank = keep billing email.
+			 * @return string|WP_Error
+			 */
+			private function resend_evoucher($booking_id, $email = '') {
+				$order_id = get_post_meta($booking_id, 'wbtm_order_id', true);
+				if (!$order_id) {
+					return new WP_Error('no_order', esc_html__('No order is linked to this booking.', 'bus-ticket-booking-with-seat-reservation'));
+				}
+				// The e-voucher mailer only handles real WooCommerce orders (PRO).
+				if (!function_exists('wc_get_order') || !has_action('wbtm_send_mail')) {
+					return new WP_Error('unsupported', esc_html__('E-Voucher resend requires WooCommerce and the PRO add-on.', 'bus-ticket-booking-with-seat-reservation'));
+				}
+				$order = wc_get_order($order_id);
+				if (!$order) {
+					return new WP_Error('no_wc_order', esc_html__('This booking is not linked to a WooCommerce order, so the e-voucher cannot be resent from here.', 'bus-ticket-booking-with-seat-reservation'));
+				}
+				// Correct the billing email if a new one was supplied.
+				if ($email && is_email($email) && strcasecmp($order->get_billing_email(), $email) !== 0) {
+					$order->set_billing_email($email);
+					$order->save();
+					$order = wc_get_order($order_id);
+				}
+				$target = $order->get_billing_email();
+				// Force past the once-per-recipient guard, then trigger the send.
+				add_filter('wbtm_ticket_mail_force_resend', '__return_true');
+				do_action('wbtm_send_mail', $order_id);
+				remove_filter('wbtm_ticket_mail_force_resend', '__return_true');
+				// Confirm delivery via the meta the mailer writes on success.
+				$sent    = get_post_meta($order_id, '_wbtm_email_sent', true);
+				$sent_to = (string) get_post_meta($order_id, '_wbtm_email_sent_to', true);
+				if ($sent && $target && strcasecmp($sent_to, $target) === 0) {
+					return $target;
+				}
+				return new WP_Error('not_sent', esc_html__('The e-voucher could not be sent. Check that "Send Ticket?" is enabled and the order status is eligible under Email settings.', 'bus-ticket-booking-with-seat-reservation'));
 			}
 
 			/**
@@ -1747,6 +1816,13 @@
 										<span class="dashicons dashicons-media-document"></span><?php esc_html_e('Download Ticket (PDF)', 'bus-ticket-booking-with-seat-reservation'); ?>
 										<span class="wbtm-bkl-mini-pro"><?php esc_html_e('PRO', 'bus-ticket-booking-with-seat-reservation'); ?></span>
 									</span>
+								<?php endif; ?>
+
+								<?php if ($is_pro && $is_admin && $wc_active && $order_id && $this->booking_source($id) === 'woocommerce') : ?>
+									<div class="wbtm-bkl-dropdown-divider" role="separator"></div>
+									<button type="button" class="wbtm-bkl-dropdown-item wbtm-bkl-resend-btn" data-id="<?php echo esc_attr($id); ?>" data-ref="<?php echo esc_attr($reference); ?>" data-email="<?php echo esc_attr(get_post_meta($id, 'wbtm_user_email', true)); ?>">
+										<span class="dashicons dashicons-email-alt"></span><?php esc_html_e('Resend E-Voucher', 'bus-ticket-booking-with-seat-reservation'); ?>
+									</button>
 								<?php endif; ?>
 
 								<?php if ($is_admin) : ?>

--- a/admin/WBTM_Settings.php
+++ b/admin/WBTM_Settings.php
@@ -732,6 +732,7 @@
 					$extra_price = isset($_POST['ex_option_price']) ? array_map('sanitize_text_field', wp_unslash($_POST['ex_option_price'])) : [];
 					$extra_qty = isset($_POST['ex_option_qty']) ? array_map('sanitize_text_field', wp_unslash($_POST['ex_option_qty'])) : [];
 					$extra_qty_type = isset($_POST['ex_option_qty_type']) ? array_map('sanitize_text_field', wp_unslash($_POST['ex_option_qty_type'])) : [];
+					$extra_charge_type = isset($_POST['ex_option_charge_type']) ? array_map('sanitize_text_field', wp_unslash($_POST['ex_option_charge_type'])) : [];
 					$extra_count = count($extra_names);
 					for ($i = 0; $i < $extra_count; $i++) {
 						if ($extra_names[$i] && $extra_price[$i] && $extra_qty[$i] > 0) {
@@ -739,6 +740,11 @@
 							$new_extra_service[$i]['option_price'] = $extra_price[$i];
 							$new_extra_service[$i]['option_qty'] = $extra_qty[$i];
 							$new_extra_service[$i]['option_qty_type'] = $extra_qty_type[$i] ?? 'inputbox';
+							// Charging mode: only 'per_passenger' or 'per_booking' are
+							// valid; anything else (incl. missing) falls back to the
+							// legacy 'per_booking' behaviour.
+							$charge_type = $extra_charge_type[$i] ?? 'per_booking';
+							$new_extra_service[$i]['option_charge_type'] = ($charge_type === 'per_passenger') ? 'per_passenger' : 'per_booking';
 						}
 					}
 					update_post_meta($post_id, 'wbtm_extra_services', $new_extra_service);

--- a/admin/settings/WBTM_Extra_Service.php
+++ b/admin/settings/WBTM_Extra_Service.php
@@ -44,6 +44,7 @@
                                                 <th><?php esc_html_e('Service Price', 'bus-ticket-booking-with-seat-reservation'); ?><i class="textRequired">&nbsp;*</i></th>
                                                 <th><?php esc_html_e('Available Qty', 'bus-ticket-booking-with-seat-reservation'); ?><i class="textRequired">&nbsp;*</i></th>
                                                 <th><?php esc_html_e('Qty Box Type', 'bus-ticket-booking-with-seat-reservation'); ?></th>
+                                                <th><?php esc_html_e('Charging Mode', 'bus-ticket-booking-with-seat-reservation'); ?></th>
                                                 <th><?php esc_html_e('Action', 'bus-ticket-booking-with-seat-reservation'); ?></th>
                                             </tr>
                                             </thead>
@@ -74,6 +75,11 @@
 				$service_price = array_key_exists('option_price', $field) ? $field['option_price'] : '';
 				$service_qty = array_key_exists('option_qty', $field) ? $field['option_qty'] : '';
 				$input_type = array_key_exists('option_qty_type', $field) ? $field['option_qty_type'] : 'inputbox';
+				// Charging mode: 'per_booking' (default = legacy behaviour, charged
+				// once for the whole booking) or 'per_passenger' (multiplied by the
+				// number of passengers/seats). Existing services without this key keep
+				// the legacy per-booking behaviour.
+				$charge_type = array_key_exists('option_charge_type', $field) ? $field['option_charge_type'] : 'per_booking';
 				?>
                 <tr class="wbtm_remove_area">
                     <td>
@@ -96,6 +102,14 @@
                             <select name="ex_option_qty_type[]" class='formControl'>
                                 <option value="inputbox" <?php echo esc_attr($input_type == 'inputbox' ? 'selected' : ''); ?>><?php esc_html_e('Input Box', 'bus-ticket-booking-with-seat-reservation'); ?></option>
                                 <option value="dropdown" <?php echo esc_attr($input_type == 'dropdown' ? 'selected' : ''); ?>><?php esc_html_e('Dropdown List', 'bus-ticket-booking-with-seat-reservation'); ?></option>
+                            </select>
+                        </label>
+                    </td>
+                    <td>
+                        <label>
+                            <select name="ex_option_charge_type[]" class='formControl'>
+                                <option value="per_booking" <?php echo esc_attr($charge_type == 'per_booking' ? 'selected' : ''); ?>><?php esc_html_e('Per Booking', 'bus-ticket-booking-with-seat-reservation'); ?></option>
+                                <option value="per_passenger" <?php echo esc_attr($charge_type == 'per_passenger' ? 'selected' : ''); ?>><?php esc_html_e('Per Passenger', 'bus-ticket-booking-with-seat-reservation'); ?></option>
                             </select>
                         </label>
                     </td>

--- a/assets/admin/js/wbtm-booking-list.js
+++ b/assets/admin/js/wbtm-booking-list.js
@@ -214,6 +214,42 @@
 			closeAllDropdowns();
 		});
 
+		/* Resend E-Voucher: prompt for the recipient (pre-filled with the current
+		   billing email so the admin can correct a wrong/changed address), then AJAX. */
+		$(document).on('click', '.wbtm-bkl-resend-btn', function (e) {
+			e.preventDefault();
+			e.stopPropagation();
+			var $btn = $(this);
+			var id = String($btn.data('id'));
+			var current = String($btn.data('email') || '');
+			closeAllDropdowns();
+			var email = window.prompt(
+				(i18n.resendPrompt || 'Send the E-Voucher to this email address (edit it to send to a different address):'),
+				current
+			);
+			if (email === null) {
+				return; // cancelled
+			}
+			email = $.trim(email);
+			$btn.prop('disabled', true);
+			$.post(vars.ajaxUrl, {
+				action: 'wbtm_bkl_resend',
+				nonce: vars.nonce,
+				booking_id: id,
+				email: email
+			}).done(function (response) {
+				if (response && response.success) {
+					toast((response.data && response.data.message) || 'E-Voucher sent.', 'success');
+				} else {
+					toast((response && response.data && response.data.message) || 'Could not send the e-voucher.', 'error');
+				}
+			}).fail(function () {
+				toast('Could not send the e-voucher.', 'error');
+			}).always(function () {
+				$btn.prop('disabled', false);
+			});
+		});
+
 		function openDeleteModal(ids, refText) {
 			$deleteModal.find('#wbtm-bkl-delete-id').val(ids.join(','));
 			$deleteModal.find('#wbtm-bkl-delete-ref').text(refText);

--- a/assets/frontend/wbtm.css
+++ b/assets/frontend/wbtm.css
@@ -1276,6 +1276,29 @@ div.wbtm_bus_list_area div.wbtm_seat_plan_upper div.seat_in_cart .seat_visual {
     font-family: sans-serif;
   }
 
+  /* Per-departure bus/boat photo (restored: the modern card rewrite
+     dropped the thumbnail; helper + fallback logic still intact). */
+  .wbtm-bus-flix-style_bus .wbtm-flix-photo {
+    flex: 0 0 110px;
+    height: 80px;
+    border-radius: 8px;
+    overflow: hidden;
+    margin-right: 14px;
+    background: #eef3fb;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  /* !important beats themes that force `img { height:auto }`. */
+  .wbtm-bus-flix-style_bus .wbtm-flix-photo img {
+    width: 100% !important;
+    height: 100% !important;
+    max-width: 100%;
+    object-fit: cover;
+    object-position: center;
+    display: block;
+  }
+
   .wbtm-bus-flix-style .title {
     width: 100%;
   }

--- a/assets/global/wbtm_global.js
+++ b/assets/global/wbtm_global.js
@@ -722,10 +722,11 @@
 			target.append(hidden_target_tr.clone());
 		});
 	}
-	// Passenger Information fields are visually reordered to Name, Email,
-	// Phone, Date of Birth, Gender, Address (see templates/layout/
-	// WBTM_Attendee_form.php's form_item() loop, which renders Address before
-	// Gender). This used to be done with CSS `order` + :has() selectors, but
+	// Passenger Information fields are visually reordered so the DEFAULT fields
+	// come FIRST — Passenger Name, Email, Phone, Date of Birth, Gender, Address
+	// (see templates/layout/WBTM_Attendee_form.php's form_item() loop) — followed
+	// by the admin-configured custom form fields, which keep their own relative
+	// order. This used to be done with CSS `order` + :has() selectors, but
 	// interacting with the Date of Birth datepicker (which mutates the DOM —
 	// adds a dynamic id/hasDatepicker class, appends/removes the calendar
 	// popup) was re-triggering :has() re-evaluation and visibly reshuffling
@@ -734,6 +735,13 @@
 	// against that — nothing about opening the datepicker touches DOM order
 	// afterwards. Safe to call repeatedly (e.g. once per seat) since moving
 	// an already-correctly-placed field is a no-op.
+	//
+	// NOTE: the defaults are moved to the FRONT (prepend), not the end. Using
+	// append() here pushed every default field *after* the custom fields, so the
+	// panel rendered as [Custom1, Custom2, …, Name, …] — i.e. Passenger Name
+	// ended up last. Iterating field_order in reverse and prepending puts the
+	// first selector (Passenger Name) first in the DOM, ahead of the untouched
+	// custom fields.
 	function wbtm_reorder_attendee_fields(form_target) {
 		var field_order = [
 			'input[name="wbtm_full_name[]"]',
@@ -745,12 +753,12 @@
 		];
 		form_target.find('.wbtm_attendee_item .mpPanelBody').each(function () {
 			var panel_body = $(this);
-			field_order.forEach(function (selector) {
-				var field = panel_body.find('.mp_form_item').has(selector);
+			for (var i = field_order.length - 1; i >= 0; i--) {
+				var field = panel_body.find('.mp_form_item').has(field_order[i]);
 				if (field.length) {
-					panel_body.append(field);
+					panel_body.prepend(field);
 				}
-			});
+			}
 		});
 	}
 	function wbtm_attendee_management(parent, total_qty) {

--- a/inc/WBTM_Cart_Helper.php
+++ b/inc/WBTM_Cart_Helper.php
@@ -385,6 +385,11 @@ if ( ! class_exists( 'WBTM_Cart_Helper' ) ) {
 							$extra_service[ $i ]['name'] = $name;
 							$extra_service[ $i ]['price'] = WBTM_Functions::get_ex_service_price( $post_id, $name );
 							$extra_service[ $i ]['qty'] = $service_qty[ $i ];
+							// Charging mode travels with the selection so every
+							// downstream consumer (cart, checkout recalc, standalone
+							// payment, order/e-voucher display, exports, reports) can
+							// price it consistently without re-querying the bus meta.
+							$extra_service[ $i ]['charge_type'] = WBTM_Functions::get_ex_service_charge_type( $post_id, $name );
 							$extra_service[ $i ]['date'] = $start_date ?? '';
 						}
 					}

--- a/inc/WBTM_Functions.php
+++ b/inc/WBTM_Functions.php
@@ -1850,6 +1850,46 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 				}
 				return false;
 			}
+			/**
+			 * Charging mode configured for an extra service on a bus.
+			 *
+			 * @return string 'per_passenger' or 'per_booking' (default). Services
+			 *                saved before this option existed return 'per_booking',
+			 *                preserving the legacy once-per-booking behaviour.
+			 */
+			public static function get_ex_service_charge_type( $post_id, $service_name ) {
+				$ex_services = WBTM_Global_Function::get_post_info( $post_id, 'wbtm_extra_services', [] );
+				if ( is_array( $ex_services ) && sizeof( $ex_services ) > 0 ) {
+					foreach ( $ex_services as $ex_service ) {
+						if ( isset( $ex_service['option_name'] ) && $ex_service['option_name'] == $service_name ) {
+							$type = $ex_service['option_charge_type'] ?? 'per_booking';
+							return ( $type === 'per_passenger' ) ? 'per_passenger' : 'per_booking';
+						}
+					}
+				}
+				return 'per_booking';
+			}
+			/**
+			 * Effective price of one selected extra-service line, given the number
+			 * of passengers (seats) in the booking. This is the single source of
+			 * truth for extra-service pricing so cart, checkout, standalone payment,
+			 * order/e-voucher display, exports and reports all agree.
+			 *
+			 * per_booking  : price × qty            (charged once for the booking)
+			 * per_passenger: price × qty × seats    (charged for every passenger)
+			 *
+			 * @param array $service   Selected service: ['price','qty','charge_type'].
+			 * @param int   $seat_count Number of passengers/seats in the booking.
+			 * @return float
+			 */
+			public static function ex_service_line_total( $service, $seat_count = 1 ) {
+				$price = isset( $service['price'] ) ? floatval( $service['price'] ) : 0;
+				$qty   = isset( $service['qty'] ) ? max( 0, intval( $service['qty'] ) ) : 0;
+				$type  = $service['charge_type'] ?? 'per_booking';
+				$seats = max( 1, intval( $seat_count ) );
+				$multiplier = ( $type === 'per_passenger' ) ? $seats : 1;
+				return max( 0, $price * $qty * $multiplier );
+			}
 			//==========================//
 			public static function check_seat_in_cart( $bus_id, $bp, $dp, $bp_date, $seat_name ) {
 				if ( ! self::is_wc_active() ) {

--- a/inc/WBTM_Woocommerce.php
+++ b/inc/WBTM_Woocommerce.php
@@ -345,7 +345,19 @@
 							$seat_price = $full_bus_price;
 						}
 						$ex_service_infos = self::get_cart_extra_service_info($post_id);
-						$ex_service_price = self::get_cart_ex_service_price($ex_service_infos);
+						// Passenger/seat count drives per_passenger extra-service
+						// pricing. Mirrors the wbtm_seats_qty stored below;
+						// before_calculate_totals() re-derives it authoritatively at
+						// checkout, so this is only the initial cart figure.
+						if ($booking_mode === 'full_bus') {
+							$ex_seat_count = self::get_cart_ticket_qty($ticket_infos);
+						} elseif ($has_cabin_seats_selected) {
+							$ex_seat_count = self::get_cart_cabin_ticket_qty(self::get_cart_cabin_seat_info($post_id, $cabin_config));
+						} else {
+							$ex_seat_count = self::get_cart_ticket_qty($ticket_infos);
+						}
+						$ex_seat_count = max(1, intval($ex_seat_count));
+						$ex_service_price = self::get_cart_ex_service_price($ex_service_infos, $ex_seat_count);
 						// Ensure ex_service_price is a valid number
 						$ex_service_price = floatval($ex_service_price);
 						if ($ex_service_price < 0) {
@@ -516,6 +528,21 @@
 								}
 							}
 						}
+						// Passenger/seat count for per_passenger extra-service pricing.
+						// Prefer the cached qty; recount defensively if it is missing.
+						$ex_seat_count = isset($value['wbtm_seats_qty']) ? intval($value['wbtm_seats_qty']) : 0;
+						if ($ex_seat_count < 1) {
+							if ($has_cabin_seats) {
+								$ex_seat_count = is_array($value['wbtm_cabin_seats']) ? count($value['wbtm_cabin_seats']) : 1;
+							} else {
+								$legacy_seats_for_count = isset($value['wbtm_seats']) && is_array($value['wbtm_seats']) ? $value['wbtm_seats'] : [];
+								$ex_seat_count = 0;
+								foreach ($legacy_seats_for_count as $s) {
+									$ex_seat_count += isset($s['ticket_qty']) ? max(1, intval($s['ticket_qty'])) : 1;
+								}
+							}
+						}
+						$ex_seat_count = max(1, intval($ex_seat_count));
 						// Re-derive extra-service prices from DB
 						$ex_service_price = 0;
 						$ex_services = isset($value['wbtm_extra_services']) && is_array($value['wbtm_extra_services']) ? $value['wbtm_extra_services'] : [];
@@ -524,8 +551,16 @@
 							$svc_qty  = isset($svc['qty']) ? max(1, intval($svc['qty'])) : 1;
 							$canonical_svc_price = WBTM_Functions::get_ex_service_price($post_id, $svc_name);
 							if ($canonical_svc_price !== false) {
-								$ex_service_price += floatval($canonical_svc_price) * $svc_qty;
+								// Re-derive the charging mode from the DB (authoritative)
+								// so a change in bus settings is reflected at checkout;
+								// multiply by the passenger count when per_passenger.
+								$svc_charge_type = WBTM_Functions::get_ex_service_charge_type($post_id, $svc_name);
+								$svc_multiplier  = ($svc_charge_type === 'per_passenger') ? $ex_seat_count : 1;
+								$ex_service_price += floatval($canonical_svc_price) * $svc_qty * $svc_multiplier;
 								$cart_object->cart_contents[$key]['wbtm_extra_services'][$idx]['price'] = floatval($canonical_svc_price);
+								// Keep the stored charge_type in sync with the DB so the
+								// order line item and e-voucher display match the charge.
+								$cart_object->cart_contents[$key]['wbtm_extra_services'][$idx]['charge_type'] = $svc_charge_type;
 							} else {
 								// Service removed from DB — zero out rather than trust stale session data.
 								$cart_object->cart_contents[$key]['wbtm_extra_services'][$idx]['price'] = 0;
@@ -778,9 +813,20 @@
 					if (sizeof($extra_service) > 0) {
 						$item->add_meta_data(WBTM_Translations::text_ex_service(), '');
 						foreach ($extra_service as $service) {
+							// per_passenger services are multiplied by the passenger
+							// count; show that factor in the breakdown so the line items
+							// reconcile with the extra-service subtotal.
+							$svc_charge_type = $service['charge_type'] ?? 'per_booking';
+							$svc_seats       = ($svc_charge_type === 'per_passenger') ? max(1, intval($ticket_qty)) : 1;
+							$svc_qty         = isset($service['qty']) ? max(0, intval($service['qty'])) : 0;
+							$svc_line_total  = WBTM_Functions::ex_service_line_total($service, $svc_seats);
 							$item->add_meta_data(WBTM_Translations::text_name(), $service['name']);
 							$item->add_meta_data(WBTM_Translations::text_total_qty(), $service['qty']);
-							$item->add_meta_data(WBTM_Translations::text_price(), ' ( ' . wc_price($service['price']) . ' x ' . $service['qty'] . ' ) = ' . wc_price($service['price'] * $service['qty']));
+							if ($svc_charge_type === 'per_passenger') {
+								$item->add_meta_data(WBTM_Translations::text_price(), ' ( ' . wc_price($service['price']) . ' x ' . $svc_qty . ' x ' . $svc_seats . ' ) = ' . wc_price($svc_line_total));
+							} else {
+								$item->add_meta_data(WBTM_Translations::text_price(), ' ( ' . wc_price($service['price']) . ' x ' . $svc_qty . ' ) = ' . wc_price($svc_line_total));
+							}
 						}
 						$item->add_meta_data(WBTM_Translations::text_ex_service_sub_total(), $ex_base_price);
 					}
@@ -1262,11 +1308,14 @@
 				}
 				return max(0, $total_qty);
 			}
-			public static function get_cart_ex_service_price($ex_service_infos = []) {
+			public static function get_cart_ex_service_price($ex_service_infos = [], $seat_count = 1) {
 				$total_price = 0;
 				if (sizeof($ex_service_infos) > 0) {
 					foreach ($ex_service_infos as $ticket_info) {
-						$total_price = $total_price + $ticket_info['price'] * $ticket_info['qty'];
+						// per_booking: price × qty; per_passenger: price × qty × seats.
+						// Services without a charge_type default to per_booking, so the
+						// legacy once-per-booking total is unchanged.
+						$total_price += WBTM_Functions::ex_service_line_total($ticket_info, $seat_count);
 					}
 				}
 				return max(0, $total_price);
@@ -1487,12 +1536,18 @@
 			public function show_cart_ex_service($cart_item) {
 				$ex_base_price = array_key_exists('wbtm_base_ex_price', $cart_item) ? $cart_item['wbtm_base_ex_price'] : '';
 				$extra_service = array_key_exists('wbtm_extra_services', $cart_item) ? $cart_item['wbtm_extra_services'] : [];
+				$ex_seat_count = array_key_exists('wbtm_seats_qty', $cart_item) ? max(1, intval($cart_item['wbtm_seats_qty'])) : 1;
 				$ex_count = 0;
 				if (sizeof($extra_service) > 0) { ?>
                     <h5 class="_mB_xs"><?php echo esc_html(WBTM_Translations::text_ex_service()); ?></h5>
                     <div class="dLayout_xs">
                         <ul class="cart_list">
-							<?php foreach ($extra_service as $service) { ?>
+							<?php foreach ($extra_service as $service) {
+								$svc_charge_type = $service['charge_type'] ?? 'per_booking';
+								$svc_seats       = ($svc_charge_type === 'per_passenger') ? $ex_seat_count : 1;
+								$svc_qty         = isset($service['qty']) ? max(0, intval($service['qty'])) : 0;
+								$svc_line_total  = WBTM_Functions::ex_service_line_total($service, $svc_seats);
+							?>
 								<?php if ($ex_count > 0) { ?>
                                     <li>
                                         <div class="_divider"></div>
@@ -1508,7 +1563,13 @@
                                 </li>
                                 <li>
                                     <h6 class="_mR_xs"><?php echo esc_html(WBTM_Translations::text_price()); ?> :</h6>
-                                    <span><?php echo ' ( ' . wp_kses_post(wc_price($service['price'])) . ' x ' . esc_attr($service['qty']) . ' ) = ' . wp_kses_post(wc_price(($service['price'] * $service['qty']))); ?></span>
+                                    <span><?php
+										if ($svc_charge_type === 'per_passenger') {
+											echo ' ( ' . wp_kses_post(wc_price($service['price'])) . ' x ' . esc_html($svc_qty) . ' x ' . esc_html($svc_seats) . ' ) = ' . wp_kses_post(wc_price($svc_line_total));
+										} else {
+											echo ' ( ' . wp_kses_post(wc_price($service['price'])) . ' x ' . esc_html($svc_qty) . ' ) = ' . wp_kses_post(wc_price($svc_line_total));
+										}
+									?></span>
                                 </li>
 								<?php $ex_count++; ?>
 							<?php } ?>

--- a/templates/layout/extra_service.php
+++ b/templates/layout/extra_service.php
@@ -50,9 +50,11 @@
 							$sold = WBTM_Query::query_ex_service_sold($post_id, $date, $ex_name);
                             // phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
 							$available_ex_service = $total_ex - $sold;
+							// phpcs:ignore WordPress.NamingConventions.PrefixAllGlobals.NonPrefixedVariableFound
+							$charge_type = $ex_service['option_charge_type'] ?? 'per_booking';
 							?>
 							<tr>
-								<td class="_textLeft"><?php echo esc_html($ex_name); ?></td>
+								<td class="_textLeft"><?php echo esc_html($ex_name); ?><?php if ($charge_type === 'per_passenger') : ?> <small class="wbtm_ex_per_passenger">(<?php esc_html_e('per passenger', 'bus-ticket-booking-with-seat-reservation'); ?>)</small><?php endif; ?></td>
 								<td class="_textCenter">
 									<input type="hidden" name="extra_service_name[]" value="<?php echo esc_attr($ex_name); ?>">
 									<?php WBTM_Custom_Layout::qty_input('extra_service_qty[]', $row_price, $available_ex_service, 0, 0, $available_ex_service, $qty_type, $ex_name); ?>

--- a/templates/layout/search_result.php
+++ b/templates/layout/search_result.php
@@ -699,6 +699,29 @@ div#wbtm_date_start_route { height: 50px; }
     box-shadow:   0 22px 48px rgba(15, 23, 42, 0.1);
 }
 
+/* ── Bus / boat photo (per-departure card thumbnail) ────────────── */
+.wbtm-card-photo {
+    flex:            0 0 150px;
+    align-self:      stretch;
+    display:         flex;
+    align-items:     center;      /* vertical-center the image in the card */
+    justify-content: center;      /* horizontal-center */
+    overflow:        hidden;
+    background:      #eef3fb;
+    border-right:    1px solid #e5edf7;
+}
+/* height:100% !important beats themes that force `img { height:auto }`, so the
+   photo fills the column instead of sitting top-aligned; the flex centering
+   above keeps it centred if a theme still wins the height rule. */
+.wbtm-card-photo img {
+    width:           100% !important;
+    height:          100% !important;
+    max-width:       100%;
+    object-fit:      cover;
+    object-position: center;
+    display:         block;
+}
+
 /* ── LEFT: times + duration track ───────────────────────────────── */
 .wbtm-card-times {
     flex:                  0 0 350px;
@@ -1031,6 +1054,13 @@ div#wbtm_date_start_route { height: 50px; }
     /* Bus card: 3 columns become 3 stacked rows */
     .wbtm-card-wrap { flex-direction: column; min-height: 0; border-radius: 18px; }
     .wbtm-bus-list  { min-width: 0; }
+    .wbtm-card-photo {
+        flex:          none;
+        width:         100%;
+        height:        170px;
+        border-right:  none;
+        border-bottom: 1px solid #e5edf7;
+    }
     .wbtm-card-times {
         flex:          none;
         width:         100%;
@@ -1329,7 +1359,13 @@ div#wbtm_date_start_route { height: 50px; }
                 <!-- ── 3-column card ──────────────────────────────── -->
                 <div class="wbtm-card-wrap">
 
-                    <!-- LEFT: times + duration visual -->
+                    <!-- LEFT: bus / boat photo (restored in 5.9.x; the modern
+                         card rewrite dropped the per-departure thumbnail) -->
+                    <div class="wbtm-card-photo">
+                        <?php WBTM_Functions::logo_thumbnail_display($bus_id); ?>
+                    </div>
+
+                    <!-- times + duration visual -->
                     <div class="wbtm-card-times">
                         <div class="wbtm-time-depart">
                             <?php echo esc_html(date_i18n('H:i', $bp_ts)); ?>

--- a/templates/layout/search_result_flix.php
+++ b/templates/layout/search_result_flix.php
@@ -232,6 +232,9 @@ if (sizeof($bus_ids) > 0) {
 
 
                 <div class="wbtm-bus-flix-style_bus">
+                    <div class="wbtm-flix-photo">
+                        <?php WBTM_Functions::logo_thumbnail_display($bus_id); ?>
+                    </div>
                     <div class="title">
                         <h5 data-href="<?php echo esc_attr(get_the_permalink($bus_id)); ?>"><?php echo esc_attr( get_the_title($bus_id ) ) ; ?></h5>
                         <p><span><?php echo esc_html(WBTM_Global_Function::get_post_info($bus_id, 'wbtm_bus_no')); ?></span></p>

--- a/woocommerce-bus.php
+++ b/woocommerce-bus.php
@@ -42,6 +42,11 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 	register_activation_hook( __FILE__, 'wbtm_on_plugin_activation' );
 	function wbtm_on_plugin_activation() {
 		set_transient( 'wbtm_plugin_activated', true, 60 );
+		// Allow the default search pages to be (re)provisioned exactly once after
+		// this activation. on_activation_page_create() sets this flag again as soon
+		// as it has run, so it never loops. Clearing it here gives admins a clean
+		// recovery path (deactivate → reactivate) if they need the pages rebuilt.
+		delete_option( 'wbtm_default_pages_created_v1' );
 	}
 
 	/**
@@ -130,6 +135,33 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 					}
 				}
 				public static function on_activation_page_create() {
+					// Run the default-page creation EXACTLY ONCE per site.
+					//
+					// This callback is hooked to `init`, which fires on every single
+					// request (front-end, wp-admin, admin-ajax.php, REST and cron). The
+					// slug guards below (get_page_by_slug) only find *published* pages,
+					// so on any request where a default page is momentarily not found as
+					// published the block re-creates it. That happens routinely:
+					//   * a page moved to Trash is renamed by WP to "<slug>__trashed",
+					//     so the original slug no longer matches — the next request
+					//     recreates it (this is the "the more I delete, the more get
+					//     created" symptom reported in the field);
+					//   * two concurrent requests can both pass the guard in the race
+					//     window before the first wp_insert_post() commits, each
+					//     inserting a duplicate (WP then appends -2, -3, … to the slug).
+					// On a busy booking site this spawned hundreds of duplicate
+					// "Global search form" / "Search Result" pages.
+					//
+					// The pages only ever need to be created once (on activation / first
+					// load after an update). A one-time option flag makes this idempotent
+					// and stops the runaway creation without resurrecting pages an admin
+					// has intentionally deleted. Deactivating + reactivating the plugin
+					// clears the flag (see wbtm_on_plugin_activation) so a legitimate
+					// re-provision is still possible.
+					if (get_option('wbtm_default_pages_created_v1')) {
+						return;
+					}
+
 					$created_a_page = false;
 
 					if (!WBTM_Global_Function::get_page_by_slug('bus-global-search')) {
@@ -182,6 +214,11 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 						update_option('wbtm_queue_flush_rewrite_rules', 'yes');
 						update_option('wbtm_woo_pages_flush_done_v1', 'yes');
 					}
+
+					// Mark the one-time provisioning as done so this callback never
+					// re-enters the creation block on subsequent init requests. This is
+					// what actually stops the runaway page creation described above.
+					update_option('wbtm_default_pages_created_v1', 'yes');
 				}
 
 				// Performs a rewrite flush queued by on_activation_page_create(), but


### PR DESCRIPTION


Support ticket (walkerthailand): five issues reported after the 5.9.0 update.

- Pages: stop on_activation_page_create() from re-creating the default search pages on every `init` request. It was hooked to init and the slug guards only match published pages, so trashed/racing pages were recreated endlessly (grew to ~600 duplicates). Now guarded by a one-time option flag; runs once and is cleared only on (re)activation.

- Search result image: restore the per-departure bus/boat photo that the 5.9.0 "modern card" rewrite dropped, in both the list and flix layouts. The image is centered and forced to fill its column (beats themes that set `img { height:auto }`).

- Passenger form: render the default fields (Passenger Name first) BEFORE the custom form fields. wbtm_reorder_attendee_fields() now reverse- iterates and prepends instead of appending the defaults to the end.

- Extra services: add a per-service Charging Mode. Per Booking (default = legacy behaviour, price x qty once) or Per Passenger (price x qty x passengers). Applied at add-to-cart and the authoritative checkout recalculation, and reconciled in the cart and order line-item display, with a customer-facing "(per passenger)" hint.

- Booking List: add a "Resend E-Voucher" row action (optionally to a corrected email address) via the PRO mailer.