### PR TITLE
fix(dates): stop weekday off-days blocking hand-picked operating dates

### DIFF
--- a/inc/WBTM_Functions.php
+++ b/inc/WBTM_Functions.php
@@ -1398,11 +1398,12 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 					$now           = current_time( 'Y-m-d' );
 					$year          = current_time( 'Y' );
 			
-					// Off days / off dates apply in BOTH modes, so a bus never runs on a day or
-					// date the operator marked off. Previously the "operate on specific dates"
-					// mode ignored these, so off days/dates leaked into search and the calendar.
+					// Off dates and off ranges apply in BOTH modes, so a bus never runs on a
+					// date the operator explicitly marked off. Previously the "operate on
+					// specific dates" mode ignored these, so off dates leaked into search
+					// and the calendar.
 					list( $off_dates, $off_day_array ) = self::get_off_dates_and_days( $post_id, $year, $now );
-			
+
 					if ( $show_on_dates == 'yes' ) {
 						$on_dates = WBTM_Global_Function::get_post_info( $post_id, 'wbtm_particular_dates', array() );
 						if ( ! empty( $on_dates ) ) {
@@ -1416,8 +1417,17 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 									$date_item = gmdate( 'Y-m-d', strtotime( ($year + 1) . '-' . $on_date ) );
 								}
 								if ( strtotime( $date_item ) >= strtotime( $now ) ) {
-									$day = strtolower( gmdate( 'l', strtotime( $date_item ) ) );
-									if ( ! in_array( $date_item, $off_dates ) && ! in_array( $day, $off_day_array ) ) {
+									// Only an explicit off DATE may veto a hand-picked date. The weekday
+									// off-day list ($off_day_array) is deliberately NOT applied here:
+									// naming an exact date is a more specific instruction than a
+									// recurring weekday rule, and the two are contradictory by nature.
+									//
+									// Holiday buses are the real-world case — they are configured with
+									// every normal weekday marked off so they stay out of the regular
+									// timetable, and then given the public holidays as specific dates.
+									// Applying the weekday rule here silently dropped every holiday
+									// that did not happen to fall on the bus's one open weekday.
+									if ( ! in_array( $date_item, $off_dates ) ) {
 										$all_dates[] = $date_item;
 									}
 								}


### PR DESCRIPTION
8a1a6a8 made off days, off dates and off ranges apply in "operate on specific dates" mode. Applying the off DATES and RANGES there was correct and is kept. Applying the weekday off-day list was an over-correction and broke the holiday-bus pattern.

Holiday buses are configured with every normal weekday marked off, so they stay out of the regular timetable, and are then given the public holidays as specific dates. Since 8a1a6a8 the weekday rule was evaluated against those hand-picked dates too, so a holiday was only offered when it happened to fall on the bus's one remaining open weekday. Every other holiday silently disappeared from the search and the date picker.

Seen on a live 48-bus fleet: of five configured 2026 holidays only 1 Nov worked, purely because it lands on a Sunday. 15 Aug, 11 Nov and 25 Dec returned zero departures, so the date picker greyed them out entirely.

Fix: in specific-dates mode only an explicit off DATE (or off range, which expands into off dates) may veto a listed date. Naming an exact date is a more specific instruction than a recurring weekday rule, and configuring both is contradictory by nature. Repeating-schedule mode is untouched and still honours weekday off-days.

No data migration needed: existing holiday buses start working again as their operators originally configured them.

Verified against the real get_post_date() with the live configuration pattern:
  - all five holidays offered, on Sun/Mon/Wed/Thu/Sat alike
  - an explicit off date still excluded (8a1a6a8 leak fix intact)
  - an off range still excluded (8a1a6a8 leak fix intact)
  - repeating bus: same date set, no Sundays, off dates still honoured