### PR TITLE
Export passenger-form fields in the Booking List CSV and PDF

### DIFF
--- a/admin/WBTM_Booking_List.php
+++ b/admin/WBTM_Booking_List.php
@@ -579,6 +579,11 @@
 				$args = $this->build_query_args(-1, 1);
 				$ids  = get_posts(array_merge($args, array('fields' => 'ids')));
 
+				// Every passenger-form field (built-in + custom, e.g. "Emergency Contact
+				// Name") becomes a trailing column, so anything the booking form collects
+				// leaves in the export — see passenger_field_columns().
+				$pax_cols = $this->passenger_field_columns($ids);
+
 				nocache_headers();
 				header('Content-Type: text/csv; charset=utf-8');
 				header('Content-Disposition: attachment; filename=wbtm-bookings-' . gmdate('Y-m-d') . '.csv');
@@ -586,7 +591,11 @@
 				// 'Total' is tax-inclusive (store prices include tax); 'Tax (incl.)' is the
 				// portion of it that is tax and 'Net (excl. Tax)' the remainder — they are
 				// breakdowns of Total, not additions to it.
-				fputcsv($out, array('Booking ID', 'Order ID', 'Source', 'Customer', 'Email', 'Phone', 'Address', 'Passenger', 'Journey Leg', 'Bus', 'Boarding', 'Dropping', 'Journey Date', 'Seat', 'Ticket', 'Fare', 'Extra Services', 'Extra Service Details', 'Total', 'Tax (incl.)', 'Net (excl. Tax)', 'Payment Plan', 'Deposit Paid', 'Remaining Due', 'Balance Due Date', 'Status', 'Booked On'));
+				$header = array('Booking ID', 'Order ID', 'Source', 'Customer', 'Email', 'Phone', 'Address', 'Passenger', 'Journey Leg', 'Bus', 'Boarding', 'Dropping', 'Journey Date', 'Seat', 'Ticket', 'Fare', 'Extra Services', 'Extra Service Details', 'Total', 'Tax (incl.)', 'Net (excl. Tax)', 'Payment Plan', 'Deposit Paid', 'Remaining Due', 'Balance Due Date', 'Status', 'Booked On');
+				foreach ($pax_cols as $pax_label) {
+					$header[] = $pax_label;
+				}
+				fputcsv($out, $header);
 				foreach ($ids as $id) {
 					$bus_id = (int) get_post_meta($id, 'wbtm_bus_id', true);
 					$pax    = $this->passenger_bits($id);
@@ -597,7 +606,7 @@
 					$extras = $this->extra_services_total($id);
 					$tax    = $this->booking_tax($id);
 					$dep    = $this->deposit_info($id);
-					fputcsv($out, array(
+					$row    = array(
 						$id,
 						get_post_meta($id, 'wbtm_order_id', true),
 						$this->booking_source($id) === 'standalone' ? 'Custom' : 'WooCommerce',
@@ -625,10 +634,159 @@
 						$dep['due_date'],
 						get_post_meta($id, 'wbtm_order_status', true),
 						get_post_meta($id, 'wbtm_booking_date', true) ?: get_the_date('Y-m-d H:i', $id),
-					));
+					);
+					if (!empty($pax_cols)) {
+						$answers = $this->passenger_field_answers($id);
+						foreach ($pax_cols as $field_id => $pax_label) {
+							$row[] = $this->passenger_field_answer($answers, $field_id, $pax_label);
+						}
+					}
+					fputcsv($out, $row);
 				}
 				fclose($out);
 				exit;
+			}
+
+			/**
+			 * The passenger-form columns an export should carry: field_id => label.
+			 *
+			 * Buses configure their booking form as two post-meta lists — the built-in
+			 * fields (wbtm_attendee_info) and the admin's own additions
+			 * (wbtm_custom_attendee_info) — and every booked seat stores whatever the
+			 * passenger typed under the same field ids. The bus config is read first so
+			 * headers use the configured labels in the configured order (and stay
+			 * consistent even when a passenger left a field blank); a second pass over
+			 * the bookings themselves picks up any field that has since been removed or
+			 * renamed in the form, so previously-collected answers can never silently
+			 * drop out of the export.
+			 *
+			 * Only buses present in the exported set are inspected, so a filtered export
+			 * gets exactly that bus's fields rather than every field on the site.
+			 */
+			private function passenger_field_columns(array $ids) {
+				$cols    = array();
+				$bus_ids = array();
+				foreach ($ids as $id) {
+					$bus_id = (int) get_post_meta($id, 'wbtm_bus_id', true);
+					if ($bus_id > 0) {
+						$bus_ids[$bus_id] = true;
+					}
+				}
+				foreach (array_keys($bus_ids) as $bus_id) {
+					foreach (array('wbtm_attendee_info', 'wbtm_custom_attendee_info') as $meta_key) {
+						$fields = get_post_meta($bus_id, $meta_key, true);
+						if (!is_array($fields)) {
+							continue;
+						}
+						foreach ($fields as $field) {
+							if (!is_array($field) || empty($field['field_id'])) {
+								continue;
+							}
+							// 'active' absent means active (older bus configs predate the flag).
+							if (array_key_exists('active', $field) && !$field['active']) {
+								continue;
+							}
+							$field_id = (string) $field['field_id'];
+							if (isset($cols[$field_id])) {
+								continue;
+							}
+							$label = '';
+							if (!empty($field['field_label'])) {
+								$label = $field['field_label'];
+							} elseif (!empty($field['d_label'])) {
+								$label = $field['d_label'];
+							}
+							$cols[$field_id] = $label !== '' ? $label : $this->humanize_field_id($field_id);
+						}
+					}
+				}
+				foreach ($ids as $id) {
+					$info = get_post_meta($id, 'wbtm_attendee_info', true);
+					if (!is_array($info)) {
+						continue;
+					}
+					foreach ($info as $field_id => $field) {
+						// Legacy bookings store a numerically-indexed list instead of a
+						// field_id map; those are matched by label in passenger_field_answer().
+						if (!is_string($field_id) || $field_id === '' || isset($cols[$field_id])) {
+							continue;
+						}
+						$label = (is_array($field) && !empty($field['name'])) ? $field['name'] : '';
+						$cols[$field_id] = $label !== '' ? $label : $this->humanize_field_id($field_id);
+					}
+				}
+				return $cols;
+			}
+
+			/**
+			 * A booking's passenger-form answers, indexed both by field id and by the
+			 * label stored alongside each answer. The label index is what lets legacy
+			 * bookings (stored as a numeric list of {name, value} pairs rather than a
+			 * field_id map) still line up with the columns.
+			 */
+			private function passenger_field_answers($id) {
+				$answers = array('by_id' => array(), 'by_label' => array());
+				$info    = get_post_meta($id, 'wbtm_attendee_info', true);
+				if (!is_array($info)) {
+					return $answers;
+				}
+				foreach ($info as $field_id => $field) {
+					$value = is_array($field) ? ($field['value'] ?? '') : $field;
+					$value = is_array($value) ? implode(', ', $value) : (string) $value;
+					if (is_string($field_id) && $field_id !== '') {
+						$answers['by_id'][$field_id] = $value;
+					}
+					$label = (is_array($field) && !empty($field['name'])) ? (string) $field['name'] : '';
+					if ($label !== '' && !isset($answers['by_label'][$label])) {
+						$answers['by_label'][$label] = $value;
+					}
+				}
+				return $answers;
+			}
+
+			/**
+			 * One passenger-form answer for one column — by field id, falling back to
+			 * the column label for legacy bookings. Missing answers export as blank so
+			 * every row keeps the same column count as the header.
+			 */
+			private function passenger_field_answer(array $answers, $field_id, $label) {
+				if (isset($answers['by_id'][$field_id])) {
+					return $answers['by_id'][$field_id];
+				}
+				if ($label !== '' && isset($answers['by_label'][$label])) {
+					return $answers['by_label'][$label];
+				}
+				return '';
+			}
+
+			/**
+			 * One booking's answered passenger-form fields as an escaped "Label: value"
+			 * strip for the PDF export, or '' when the passenger filled nothing in.
+			 * Column order follows $pax_cols so the strips stay consistent down the page.
+			 */
+			private function passenger_field_strip($id, array $pax_cols) {
+				if (empty($pax_cols)) {
+					return '';
+				}
+				$answers = $this->passenger_field_answers($id);
+				$bits    = array();
+				foreach ($pax_cols as $field_id => $label) {
+					$value = $this->passenger_field_answer($answers, $field_id, $label);
+					if ($value === '') {
+						continue;
+					}
+					$bits[] = '<span style="color:#64748b;">' . esc_html($label) . ':</span> ' . esc_html($value);
+				}
+				return $bits ? implode(' &nbsp;&bull;&nbsp; ', $bits) : '';
+			}
+
+			/**
+			 * Readable header for a field that carries no configured label
+			 * (wbtm_emergency_contact => "Emergency Contact").
+			 */
+			private function humanize_field_id($field_id) {
+				$clean = preg_replace('/^wbtm[_-]/', '', (string) $field_id);
+				return ucwords(str_replace(array('_', '-'), ' ', $clean));
 			}
 
 			/**
@@ -649,6 +807,9 @@
 
 				$args = $this->build_query_args(-1, 1);
 				$ids  = get_posts(array_merge($args, array('fields' => 'ids')));
+
+				// Same passenger-form fields the CSV exports — see passenger_field_columns().
+				$pax_cols = $this->passenger_field_columns($ids);
 
 				$rows = '';
 				$grand_total  = 0;
@@ -713,6 +874,15 @@
 						. '<td>' . esc_html(ucfirst(str_replace('wc-', '', (string) $status)) ?: '—') . '</td>'
 						. '<td>' . esc_html($leg) . '</td>'
 						. '</tr>';
+					// Passenger-form answers (built-in + custom fields such as "Emergency
+					// Contact Name") ride along as a full-width continuation strip under the
+					// booking rather than one column per field: a booking form can carry any
+					// number of fields, and extra columns would collapse this already
+					// 13-column landscape table. Bookings with nothing filled in get no strip.
+					$pax_strip = $this->passenger_field_strip($id, $pax_cols);
+					if ($pax_strip !== '') {
+						$rows .= '<tr><td class="pax" colspan="13">' . $pax_strip . '</td></tr>';
+					}
 				}
 				if ($rows === '') {
 					$rows = '<tr><td colspan="13" style="text-align:center;color:#999;padding:18px;">' . esc_html__('No bookings found.', 'bus-ticket-booking-with-seat-reservation') . '</td></tr>';
@@ -727,6 +897,7 @@
 					. 'table{width:100%;border-collapse:collapse;}'
 					. 'th{background:#f1f5f9;text-align:left;padding:6px 7px;font-size:8.5px;text-transform:uppercase;border-bottom:1px solid #cbd5e1;}'
 					. 'td{padding:6px 7px;border-bottom:1px solid #eef2f6;vertical-align:top;}'
+					. 'td.pax{background:#f8fafc;color:#334155;font-size:8.5px;padding:4px 7px 5px;}'
 					. 'tfoot td{font-weight:bold;border-top:1px solid #cbd5e1;}'
 					. '</style>';
 				$html .= '<h1>' . esc_html__('Booking List', 'bus-ticket-booking-with-seat-reservation') . '</h1>';
@@ -2142,8 +2313,14 @@
 													$value = is_array($field) ? ($field['value'] ?? '') : $field;
 													$value = is_array($value) ? implode(', ', $value) : $value;
 													if ($value === '') continue;
+													// Each answer carries the form label it was collected under; fall
+													// back to the field id only when that label is missing.
+													$field_label = (is_array($field) && !empty($field['name'])) ? $field['name'] : '';
+													if ($field_label === '') {
+														$field_label = is_string($field_key) ? $this->humanize_field_id($field_key) : __('Field', 'bus-ticket-booking-with-seat-reservation');
+													}
 												?>
-													<dt><?php echo esc_html(is_string($field_key) ? ucwords(str_replace('_', ' ', $field_key)) : esc_html__('Field', 'bus-ticket-booking-with-seat-reservation')); ?></dt>
+													<dt><?php echo esc_html($field_label); ?></dt>
 													<dd><?php echo esc_html($value); ?></dd>
 												<?php endforeach; ?>
 											</dl>

--- a/admin/WBTM_Booking_List.php
+++ b/admin/WBTM_Booking_List.php
@@ -38,6 +38,7 @@
 				add_action('wp_ajax_wbtm_bkl_save_columns', array($this, 'ajax_save_columns'));
 				add_action('admin_post_wbtm_bkl_export_csv', array($this, 'handle_export_csv'));
 				add_action('admin_post_wbtm_bkl_export_pdf', array($this, 'handle_export_pdf'));
+				add_action('admin_post_wbtm_bkl_export_thermal', array($this, 'handle_export_thermal'));
 			}
 
 			public function register_menu() {
@@ -124,6 +125,20 @@
 					// there is no duplicate handler. When it is not active these stay inert.
 					'qrActive' => class_exists('WBTM_QR_CODE_Functions'),
 					'qrNonce'  => wp_create_nonce('wbtm_pro_admin_nonce'),
+					// Export modal: the JS assembles wbtm_bl_* args from the chosen scope
+					// and posts them to admin-post.php, one nonce per format handler.
+					// 'currentFilters' is the filter bar's live state, so the "Current view"
+					// scope exports exactly what is on screen; 'today' comes from the server
+					// so a day-boundary export follows the site's timezone, not the browser's.
+					'exportBase'     => admin_url('admin-post.php'),
+					'exportNonces'   => array(
+						'csv'     => wp_create_nonce('wbtm_bkl_export_csv'),
+						'pdf'     => wp_create_nonce('wbtm_bkl_export_pdf'),
+						'thermal' => wp_create_nonce('wbtm_bkl_export_thermal'),
+					),
+					'currentFilters' => $this->current_filter_query_args(),
+					'today'          => current_time('Y-m-d'),
+					'maxThermal'     => self::MAX_THERMAL_TICKETS,
 					'i18n'    => array(
 						'proOnly'     => esc_html__('This is a PRO feature. Upgrade to unlock it.', 'bus-ticket-booking-with-seat-reservation'),
 						'deleted'     => esc_html__('Booking deleted.', 'bus-ticket-booking-with-seat-reservation'),
@@ -140,6 +155,12 @@
 						'checkinError'      => esc_html__('Could not update check-in.', 'bus-ticket-booking-with-seat-reservation'),
 						'confirmCheckin'    => esc_html__('Check in %d booking(s)?', 'bus-ticket-booking-with-seat-reservation'),
 						'confirmRevoke'     => esc_html__('Revoke check-in for %d booking(s)?', 'bus-ticket-booking-with-seat-reservation'),
+						'exportNoFormat'    => esc_html__('Please choose an export format.', 'bus-ticket-booking-with-seat-reservation'),
+						'exportNoRows'      => esc_html__('Tick the bookings you want to export first, or choose a different scope.', 'bus-ticket-booking-with-seat-reservation'),
+						'exportBadRange'    => esc_html__('Please pick both a From and a To date.', 'bus-ticket-booking-with-seat-reservation'),
+						'exportRangeOrder'  => esc_html__('The From date cannot be after the To date.', 'bus-ticket-booking-with-seat-reservation'),
+						'exportTooManyThermal' => esc_html__('Thermal printing is capped at %d tickets per run. Narrow the selection down.', 'bus-ticket-booking-with-seat-reservation'),
+						'exportStarted'     => esc_html__('Preparing your export…', 'bus-ticket-booking-with-seat-reservation'),
 					),
 				));
 			}
@@ -567,8 +588,8 @@
 
 			/**
 			 * Pro-only: stream all matching bookings (respecting the current filters)
-			 * as a CSV download. Gated on is_pro() so "Export CSV" is never wired up
-			 * to a working action in free installs.
+			 * as a CSV download. Gated on is_pro() so the Export dialog is never wired
+			 * up to a working action in free installs.
 			 */
 			public function handle_export_csv() {
 				if (!current_user_can('manage_options') || !$this->is_pro()) {
@@ -700,6 +721,15 @@
 						}
 					}
 				}
+				// Labels already claimed by the bus config, lowercased for comparison. A
+				// booking-level field carrying one of these is the SAME question under a
+				// different id (a renamed field id, an older form revision), so it must
+				// merge into the existing column — passenger_field_answer() finds its value
+				// by label. Adding a second column instead printed the answer twice.
+				$claimed = array();
+				foreach ($cols as $existing_label) {
+					$claimed[strtolower(trim((string) $existing_label))] = true;
+				}
 				foreach ($ids as $id) {
 					$info = get_post_meta($id, 'wbtm_attendee_info', true);
 					if (!is_array($info)) {
@@ -712,7 +742,13 @@
 							continue;
 						}
 						$label = (is_array($field) && !empty($field['name'])) ? $field['name'] : '';
-						$cols[$field_id] = $label !== '' ? $label : $this->humanize_field_id($field_id);
+						$label = $label !== '' ? $label : $this->humanize_field_id($field_id);
+						$key   = strtolower(trim($label));
+						if (isset($claimed[$key])) {
+							continue;
+						}
+						$claimed[$key]   = true;
+						$cols[$field_id] = $label;
 					}
 				}
 				return $cols;
@@ -775,9 +811,31 @@
 					if ($value === '') {
 						continue;
 					}
-					$bits[] = '<span style="color:#64748b;">' . esc_html($label) . ':</span> ' . esc_html($value);
+					$bits[] = '<span class="lbl">' . esc_html($label) . ':</span> ' . esc_html($value);
 				}
 				return $bits ? implode(' &nbsp;&bull;&nbsp; ', $bits) : '';
+			}
+
+			/**
+			 * A price formatted for the PDF.
+			 *
+			 * Amounts are deliberately NEVER bold. mPDF resolves each weight to a
+			 * separate font file, and the bold faces bundled with it are missing several
+			 * currency glyphs that the regular faces have — the Bangladeshi Taka (৳)
+			 * among them — so a bold price printed the amount with a tofu box where the
+			 * symbol should be. Emphasis in the totals row comes from its tint and rule
+			 * instead of weight, which costs nothing and always renders.
+			 *
+			 * @param float $amount Value to format.
+			 * @param bool  $markup Wrap in a span (false when the caller escapes the
+			 *                      result itself, e.g. inside a translated sentence).
+			 */
+			private function pdf_money($amount, $markup = true) {
+				$price = wp_strip_all_tags(WBTM_Global_Function::format_price($amount));
+				// format_price() returns an HTML entity for many symbols (&#2547; for ৳);
+				// mPDF needs the real character, and this string is escaped from here on.
+				$price = html_entity_decode($price, ENT_QUOTES, get_bloginfo('charset') ?: 'UTF-8');
+				return $markup ? '<span style="font-weight:normal;">' . esc_html($price) . '</span>' : $price;
 			}
 
 			/**
@@ -815,8 +873,12 @@
 				$grand_total  = 0;
 				$grand_extras = 0;
 				$grand_tax    = 0;
+				$bus_seen     = array();
 				foreach ($ids as $id) {
 					$bus_id = (int) get_post_meta($id, 'wbtm_bus_id', true);
+					if ($bus_id) {
+						$bus_seen[$bus_id] = true;
+					}
 					$order_id = get_post_meta($id, 'wbtm_order_id', true);
 					$pax    = $this->passenger_bits($id);
 					$name   = get_post_meta($id, 'wbtm_user_name', true) ?: $pax['name'];
@@ -840,37 +902,37 @@
 					$grand_tax    += $tax;
 
 					$route = trim($bp . ($dp ? ' → ' . $dp : ''));
-					$cust  = esc_html($name ?: '—') . ($phone ? '<br><span style="color:#777;">' . esc_html($phone) . '</span>' : '');
-					$seatt = esc_html($this->seat_label($id)) . ($ticket ? '<br><span style="color:#777;">' . esc_html($ticket) . '</span>' : '');
+					$cust  = '<strong>' . esc_html($name ?: '—') . '</strong>' . ($phone ? '<br><span class="sub">' . esc_html($phone) . '</span>' : '');
+					$seatt = '<strong>' . esc_html($this->seat_label($id)) . '</strong>' . ($ticket ? '<br><span class="sub">' . esc_html($ticket) . '</span>' : '');
 					$exlabel = $this->extra_services_label($id);
 					$excell  = $extras > 0
-						? wp_strip_all_tags(WBTM_Global_Function::format_price($extras)) . ($exlabel ? '<br><span style="color:#777;">' . esc_html($exlabel) . '</span>' : '')
-						: '—';
-					$taxcell = $tax > 0 ? wp_strip_all_tags(WBTM_Global_Function::format_price($tax)) : '—';
+						? $this->pdf_money($extras) . ($exlabel ? '<br><span class="sub">' . esc_html($exlabel) . '</span>' : '')
+						: '<span class="nil">—</span>';
+					$taxcell = $tax > 0 ? $this->pdf_money($tax) : '<span class="nil">—</span>';
 					// Deposit bookings show what was actually collected vs still owed,
 					// since the Total column is the full (tax-inclusive) ticket price.
 					$depnote = '';
 					if ($dep['is_deposit'] && $dep['remaining'] > 0) {
-						$depnote = '<br><span style="color:#c0392b;">' . esc_html(sprintf(
+						$depnote = '<br><span class="due">' . esc_html(sprintf(
 							/* translators: 1: amount paid so far, 2: outstanding balance. */
 							__('paid %1$s · due %2$s', 'bus-ticket-booking-with-seat-reservation'),
-							wp_strip_all_tags(WBTM_Global_Function::format_price($dep['paid'])),
-							wp_strip_all_tags(WBTM_Global_Function::format_price($dep['remaining']))
+							$this->pdf_money($dep['paid'], false),
+							$this->pdf_money($dep['remaining'], false)
 						)) . '</span>';
 					}
 
 					$rows .= '<tr>'
-						. '<td>#' . esc_html($order_id ?: $id) . '<br><span style="color:#999;">ID ' . esc_html($id) . '</span></td>'
-						. '<td>' . esc_html($source) . '</td>'
+						. '<td><strong>#' . esc_html($order_id ?: $id) . '</strong><br><span class="sub">ID ' . esc_html($id) . '</span></td>'
+						. '<td><span class="tag">' . esc_html($source) . '</span></td>'
 						. '<td>' . $cust . '</td>'
 						. '<td>' . esc_html($bus_id ? get_the_title($bus_id) : '—') . '</td>'
 						. '<td>' . esc_html($route ?: '—') . '</td>'
 						. '<td>' . esc_html($jdate ?: '—') . '</td>'
 						. '<td>' . $seatt . '</td>'
-						. '<td>' . wp_strip_all_tags(WBTM_Global_Function::format_price($fare)) . '</td>'
-						. '<td>' . $excell . '</td>'
-						. '<td>' . $taxcell . '</td>'
-						. '<td>' . wp_strip_all_tags(WBTM_Global_Function::format_price($total)) . $depnote . '</td>'
+						. '<td class="num">' . $this->pdf_money($fare) . '</td>'
+						. '<td class="num">' . $excell . '</td>'
+						. '<td class="num">' . $taxcell . '</td>'
+						. '<td class="num strong-num">' . $this->pdf_money($total) . $depnote . '</td>'
 						. '<td>' . esc_html(ucfirst(str_replace('wc-', '', (string) $status)) ?: '—') . '</td>'
 						. '<td>' . esc_html($leg) . '</td>'
 						. '</tr>';
@@ -885,47 +947,108 @@
 					}
 				}
 				if ($rows === '') {
-					$rows = '<tr><td colspan="13" style="text-align:center;color:#999;padding:18px;">' . esc_html__('No bookings found.', 'bus-ticket-booking-with-seat-reservation') . '</td></tr>';
+					$rows = '<tr><td colspan="13" class="empty">' . esc_html__('No bookings found.', 'bus-ticket-booking-with-seat-reservation') . '</td></tr>';
 				}
 
-				$generated = esc_html(date_i18n(get_option('date_format') . ' ' . get_option('time_format')));
+				$generated = date_i18n(get_option('date_format') . ' ' . get_option('time_format'));
 				$count     = count($ids);
+				$net       = max(0, $grand_total - $grand_tax);
+
+				// Light, print-first palette: white paper, slate ink, hairline rules, and the
+				// plugin's rose used only for the accent rule, the summary figures and the
+				// totals row. Nothing here relies on a dark fill, so it stays legible on a
+				// mono office printer and doesn't drink toner.
 				$html  = '<style>'
-					. 'body{font-family:sans-serif;color:#333;font-size:9px;}'
-					. 'h1{font-size:15px;margin:0 0 2px;}'
-					. '.meta{color:#777;font-size:9px;margin:0 0 10px;}'
-					. 'table{width:100%;border-collapse:collapse;}'
-					. 'th{background:#f1f5f9;text-align:left;padding:6px 7px;font-size:8.5px;text-transform:uppercase;border-bottom:1px solid #cbd5e1;}'
-					. 'td{padding:6px 7px;border-bottom:1px solid #eef2f6;vertical-align:top;}'
-					. 'td.pax{background:#f8fafc;color:#334155;font-size:8.5px;padding:4px 7px 5px;}'
-					. 'tfoot td{font-weight:bold;border-top:1px solid #cbd5e1;}'
+					// freesans, not sans-serif: mPDF's default (DejaVu) has no glyph for
+					// several currency signs — the Bangladeshi Taka (৳) among them — and
+					// printed a tofu box. See pdf_money() for why amounts are never bold.
+					. 'body{font-family:freesans;color:#1f2937;font-size:8.6pt;}'
+					. '.doc-head{width:100%;border-collapse:collapse;margin:0 0 2mm;}'
+					. '.doc-head td{padding:0;border:0;vertical-align:bottom;}'
+					. '.doc-title{font-size:16pt;font-weight:bold;color:#0f172a;letter-spacing:-.2pt;}'
+					. '.doc-sub{font-size:8pt;color:#94a3b8;padding-top:1mm;}'
+					. '.doc-org{text-align:right;font-size:9.5pt;font-weight:bold;color:#475569;}'
+					. '.org-host{font-size:7.5pt;font-weight:normal;color:#a8b3c2;}'
+					. '.rule{height:2px;background:#e63946;font-size:0;line-height:0;margin:0 0 4mm;}'
+					// Summary strip: four light cards, figures in rose, labels in muted caps.
+					. '.sum{width:100%;border-collapse:separate;border-spacing:2.5mm 0;margin:0 0 4mm;}'
+					. '.sum td{background:#f8fafc;border:1px solid #eaeff5;padding:2.6mm 3mm;width:25%;}'
+					. '.sum .k{font-size:7pt;color:#94a3b8;text-transform:uppercase;letter-spacing:.3pt;}'
+					. '.sum .v{font-size:12pt;color:#e63946;padding-top:.6mm;}'
+					. 'table.list{width:100%;border-collapse:collapse;}'
+					. 'table.list th{background:#f7f9fc;text-align:left;padding:2.4mm 2mm;font-size:7pt;font-weight:bold;'
+						. 'text-transform:uppercase;letter-spacing:.3pt;color:#64748b;border-bottom:1px solid #dde5ee;}'
+					. 'table.list td{padding:2.4mm 2mm;border-bottom:1px solid #eef2f7;vertical-align:top;line-height:1.35;}'
+					. 'table.list td.num{text-align:right;white-space:nowrap;}'
+					. 'table.list td.strong-num{color:#0f172a;}'
+					. '.sub{color:#98a4b3;font-size:7.4pt;}'
+					. '.nil{color:#cbd5e1;}'
+					. '.due{color:#c0392b;font-size:7.4pt;}'
+					. '.tag{background:#eef2f7;color:#5b6878;font-size:7pt;padding:.6mm 1.4mm;}'
+					// Passenger-form answers: a tinted continuation strip under each booking.
+					. 'td.pax{background:#f9fbfd;color:#475569;font-size:7.4pt;padding:1.6mm 2mm 2mm;border-bottom:1px solid #eef2f7;}'
+					. 'td.pax .lbl{color:#9aa6b5;}'
+					. 'td.empty{text-align:center;color:#a8b3c2;padding:12mm 2mm;}'
+					. 'tfoot td{background:#fdf2f4;border-top:1.5px solid #e63946;border-bottom:0;color:#8f1d28;padding:2.8mm 2mm;}'
+					. 'tfoot .lbl{text-align:right;font-weight:bold;text-transform:uppercase;font-size:7.5pt;letter-spacing:.3pt;}'
 					. '</style>';
-				$html .= '<h1>' . esc_html__('Booking List', 'bus-ticket-booking-with-seat-reservation') . '</h1>';
-				$html .= '<p class="meta">' . sprintf(
-					/* translators: 1: number of bookings, 2: date/time generated. */
-					esc_html__('%1$s booking(s) — generated %2$s', 'bus-ticket-booking-with-seat-reservation'),
-					esc_html(number_format_i18n($count)),
-					$generated
-				) . '</p>';
-				$html .= '<table><thead><tr>'
-					. '<th>' . esc_html__('Booking', 'bus-ticket-booking-with-seat-reservation') . '</th>'
-					. '<th>' . esc_html__('Source', 'bus-ticket-booking-with-seat-reservation') . '</th>'
-					. '<th>' . esc_html__('Customer', 'bus-ticket-booking-with-seat-reservation') . '</th>'
-					. '<th>' . esc_html__('Bus', 'bus-ticket-booking-with-seat-reservation') . '</th>'
-					. '<th>' . esc_html__('Route', 'bus-ticket-booking-with-seat-reservation') . '</th>'
-					. '<th>' . esc_html__('Journey Date', 'bus-ticket-booking-with-seat-reservation') . '</th>'
-					. '<th>' . esc_html__('Seat / Ticket', 'bus-ticket-booking-with-seat-reservation') . '</th>'
-					. '<th>' . esc_html__('Fare', 'bus-ticket-booking-with-seat-reservation') . '</th>'
-					. '<th>' . esc_html__('Extra Services', 'bus-ticket-booking-with-seat-reservation') . '</th>'
-					. '<th>' . esc_html__('Tax (incl.)', 'bus-ticket-booking-with-seat-reservation') . '</th>'
-					. '<th>' . esc_html__('Total', 'bus-ticket-booking-with-seat-reservation') . '</th>'
-					. '<th>' . esc_html__('Status', 'bus-ticket-booking-with-seat-reservation') . '</th>'
-					. '<th>' . esc_html__('Leg', 'bus-ticket-booking-with-seat-reservation') . '</th>'
-					. '</tr></thead><tbody>' . $rows . '</tbody>'
-					. '<tfoot><tr><td colspan="8" style="text-align:right;">' . esc_html__('Grand Total', 'bus-ticket-booking-with-seat-reservation') . '</td>'
-					. '<td>' . wp_strip_all_tags(WBTM_Global_Function::format_price($grand_extras)) . '</td>'
-					. '<td>' . wp_strip_all_tags(WBTM_Global_Function::format_price($grand_tax)) . '</td>'
-					. '<td>' . wp_strip_all_tags(WBTM_Global_Function::format_price($grand_total)) . '</td><td colspan="2"></td></tr></tfoot>'
+
+				$html .= '<table class="doc-head"><tr>'
+					. '<td><div class="doc-title">' . esc_html__('Booking List', 'bus-ticket-booking-with-seat-reservation') . '</div>'
+					. '<div class="doc-sub">' . sprintf(
+						/* translators: 1: number of bookings, 2: date/time generated. */
+						esc_html__('%1$s booking(s) · generated %2$s', 'bus-ticket-booking-with-seat-reservation'),
+						esc_html(number_format_i18n($count)),
+						esc_html($generated)
+					) . '</div></td>'
+					// Explicit <br>: mPDF ignores display:block on an inline element, so a
+					// styled <small> alone left the host glued to the site name.
+					. '<td class="doc-org">' . esc_html(get_bloginfo('name'))
+					. '<br><span class="org-host">' . esc_html(wp_parse_url(home_url(), PHP_URL_HOST)) . '</span></td>'
+					. '</tr></table><div class="rule"></div>';
+
+				$summary = array(
+					array(esc_html__('Bookings', 'bus-ticket-booking-with-seat-reservation'), esc_html(number_format_i18n($count))),
+					array(esc_html__('Revenue (incl. tax)', 'bus-ticket-booking-with-seat-reservation'), $this->pdf_money($grand_total)),
+					array(esc_html__('Net (excl. tax)', 'bus-ticket-booking-with-seat-reservation'), $this->pdf_money($net)),
+					array(esc_html__('Buses', 'bus-ticket-booking-with-seat-reservation'), esc_html(number_format_i18n(count($bus_seen)))),
+				);
+				$html .= '<table class="sum"><tr>';
+				foreach ($summary as $card) {
+					$html .= '<td><div class="k">' . $card[0] . '</div><div class="v">' . $card[1] . '</div></td>';
+				}
+				$html .= '</tr></table>';
+
+				// Fixed column widths (percent of the table): with auto layout a long extra
+				// service name stole space from the money columns and pushed "Tax (incl.)"
+				// onto two lines. Widths total 100 and are ordered as the row cells above.
+				$columns = array(
+					array(__('Booking', 'bus-ticket-booking-with-seat-reservation'), 7, 'left'),
+					array(__('Source', 'bus-ticket-booking-with-seat-reservation'), 7, 'left'),
+					array(__('Customer', 'bus-ticket-booking-with-seat-reservation'), 12, 'left'),
+					array(__('Bus', 'bus-ticket-booking-with-seat-reservation'), 7, 'left'),
+					array(__('Route', 'bus-ticket-booking-with-seat-reservation'), 9, 'left'),
+					array(__('Journey Date', 'bus-ticket-booking-with-seat-reservation'), 8.5, 'left'),
+					array(__('Seat / Ticket', 'bus-ticket-booking-with-seat-reservation'), 6.5, 'left'),
+					array(__('Fare', 'bus-ticket-booking-with-seat-reservation'), 6.5, 'right'),
+					array(__('Extra Services', 'bus-ticket-booking-with-seat-reservation'), 10, 'right'),
+					array(__('Tax (incl.)', 'bus-ticket-booking-with-seat-reservation'), 5.5, 'right'),
+					array(__('Total', 'bus-ticket-booking-with-seat-reservation'), 7, 'right'),
+					array(__('Status', 'bus-ticket-booking-with-seat-reservation'), 7.5, 'left'),
+					array(__('Leg', 'bus-ticket-booking-with-seat-reservation'), 6.5, 'left'),
+				);
+				$html .= '<table class="list"><thead><tr>';
+				foreach ($columns as $column) {
+					$html .= '<th style="width:' . esc_attr($column[1]) . '%;text-align:' . esc_attr($column[2]) . ';">'
+						. esc_html($column[0]) . '</th>';
+				}
+				$html .= '</tr></thead><tbody>' . $rows . '</tbody>'
+					. '<tfoot><tr>'
+					. '<td colspan="8" class="lbl">' . esc_html__('Grand Total', 'bus-ticket-booking-with-seat-reservation') . '</td>'
+					. '<td class="num">' . $this->pdf_money($grand_extras) . '</td>'
+					. '<td class="num">' . $this->pdf_money($grand_tax) . '</td>'
+					. '<td class="num">' . $this->pdf_money($grand_total) . '</td>'
+					. '<td colspan="2"></td></tr></tfoot>'
 					. '</table>';
 
 				// Raise PCRE limits for large lists (mirrors the Pro generator's guard),
@@ -935,13 +1058,81 @@
 				if ((int) ini_get('pcre.recursion_limit') < 200000) { @ini_set('pcre.recursion_limit', '200000'); }
 
 				try {
-					$mpdf = new \Mpdf\Mpdf(array('mode' => 'utf-8', 'format' => 'A4-L', 'margin_top' => 12, 'margin_bottom' => 12, 'margin_left' => 10, 'margin_right' => 10));
+					$mpdf = new \Mpdf\Mpdf(array(
+						'mode'          => 'utf-8',
+						'format'        => 'A4-L',
+						'margin_top'    => 12,
+						'margin_bottom' => 14,
+						'margin_left'   => 10,
+						'margin_right'  => 10,
+						// Match the stylesheet so the page footer resolves the same glyphs.
+						'default_font'  => 'freesans',
+					));
+					// Repeat the column headers on every page and number the pages, so a
+					// multi-page manifest is still readable once it is off the screen.
+					$mpdf->SetHTMLFooter(
+						'<table width="100%" style="font-family:freesans;font-size:7pt;color:#a8b3c2;border-top:1px solid #eef2f7;padding-top:1.5mm;"><tr>'
+						. '<td>' . esc_html(get_bloginfo('name')) . '</td>'
+						. '<td style="text-align:right;">' . esc_html__('Page', 'bus-ticket-booking-with-seat-reservation') . ' {PAGENO} / {nbpg}</td>'
+						. '</tr></table>'
+					);
 					$mpdf->WriteHTML($html);
 					$mpdf->Output('bookings-' . gmdate('Y-m-d') . '.pdf', 'D');
 				} catch (\Throwable $e) {
 					error_log('WBTM Booking List PDF export failed — ' . $e->getMessage());
 					wp_die(esc_html__('Could not generate the PDF. Please try again.', 'bus-ticket-booking-with-seat-reservation'));
 				}
+				exit;
+			}
+
+			/**
+			 * Pro-only: print one thermal (POS) receipt ticket per matching booking as a
+			 * single roll. The receipt layout itself is the Pro add-on's, so this resolves
+			 * the booking set from the shared query builder and hands the id list to the
+			 * Pro generator (which already owns roll width, height estimation and the
+			 * per-ticket template) rather than duplicating any of that here.
+			 *
+			 * Capped at MAX_THERMAL_TICKETS: this is meant for a counter or a departure,
+			 * the ids travel in the redirect URL, and nobody prints thousands of receipts
+			 * by accident. Over the cap we stop and say so instead of silently truncating.
+			 */
+			const MAX_THERMAL_TICKETS = 200;
+
+			public function handle_export_thermal() {
+				if (!current_user_can('manage_options') || !$this->is_pro()) {
+					wp_die(esc_html__('You do not have permission to do that.', 'bus-ticket-booking-with-seat-reservation'));
+				}
+				check_admin_referer('wbtm_bkl_export_thermal');
+				if (!class_exists('WBTM_Pro_Pdf') || !WBTM_Pro_Pdf::is_mpdf_available()) {
+					wp_die(esc_html__('PDF generation is unavailable. Please install the MagePeople PDF Support plugin.', 'bus-ticket-booking-with-seat-reservation'));
+				}
+				if (!class_exists('WBTM_Global_Function') || WBTM_Global_Function::get_settings('wbtm_pdf_settings', 'thermal_ticket_enable', 'yes') !== 'yes') {
+					wp_die(esc_html__('Thermal (POS) tickets are turned off in PDF settings.', 'bus-ticket-booking-with-seat-reservation'));
+				}
+
+				$args = $this->build_query_args(-1, 1);
+				$ids  = get_posts(array_merge($args, array('fields' => 'ids')));
+				if (empty($ids)) {
+					wp_die(esc_html__('No bookings matched, so there is nothing to print.', 'bus-ticket-booking-with-seat-reservation'));
+				}
+				if (count($ids) > self::MAX_THERMAL_TICKETS) {
+					wp_die(esc_html(sprintf(
+						/* translators: 1: number of matching bookings, 2: maximum allowed. */
+						__('That selection is %1$s bookings and thermal printing is capped at %2$s tickets per run. Narrow it down — by bus, departure date, or by ticking rows — and try again.', 'bus-ticket-booking-with-seat-reservation'),
+						number_format_i18n(count($ids)),
+						number_format_i18n(self::MAX_THERMAL_TICKETS)
+					)));
+				}
+
+				// get_pdf_url() ends in wp_nonce_url(), which esc_html()s the result for use
+				// in an href — so its separators arrive as "&amp;". Sent as a Location
+				// header that would become a parameter literally named "amp;attendee_ids"
+				// and the roll would come back blank, so decode back to a real URL first.
+				$pdf_url = wp_specialchars_decode(WBTM_Pro_Pdf::get_pdf_url(array(
+					'attendee_ids' => implode(',', array_map('absint', $ids)),
+					'thermal'      => 1,
+				)), ENT_QUOTES);
+				wp_safe_redirect($pdf_url);
 				exit;
 			}
 
@@ -1019,6 +1210,14 @@
 					return $args;
 				}
 				$f = $this->get_filter_values();
+
+				// Explicit booking ids (the export modal's "Selected bookings" scope).
+				// get_filter_values() collapses an unparseable list to array(0) rather
+				// than array(), because WP_Query ignores an EMPTY post__in and would
+				// silently widen a hand-picked export to every booking.
+				if (!empty($f['ids'])) {
+					$args['post__in'] = $f['ids'];
+				}
 
 				// Per-page override (Pro).
 				if ($per_page > 0 && $f['per_page'] > 0) {
@@ -1134,7 +1333,21 @@
 				if ($per_page < 1 || $per_page > 500) {
 					$per_page = self::PER_PAGE;
 				}
+				// Hand-picked booking ids, used by the export modal's "Selected bookings"
+				// scope. A present-but-unparseable list becomes array(0) — a deliberately
+				// unmatchable post__in — so a malformed request exports nothing rather
+				// than everything (WP_Query ignores an empty post__in).
+				$ids = array();
+				if (isset($_GET['wbtm_bl_ids'])) {
+					$raw_ids  = wp_unslash($_GET['wbtm_bl_ids']);
+					$requested = is_array($raw_ids) ? $raw_ids : array_filter(array_map('trim', explode(',', (string) $raw_ids)), 'strlen');
+					$ids       = array_values(array_filter(array_map('absint', $requested)));
+					if (empty($ids) && !empty($requested)) {
+						$ids = array(0);
+					}
+				}
 				return array(
+					'ids'          => $ids,
 					'search'       => isset($_GET['wbtm_bl_s']) ? sanitize_text_field(wp_unslash($_GET['wbtm_bl_s'])) : '',
 					'status'       => isset($_GET['wbtm_bl_status']) ? sanitize_text_field(wp_unslash($_GET['wbtm_bl_status'])) : '',
 					'bus_id'       => isset($_GET['wbtm_bl_bus']) ? absint($_GET['wbtm_bl_bus']) : 0,
@@ -1175,6 +1388,7 @@
 					'wbtm_bl_booked_from'  => $f['booked_from'],
 					'wbtm_bl_booked_to'    => $f['booked_to'],
 					'wbtm_bl_sort'         => $f['sort'],
+					'wbtm_bl_ids'          => $f['ids'] ? implode(',', $f['ids']) : '',
 				);
 				$args = array();
 				foreach ($map as $key => $value) {
@@ -1343,42 +1557,33 @@
 						</div>
 						<div class="wbtm-bkl-header-actions">
 							<?php if ($is_pro && $is_admin) : ?>
-								<?php
-									// Exports respect the active filters (bus, status, dates, search…) so a
-									// filtered view exports exactly those rows; with no filter set they
-									// export every booking. The filters travel to the handler as query
-									// args, which build_query_args() re-reads there.
-									$filter_args = $this->current_filter_query_args();
-									$export_url = wp_nonce_url(
-										add_query_arg(array_merge(array('action' => 'wbtm_bkl_export_csv'), $filter_args), admin_url('admin-post.php')),
-										'wbtm_bkl_export_csv'
-									);
-									// Full booking-list PDF export (Pro + mPDF). Renders EVERY
-									// booking via our own handler — so it works with or without a
-									// bus selected, exactly like Export CSV but as a PDF (the Pro
-									// per-bus manifest PDF stays available per-row for one ticket).
-									$pdf_available = class_exists('WBTM_Pro_Pdf') && WBTM_Pro_Pdf::is_mpdf_available();
-									$pdf_url = '';
-									if ($pdf_available) {
-										$pdf_url = wp_nonce_url(
-											add_query_arg(array_merge(array('action' => 'wbtm_bkl_export_pdf'), $filter_args), admin_url('admin-post.php')),
-											'wbtm_bkl_export_pdf'
-										);
-									}
-								?>
-								<?php if ($pdf_url) : ?>
-									<a href="<?php echo esc_url($pdf_url); ?>" target="_blank" rel="noopener noreferrer" class="wbtm-bkl-pro-cta wbtm-bkl-pro-cta-alt"><span class="dashicons dashicons-media-document"></span><?php esc_html_e('Export PDF', 'bus-ticket-booking-with-seat-reservation'); ?></a>
-								<?php endif; ?>
-								<a href="<?php echo esc_url($export_url); ?>" class="wbtm-bkl-pro-cta"><span class="dashicons dashicons-download"></span><?php esc_html_e('Export CSV', 'bus-ticket-booking-with-seat-reservation'); ?></a>
+								<button type="button" id="wbtm-bkl-export-open" class="wbtm-bkl-pro-cta">
+									<span class="dashicons dashicons-download"></span><?php esc_html_e('Export', 'bus-ticket-booking-with-seat-reservation'); ?>
+								</button>
 							<?php elseif (!$is_pro && $is_admin) : ?>
 								<a href="https://mage-people.com/product/addon-bus-ticket-booking-with-seat-reservation-pro/" target="_blank" rel="noopener noreferrer" class="wbtm-bkl-pro-cta"><span class="dashicons dashicons-star-filled"></span><?php esc_html_e('Upgrade to PRO', 'bus-ticket-booking-with-seat-reservation'); ?></a>
 							<?php endif; ?>
 						</div>
 					</div>
 
-					<?php $this->render_stats($is_pro); ?>
-
-					<?php $this->render_filters($is_pro); ?>
+					<?php
+						// Free installs blur the stats and the filter bar together behind ONE
+						// PRO badge. They used to carry a lock overlay each, which stacked two
+						// identical badges down the screen; the sections themselves still
+						// render (blurred, inert) so the shape of the feature is visible.
+						if (!$is_pro) : ?>
+						<div class="wbtm-bkl-locked wbtm-bkl-locked-group is-locked">
+							<?php $this->render_stats($is_pro, false); ?>
+							<?php $this->render_filters($is_pro, false); ?>
+							<div class="wbtm-bkl-lock-overlay">
+								<?php echo wp_kses_post($this->pro_badge_html()); ?>
+								<p><?php esc_html_e('Booking analytics, search, filtering and the CSV / PDF / thermal exports are all PRO features.', 'bus-ticket-booking-with-seat-reservation'); ?></p>
+							</div>
+						</div>
+					<?php else : ?>
+						<?php $this->render_stats($is_pro); ?>
+						<?php $this->render_filters($is_pro); ?>
+					<?php endif; ?>
 
 					<div class="wbtm-bkl-table-wrap">
 						<div class="wbtm-bkl-table-toolbar">
@@ -1482,11 +1687,198 @@
 
 					<?php $this->render_delete_modal(); ?>
 					<?php $this->render_status_modal(); ?>
+					<?php if ($is_pro && $is_admin) { $this->render_export_modal(); } ?>
 				</div>
 				<?php
 			}
 
-			private function render_stats($is_pro) {
+			/**
+			 * The single "Export" dialog behind the header button: pick a format, pick
+			 * what to export, optionally narrow it further. The JS turns those choices
+			 * into the same wbtm_bl_* query args the on-screen filter bar uses, so every
+			 * scope runs through build_query_args() — one query builder for the screen
+			 * and all three exports, rather than per-scope query code.
+			 */
+			private function render_export_modal() {
+				$pdf_available = class_exists('WBTM_Pro_Pdf') && WBTM_Pro_Pdf::is_mpdf_available();
+				$thermal_available = $pdf_available
+					&& class_exists('WBTM_Global_Function')
+					&& WBTM_Global_Function::get_settings('wbtm_pdf_settings', 'thermal_ticket_enable', 'yes') === 'yes';
+				$buses    = get_posts(array('post_type' => 'wbtm_bus', 'posts_per_page' => -1, 'orderby' => 'title', 'order' => 'ASC'));
+				$statuses = $this->get_status_options();
+				$today    = current_time('Y-m-d');
+				$formats  = array(
+					'csv' => array(
+						'icon'      => 'dashicons-media-spreadsheet',
+						'label'     => __('CSV', 'bus-ticket-booking-with-seat-reservation'),
+						'desc'      => __('Spreadsheet — every column, including passenger form fields.', 'bus-ticket-booking-with-seat-reservation'),
+						'available' => true,
+						'why'       => '',
+					),
+					'pdf' => array(
+						'icon'      => 'dashicons-media-document',
+						'label'     => __('PDF', 'bus-ticket-booking-with-seat-reservation'),
+						'desc'      => __('Printable landscape manifest with totals.', 'bus-ticket-booking-with-seat-reservation'),
+						'available' => $pdf_available,
+						'why'       => __('Needs the MagePeople PDF Support plugin.', 'bus-ticket-booking-with-seat-reservation'),
+					),
+					'thermal' => array(
+						'icon'      => 'dashicons-printer',
+						'label'     => __('Thermal tickets', 'bus-ticket-booking-with-seat-reservation'),
+						'desc'      => __('One POS receipt ticket per booking, on a 58/80mm roll.', 'bus-ticket-booking-with-seat-reservation'),
+						'available' => $thermal_available,
+						'why'       => $pdf_available
+							? __('Turn on Thermal (POS) Ticket in PDF settings.', 'bus-ticket-booking-with-seat-reservation')
+							: __('Needs the MagePeople PDF Support plugin.', 'bus-ticket-booking-with-seat-reservation'),
+					),
+				);
+				// Scope rows. 'view' mirrors today's behaviour (export exactly what the
+				// filter bar selected) and stays the default so the button keeps doing
+				// the least surprising thing.
+				$scopes = array(
+					'view' => array(
+						'icon'  => 'dashicons-visibility',
+						'label' => __('Current view', 'bus-ticket-booking-with-seat-reservation'),
+						'desc'  => __('Everything the filter bar is showing right now.', 'bus-ticket-booking-with-seat-reservation'),
+					),
+					'selected' => array(
+						'icon'  => 'dashicons-yes',
+						'label' => __('Selected bookings', 'bus-ticket-booking-with-seat-reservation'),
+						'desc'  => __('Only the rows you ticked in the list.', 'bus-ticket-booking-with-seat-reservation'),
+					),
+					'today' => array(
+						'icon'  => 'dashicons-calendar-alt',
+						'label' => __("Today's bookings", 'bus-ticket-booking-with-seat-reservation'),
+						'desc'  => __('Booked today — the day-end sales sheet.', 'bus-ticket-booking-with-seat-reservation'),
+					),
+					'departing_today' => array(
+						// dashicons has no bus glyph — dashicons-car is the closest that exists.
+						'icon'  => 'dashicons-car',
+						'label' => __('Departing today', 'bus-ticket-booking-with-seat-reservation'),
+						'desc'  => __("Travelling today — the driver's manifest.", 'bus-ticket-booking-with-seat-reservation'),
+					),
+					'range' => array(
+						'icon'  => 'dashicons-calendar',
+						'label' => __('Date range', 'bus-ticket-booking-with-seat-reservation'),
+						'desc'  => __('Pick the dates and whether they mean travel or booking.', 'bus-ticket-booking-with-seat-reservation'),
+					),
+					'all' => array(
+						'icon'  => 'dashicons-database',
+						'label' => __('All bookings', 'bus-ticket-booking-with-seat-reservation'),
+						'desc'  => __('The whole book, ignoring the filter bar.', 'bus-ticket-booking-with-seat-reservation'),
+					),
+				);
+				?>
+				<div id="wbtm-bkl-export-modal" class="wbtm-bkl-modal wbtm-bkl-modal-export" style="display:none;" data-today="<?php echo esc_attr($today); ?>">
+					<div class="wbtm-bkl-modal-card">
+						<div class="wbtm-bkl-modal-head">
+							<h2><span class="dashicons dashicons-download"></span><?php esc_html_e('Export Bookings', 'bus-ticket-booking-with-seat-reservation'); ?></h2>
+							<span class="wbtm-bkl-modal-close dashicons dashicons-no-alt" role="button" aria-label="<?php esc_attr_e('Close', 'bus-ticket-booking-with-seat-reservation'); ?>"></span>
+						</div>
+						<div class="wbtm-bkl-modal-body">
+
+							<div class="wbtm-bkl-export-section">
+								<h3 class="wbtm-bkl-export-legend"><?php esc_html_e('Format', 'bus-ticket-booking-with-seat-reservation'); ?></h3>
+								<div class="wbtm-bkl-export-formats">
+									<?php $first = true; foreach ($formats as $key => $fmt) : ?>
+										<label class="wbtm-bkl-export-format<?php echo $fmt['available'] ? '' : ' is-disabled'; ?>"
+											title="<?php echo esc_attr($fmt['available'] ? $fmt['desc'] : $fmt['why']); ?>">
+											<input type="radio" name="wbtm_bkl_export_format" value="<?php echo esc_attr($key); ?>"
+												<?php checked($first && $fmt['available']); ?> <?php disabled(!$fmt['available']); ?>>
+											<span class="dashicons <?php echo esc_attr($fmt['icon']); ?>"></span>
+											<span class="wbtm-bkl-export-format-text">
+												<strong><?php echo esc_html($fmt['label']); ?></strong>
+												<small><?php echo esc_html($fmt['available'] ? $fmt['desc'] : $fmt['why']); ?></small>
+											</span>
+										</label>
+									<?php $first = false; endforeach; ?>
+								</div>
+							</div>
+
+							<div class="wbtm-bkl-export-section">
+								<h3 class="wbtm-bkl-export-legend"><?php esc_html_e('What to export', 'bus-ticket-booking-with-seat-reservation'); ?></h3>
+								<div class="wbtm-bkl-export-scopes">
+									<?php foreach ($scopes as $key => $scope) : ?>
+										<label class="wbtm-bkl-export-scope" data-scope="<?php echo esc_attr($key); ?>">
+											<input type="radio" name="wbtm_bkl_export_scope" value="<?php echo esc_attr($key); ?>" <?php checked($key, 'view'); ?>>
+											<span class="dashicons <?php echo esc_attr($scope['icon']); ?>"></span>
+											<span class="wbtm-bkl-export-scope-text">
+												<strong>
+													<?php echo esc_html($scope['label']); ?>
+													<?php if ($key === 'selected') : ?>
+														<span class="wbtm-bkl-export-count" id="wbtm-bkl-export-selected-count">(0)</span>
+													<?php endif; ?>
+												</strong>
+												<small><?php echo esc_html($scope['desc']); ?></small>
+											</span>
+										</label>
+									<?php endforeach; ?>
+								</div>
+
+								<div class="wbtm-bkl-export-range" id="wbtm-bkl-export-range" hidden>
+									<div class="wbtm-bkl-export-field">
+										<label for="wbtm-bkl-export-basis"><?php esc_html_e('Dates refer to', 'bus-ticket-booking-with-seat-reservation'); ?></label>
+										<select id="wbtm-bkl-export-basis">
+											<option value="journey"><?php esc_html_e('Journey date (travel)', 'bus-ticket-booking-with-seat-reservation'); ?></option>
+											<option value="booked"><?php esc_html_e('Booked date (sale)', 'bus-ticket-booking-with-seat-reservation'); ?></option>
+										</select>
+									</div>
+									<div class="wbtm-bkl-export-field">
+										<label for="wbtm-bkl-export-from"><?php esc_html_e('From', 'bus-ticket-booking-with-seat-reservation'); ?></label>
+										<input type="date" id="wbtm-bkl-export-from" value="<?php echo esc_attr($today); ?>">
+									</div>
+									<div class="wbtm-bkl-export-field">
+										<label for="wbtm-bkl-export-to"><?php esc_html_e('To', 'bus-ticket-booking-with-seat-reservation'); ?></label>
+										<input type="date" id="wbtm-bkl-export-to" value="<?php echo esc_attr($today); ?>">
+									</div>
+								</div>
+							</div>
+
+							<div class="wbtm-bkl-export-section" id="wbtm-bkl-export-refine">
+								<h3 class="wbtm-bkl-export-legend"><?php esc_html_e('Narrow it down', 'bus-ticket-booking-with-seat-reservation'); ?> <small><?php esc_html_e('optional', 'bus-ticket-booking-with-seat-reservation'); ?></small></h3>
+								<div class="wbtm-bkl-export-refine-row">
+									<div class="wbtm-bkl-export-field">
+										<label for="wbtm-bkl-export-bus"><?php esc_html_e('Bus', 'bus-ticket-booking-with-seat-reservation'); ?></label>
+										<select id="wbtm-bkl-export-bus">
+											<option value=""><?php esc_html_e('All buses', 'bus-ticket-booking-with-seat-reservation'); ?></option>
+											<?php foreach ($buses as $bus) : ?>
+												<option value="<?php echo esc_attr($bus->ID); ?>"><?php echo esc_html(get_the_title($bus)); ?></option>
+											<?php endforeach; ?>
+										</select>
+									</div>
+									<div class="wbtm-bkl-export-field">
+										<label for="wbtm-bkl-export-status"><?php esc_html_e('Status', 'bus-ticket-booking-with-seat-reservation'); ?></label>
+										<select id="wbtm-bkl-export-status">
+											<option value=""><?php esc_html_e('All statuses', 'bus-ticket-booking-with-seat-reservation'); ?></option>
+											<?php foreach ($statuses as $key => $label) : ?>
+												<option value="<?php echo esc_attr($key); ?>"><?php echo esc_html($label); ?></option>
+											<?php endforeach; ?>
+										</select>
+									</div>
+								</div>
+								<p class="wbtm-bkl-export-note" id="wbtm-bkl-export-refine-note" hidden>
+									<span class="dashicons dashicons-info-outline"></span>
+									<?php esc_html_e('The filter bar and your row selection already decide the rows, so these two are ignored for this scope.', 'bus-ticket-booking-with-seat-reservation'); ?>
+								</p>
+							</div>
+
+							<div class="wbtm-bkl-modal-actions">
+								<button type="button" class="wbtm-bkl-btn wbtm-bkl-btn-outline wbtm-bkl-modal-close"><?php esc_html_e('Cancel', 'bus-ticket-booking-with-seat-reservation'); ?></button>
+								<button type="button" id="wbtm-bkl-export-run" class="wbtm-bkl-btn wbtm-bkl-btn-primary"><span class="dashicons dashicons-download"></span><?php esc_html_e('Export', 'bus-ticket-booking-with-seat-reservation'); ?></button>
+							</div>
+						</div>
+					</div>
+				</div>
+				<?php
+			}
+
+			/**
+			 * @param bool $is_pro   Whether Pro is active (unlocks the real figures).
+			 * @param bool $own_lock Render this section's own PRO overlay. False when the
+			 *                       caller has already wrapped several sections in one
+			 *                       shared lock, so only a single badge is shown.
+			 */
+			private function render_stats($is_pro, $own_lock = true) {
 				$stats = $this->get_stats();
 				$cards = array(
 					array('dashicons-cart', $is_pro ? number_format_i18n($stats['total_bookings']) : '&bull;&bull;&bull;', esc_html__('Total Bookings', 'bus-ticket-booking-with-seat-reservation')),
@@ -1504,7 +1896,7 @@
 					$cards[] = array('dashicons-clock', $is_pro ? WBTM_Global_Function::format_price($stats['total_outstanding']) : '&bull;&bull;&bull;', esc_html__('Outstanding Balance', 'bus-ticket-booking-with-seat-reservation'));
 				}
 				?>
-				<div class="wbtm-bkl-locked<?php echo $is_pro ? '' : ' is-locked'; ?>">
+				<div class="wbtm-bkl-locked<?php echo ($is_pro || !$own_lock) ? '' : ' is-locked'; ?>">
 					<?php
 						// The cards describe the filtered set, so say so when a filter is
 						// active — otherwise a bus-wise total reads like a site-wide one.
@@ -1531,7 +1923,7 @@
 							</div>
 						<?php endforeach; ?>
 					</div>
-					<?php if (!$is_pro) : ?>
+					<?php if (!$is_pro && $own_lock) : ?>
 						<div class="wbtm-bkl-lock-overlay">
 							<?php echo wp_kses_post($this->pro_badge_html()); ?>
 							<p><?php esc_html_e('Booking analytics & revenue insights are a PRO feature.', 'bus-ticket-booking-with-seat-reservation'); ?></p>
@@ -1558,15 +1950,23 @@
 				));
 			}
 
-			private function render_filters($is_pro) {
+			/**
+			 * @param bool $is_pro   Whether Pro is active (unlocks search/filtering).
+			 * @param bool $own_lock Render this section's own PRO overlay — see render_stats().
+			 */
+			private function render_filters($is_pro, $own_lock = true) {
 				$f = $this->get_filter_values();
 				$statuses = $this->get_status_options();
 				$buses    = $is_pro ? get_posts(array('post_type' => 'wbtm_bus', 'posts_per_page' => -1, 'orderby' => 'title', 'order' => 'ASC')) : array();
 				$payments = $is_pro ? $this->get_distinct_meta_values('wbtm_billing_type') : array();
 				$tickets  = $is_pro ? $this->get_distinct_meta_values('wbtm_ticket') : array();
-				// Sort/per-page always have defaults, so they don't count as an "active filter".
+				// The panel starts collapsed and only auto-opens when a filter is actually
+				// narrowing the list, so the reason for a short list is never hidden.
+				// Excluded from that test: sort/per_page always have defaults, and 'ids' is
+				// export-only (the filter bar never sets it) — and being an array it would
+				// have passed the scalar test below even when empty, wedging the panel open.
 				$active_probe = $f;
-				unset($active_probe['sort'], $active_probe['per_page']);
+				unset($active_probe['sort'], $active_probe['per_page'], $active_probe['ids']);
 				$has_active_filter = $is_pro && count(array_filter($active_probe, function ($v) { return $v !== '' && $v !== 0; })) > 0;
 				$sort_options = array(
 					'newest'       => __('Newest first', 'bus-ticket-booking-with-seat-reservation'),
@@ -1584,7 +1984,7 @@
 						<span class="dashicons dashicons-arrow-down-alt2 wbtm-bkl-filters-arrow"></span>
 					</button>
 					<div class="wbtm-bkl-filters-body<?php echo $has_active_filter ? ' is-open' : ''; ?>">
-						<div class="wbtm-bkl-locked wbtm-bkl-locked-filters<?php echo $is_pro ? '' : ' is-locked'; ?>">
+						<div class="wbtm-bkl-locked wbtm-bkl-locked-filters<?php echo ($is_pro || !$own_lock) ? '' : ' is-locked'; ?>">
 							<form method="get" class="wbtm-bkl-filters" <?php echo $is_pro ? '' : 'aria-hidden="true"'; ?>>
 								<input type="hidden" name="post_type" value="wbtm_bus">
 								<input type="hidden" name="page" value="<?php echo esc_attr(self::PAGE_SLUG); ?>">
@@ -1689,10 +2089,10 @@
 									<?php endif; ?>
 								</div>
 							</form>
-							<?php if (!$is_pro) : ?>
+							<?php if (!$is_pro && $own_lock) : ?>
 								<div class="wbtm-bkl-lock-overlay">
 									<?php echo wp_kses_post($this->pro_badge_html()); ?>
-									<p><?php esc_html_e('Search, filtering & CSV export are available in PRO.', 'bus-ticket-booking-with-seat-reservation'); ?></p>
+									<p><?php esc_html_e('Search, filtering & the exports are available in PRO.', 'bus-ticket-booking-with-seat-reservation'); ?></p>
 								</div>
 							<?php endif; ?>
 						</div>

--- a/assets/admin/css/wbtm-booking-list.css
+++ b/assets/admin/css/wbtm-booking-list.css
@@ -11,10 +11,13 @@
 .wbtm-bkl-title { display: flex; align-items: center; gap: 8px; font-size: 22px; font-weight: 700; margin: 0; color: #0f172a; }
 .wbtm-bkl-title .dashicons { font-size: 22px; width: 22px; height: 22px; color: #e63946; }
 .wbtm-bkl-subtitle { margin: 4px 0 0; color: #64748b; font-size: 13px; }
+/* Used by both the "Upgrade to PRO" link and the Export <button>, hence the
+   explicit border/cursor reset — a bare <button> would otherwise draw a UA border. */
 .wbtm-bkl-pro-cta {
   display: inline-flex; align-items: center; gap: 6px; text-decoration: none;
   background: linear-gradient(135deg, #e63946, #b3212f); color: #fff;
   padding: 8px 16px; border-radius: 8px; font-weight: 600; font-size: 13px;
+  border: 0; cursor: pointer;
 }
 .wbtm-bkl-pro-cta:hover { color: #fff; filter: brightness(1.05); }
 .wbtm-bkl-pro-cta .dashicons { font-size: 16px; width: 16px; height: 16px; }
@@ -23,6 +26,11 @@
 .wbtm-bkl-locked { position: relative; margin-bottom: 16px; border-radius: 12px; overflow: hidden; }
 .wbtm-bkl-locked.is-locked > .wbtm-bkl-stats,
 .wbtm-bkl-locked.is-locked > .wbtm-bkl-filters { filter: blur(5px); opacity: .55; pointer-events: none; user-select: none; }
+/* Free tier: the stats and the filter bar share ONE lock, so there is a single
+   PRO badge for the whole region instead of one badge per section. The blur is
+   applied to the group's children here rather than by the sections themselves. */
+.wbtm-bkl-locked-group.is-locked > * { filter: blur(5px); opacity: .55; pointer-events: none; user-select: none; }
+.wbtm-bkl-locked-group.is-locked > .wbtm-bkl-lock-overlay { filter: none; opacity: 1; }
 .wbtm-bkl-lock-overlay {
   position: absolute; inset: 0; display: flex; flex-direction: column;
   align-items: center; justify-content: center; gap: 8px; text-align: center;
@@ -420,6 +428,57 @@
   .wbtm-bkl-detail-grid { grid-template-columns: 1fr; }
 }
 
+/* Export dialog — one button, a format picker and a scope picker. Wider than the
+   confirm-style modals and scrollable, since it carries three groups of controls. */
+.wbtm-bkl-modal-export .wbtm-bkl-modal-card { max-width: 620px; max-height: calc(100vh - 40px); display: flex; flex-direction: column; }
+.wbtm-bkl-modal-export .wbtm-bkl-modal-head h2 .dashicons { color: #e63946; }
+.wbtm-bkl-modal-export .wbtm-bkl-modal-body { overflow-y: auto; }
+/* The JS shows/hides the date-range block and the refine note with the [hidden]
+   attribute. Their own display rules below would otherwise beat the UA
+   [hidden]{display:none} and leave both permanently visible, so restate it at
+   class+attribute specificity. */
+.wbtm-bkl-modal-export [hidden] { display: none; }
+.wbtm-bkl-export-section { margin-bottom: 18px; }
+.wbtm-bkl-export-section:last-of-type { margin-bottom: 0; }
+.wbtm-bkl-export-legend { font-size: 11px; font-weight: 700; text-transform: uppercase; letter-spacing: .05em; color: #64748b; margin: 0 0 8px; }
+.wbtm-bkl-export-legend small { text-transform: none; letter-spacing: 0; font-weight: 500; color: #94a3b8; }
+
+.wbtm-bkl-export-formats { display: grid; grid-template-columns: repeat(auto-fit, minmax(170px, 1fr)); gap: 8px; }
+.wbtm-bkl-export-format { position: relative; display: flex; align-items: flex-start; gap: 8px; padding: 10px 12px; border: 1px solid #e2e8f0; border-radius: 10px; cursor: pointer; }
+.wbtm-bkl-export-format:hover { border-color: #cbd5e1; background: #f8fafc; }
+.wbtm-bkl-export-format input[type="radio"] { position: absolute; opacity: 0; }
+.wbtm-bkl-export-format > .dashicons { color: #94a3b8; flex: 0 0 auto; }
+.wbtm-bkl-export-format-text { display: flex; flex-direction: column; gap: 2px; min-width: 0; }
+.wbtm-bkl-export-format-text strong { font-size: 13px; color: #1e293b; }
+.wbtm-bkl-export-format-text small { font-size: 11px; line-height: 1.4; color: #94a3b8; }
+.wbtm-bkl-export-format:has(input:checked) { border-color: #e63946; background: #fdedef; }
+.wbtm-bkl-export-format:has(input:checked) > .dashicons { color: #e63946; }
+.wbtm-bkl-export-format.is-disabled { opacity: .55; cursor: not-allowed; background: #f8fafc; }
+
+.wbtm-bkl-export-scopes { display: flex; flex-direction: column; gap: 6px; }
+.wbtm-bkl-export-scope { position: relative; display: flex; align-items: flex-start; gap: 10px; padding: 9px 12px; border: 1px solid #e2e8f0; border-radius: 8px; cursor: pointer; }
+.wbtm-bkl-export-scope:hover { border-color: #cbd5e1; background: #f8fafc; }
+.wbtm-bkl-export-scope input[type="radio"] { position: absolute; opacity: 0; }
+.wbtm-bkl-export-scope > .dashicons { color: #94a3b8; flex: 0 0 auto; }
+.wbtm-bkl-export-scope:has(input:checked) { border-color: #e63946; background: #fdedef; }
+.wbtm-bkl-export-scope:has(input:checked) > .dashicons { color: #e63946; }
+.wbtm-bkl-export-scope-text { display: flex; flex-direction: column; gap: 1px; min-width: 0; }
+.wbtm-bkl-export-scope-text strong { font-size: 13px; color: #1e293b; }
+.wbtm-bkl-export-scope-text small { font-size: 11px; line-height: 1.4; color: #94a3b8; }
+.wbtm-bkl-export-count { color: #e63946; font-weight: 700; }
+
+.wbtm-bkl-export-range,
+.wbtm-bkl-export-refine-row { display: grid; grid-template-columns: repeat(auto-fit, minmax(150px, 1fr)); gap: 10px; }
+.wbtm-bkl-export-range { margin-top: 10px; padding: 12px; border: 1px dashed #cbd5e1; border-radius: 8px; background: #f8fafc; }
+.wbtm-bkl-export-field { display: flex; flex-direction: column; gap: 4px; min-width: 0; }
+.wbtm-bkl-export-field label { font-size: 11px; font-weight: 600; color: #64748b; }
+.wbtm-bkl-export-field select,
+.wbtm-bkl-export-field input[type="date"] { width: 100%; max-width: 100%; border: 1px solid #cbd5e1; border-radius: 6px; padding: 5px 8px; font-size: 13px; background: #fff; }
+.wbtm-bkl-export-field select:disabled,
+.wbtm-bkl-export-field input:disabled { background: #f1f5f9; color: #94a3b8; }
+.wbtm-bkl-export-note { display: flex; align-items: flex-start; gap: 6px; margin: 8px 0 0; font-size: 11px; line-height: 1.5; color: #64748b; }
+.wbtm-bkl-export-note .dashicons { font-size: 14px; width: 14px; height: 14px; flex: 0 0 auto; color: #94a3b8; }
+
 /* Small phones */
 @media (max-width: 600px) {
   .wbtm-bkl-title { font-size: 18px; }
@@ -428,4 +487,7 @@
   .wbtm-bkl-modal { padding: 12px; }
   .wbtm-bkl-modal-card { max-width: 100%; }
   .wbtm-bkl-columns-panel { width: calc(100vw - 24px); }
+  .wbtm-bkl-export-formats { grid-template-columns: 1fr; }
+  .wbtm-bkl-export-range,
+  .wbtm-bkl-export-refine-row { grid-template-columns: 1fr; }
 }

--- a/assets/admin/js/wbtm-booking-list.js
+++ b/assets/admin/js/wbtm-booking-list.js
@@ -504,5 +504,127 @@
 			}
 			qrUpdate(ids, type);
 		});
+
+		/* ---------------------------------------------------------------------
+		   Export dialog. One button, three formats, several scopes. Every scope is
+		   expressed as the same wbtm_bl_* query args the filter bar submits, so the
+		   server runs all of them through one query builder — there is no
+		   scope-specific query code on either side.
+		--------------------------------------------------------------------- */
+		var $exportModal = $('#wbtm-bkl-export-modal');
+
+		function exportScope() {
+			return $exportModal.find('input[name="wbtm_bkl_export_scope"]:checked').val() || 'view';
+		}
+
+		/* Row selection and the filter bar each fully determine the rows, so the
+		   bus/status refiners would be misleading there — disable and explain. */
+		function syncExportUi() {
+			var scope = exportScope();
+			var selfContained = (scope === 'view' || scope === 'selected');
+			$('#wbtm-bkl-export-range').prop('hidden', scope !== 'range');
+			$('#wbtm-bkl-export-bus, #wbtm-bkl-export-status').prop('disabled', selfContained);
+			$('#wbtm-bkl-export-refine-note').prop('hidden', !selfContained);
+			$('#wbtm-bkl-export-selected-count').text('(' + getCheckedIds().length + ')');
+		}
+
+		$(document).on('click', '#wbtm-bkl-export-open', function (e) {
+			e.preventDefault();
+			// Default to the selection when the user has actually ticked rows — that is
+			// almost always what they meant by pressing Export at that point.
+			if (getCheckedIds().length) {
+				$exportModal.find('input[name="wbtm_bkl_export_scope"][value="selected"]').prop('checked', true);
+			}
+			syncExportUi();
+			$exportModal.show();
+		});
+
+		$exportModal.on('change', 'input[name="wbtm_bkl_export_scope"]', syncExportUi);
+		$exportModal.on('click', '.wbtm-bkl-modal-close', function () {
+			$exportModal.hide();
+		});
+		$exportModal.on('click', function (e) {
+			if (e.target === this) {
+				$exportModal.hide();
+			}
+		});
+		$(document).on('keydown', function (e) {
+			if (e.key === 'Escape') {
+				$exportModal.hide();
+			}
+		});
+
+		$exportModal.on('click', '#wbtm-bkl-export-run', function () {
+			var format = $exportModal.find('input[name="wbtm_bkl_export_format"]:checked').val();
+			if (!format) {
+				toast(i18n.exportNoFormat || 'Please choose an export format.');
+				return;
+			}
+
+			var scope = exportScope();
+			var args = {};
+
+			if (scope === 'view') {
+				args = $.extend({}, vars.currentFilters || {});
+			} else if (scope === 'selected') {
+				var ids = getCheckedIds();
+				if (!ids.length) {
+					toast(i18n.exportNoRows || 'Please select at least one booking.');
+					return;
+				}
+				if (format === 'thermal' && vars.maxThermal && ids.length > vars.maxThermal) {
+					toast((i18n.exportTooManyThermal || 'Thermal printing is capped at %d tickets per run.').replace('%d', vars.maxThermal), 'error');
+					return;
+				}
+				args.wbtm_bl_ids = ids.join(',');
+			} else if (scope === 'today') {
+				args.wbtm_bl_booked_from = args.wbtm_bl_booked_to = vars.today;
+			} else if (scope === 'departing_today') {
+				args.wbtm_bl_journey_from = args.wbtm_bl_journey_to = vars.today;
+			} else if (scope === 'range') {
+				var from = $('#wbtm-bkl-export-from').val();
+				var to   = $('#wbtm-bkl-export-to').val();
+				if (!from || !to) {
+					toast(i18n.exportBadRange || 'Please pick both a From and a To date.');
+					return;
+				}
+				if (from > to) { // ISO yyyy-mm-dd compares correctly as a string
+					toast(i18n.exportRangeOrder || 'The From date cannot be after the To date.');
+					return;
+				}
+				if ($('#wbtm-bkl-export-basis').val() === 'booked') {
+					args.wbtm_bl_booked_from = from;
+					args.wbtm_bl_booked_to   = to;
+				} else {
+					args.wbtm_bl_journey_from = from;
+					args.wbtm_bl_journey_to   = to;
+				}
+			}
+			// scope 'all' deliberately sends no row args at all.
+
+			if (scope !== 'view' && scope !== 'selected') {
+				var bus = $('#wbtm-bkl-export-bus').val();
+				var status = $('#wbtm-bkl-export-status').val();
+				if (bus) { args.wbtm_bl_bus = bus; }
+				if (status) { args.wbtm_bl_status = status; }
+			}
+
+			args.action   = 'wbtm_bkl_export_' + format;
+			args._wpnonce = (vars.exportNonces || {})[format] || '';
+
+			$exportModal.hide();
+			toast(i18n.exportStarted || 'Preparing your export…');
+			// A plain navigation, not AJAX: the response is a file download (or, for
+			// thermal, a redirect into the Pro PDF generator), and the browser has to
+			// own that. The page itself stays where it is.
+			window.location.href = vars.exportBase + '?' + $.param(args);
+		});
+
+		// Keep the "Selected bookings (N)" counter honest while the dialog is open.
+		$(document).on('change', '.wbtm-bkl-row-check, #wbtm-bkl-select-all', function () {
+			if ($exportModal.is(':visible')) {
+				syncExportUi();
+			}
+		});
 	});
 })(jQuery);

--- a/readme.txt
+++ b/readme.txt
@@ -461,3 +461,18 @@ Seat number rotation stopped
 * Answers collected before a field was renamed or removed from the form still appear in exports, so nothing already gathered is ever lost
 * In the PDF, passenger details print as a compact line beneath each booking, so the table stays readable no matter how many custom fields your form has
 * The booking detail screen now labels each passenger field with your form label instead of its internal field name
+
+**One Export Button, With Rules (New)**
+* The separate "Export CSV" and "Export PDF" buttons are now a single **Export** button that opens a dialog — pick the format and exactly what to export, in one place
+* Three formats: CSV spreadsheet, printable PDF manifest, and Thermal (POS) tickets — one receipt per booking on a 58/80mm roll, so a whole departure can be printed in one run
+* Six ways to choose the rows: the current filtered view, only the bookings you ticked, today's bookings (day-end sales sheet), today's departures (driver's manifest), a date range, or every booking
+* A date range can mean travel dates or booking dates — pick which, so "everything sold last week" and "everyone travelling next week" are both one click
+* Any scope can be narrowed further by bus and by status, giving bus-wise, route-wise and status-wise exports without touching the filter bar
+* Formats that are unavailable on your site (no PDF library, or Thermal tickets switched off) are shown greyed out with the reason, instead of failing after you click
+* Thermal printing is capped at 200 tickets per run and tells you when a selection is too large, so a mis-click can never spool thousands of receipts
+
+**PDF Export Redesign**
+* The PDF manifest has been redesigned: a clean light layout with a summary strip (bookings, revenue, net of tax, buses), fixed column widths, clearer passenger detail lines and page numbering on every page
+* Fixed the currency symbol printing as an empty box for several currencies — most visibly the Bangladeshi Taka (৳) — in both the PDF manifest and the Thermal (POS) ticket
+* Fixed Thermal (POS) tickets printing a long blank stretch of paper after each receipt; every ticket is now sized to its own content, and a multi-ticket run prints one receipt per page
+* Fixed a passenger field appearing twice in exports when the same question existed under two field ids (after a form field was renamed)

--- a/readme.txt
+++ b/readme.txt
@@ -452,3 +452,12 @@ Seat number rotation stopped
 * Fixed the Upper Deck and Lower Deck of the same cabin sharing a single seat price override — each deck now keeps its own per-seat prices, so an upper-deck seat can be priced independently of the lower-deck seat with the same number
 * Seat prices you have already saved are preserved and continue to apply to the Lower Deck exactly as before; only the Upper Deck needs its prices entered
 * The Booking Calendar no longer shows the internal seat reference (such as "cabin_0_dd_A1") — it now displays the seat number with the deck shown as a small "Upper Deck" tag, and the cabin name on its own line
+
+**Passenger Form Fields in Booking List Exports (Fix)**
+* Custom fields you add to the Passenger Form — for example "Emergency Contact Name" and "Emergency Contact Phone" — are now included automatically in both the Booking List CSV and PDF exports, with no setup needed
+* Restores the custom-field export that was available in the Passenger List before it was merged into the Booking List, so passenger manifests are complete again
+* Fields use the exact labels and order you configured on the bus, and the built-in passenger fields (name, email, phone, address, gender) are exported alongside your own
+* Filtering the Booking List by a bus exports just that bus's form fields instead of every field used across the site
+* Answers collected before a field was renamed or removed from the form still appear in exports, so nothing already gathered is ever lost
+* In the PDF, passenger details print as a compact line beneath each booking, so the table stays readable no matter how many custom fields your form has
+* The booking detail screen now labels each passenger field with your form label instead of its internal field name


### PR DESCRIPTION
Client report: custom passenger fields created under the Passenger Form (e.g. Emergency Contact Name / Phone) are collected at checkout but missing from the Booking List exports — they were present in the PRO Passenger Export up to PRO 5.3.3. The client needs emergency contacts on their printed manifest for Nigerian road-safety rules.

Root cause: folding the PRO Passenger List into this plugin's Booking List orphaned PRO's `WBTM_CSV` (it still builds custom-field columns from the attendee form, but nothing links to `wp_ajax_wbtm_download_csv` any more), and both replacement exports carried a hardcoded column list. The data was never lost — it is on each booking in `wbtm_attendee_info`, and the detail screen already showed it — only the exports dropped it.

- `passenger_field_columns()`: `field_id => label` for every active field on the booking form of the buses in the exported set (built-in `wbtm_attendee_info` + custom `wbtm_custom_attendee_info`), in configured order with configured labels. A second pass over the bookings themselves picks up any field since removed or renamed in the form, so previously-collected answers can never silently drop out. Only buses present in the export are inspected, so a filtered export gets exactly that bus's fields.
- `passenger_field_answers()` / `passenger_field_answer()`: fill each row, matching by field id and falling back to the label for legacy bookings (stored as a numeric list of `{name,value}` rather than a `field_id` map). Unanswered fields export blank so every row keeps the header's column count.
- CSV: the fields become trailing columns — existing column positions are untouched.
- PDF: driven by the same helpers as the CSV so the two cannot drift. Rendered as a tinted full-width strip under each booking rather than one column per field: a booking form can carry any number of fields and extra columns would collapse the already 13-column A4-landscape table. Bookings with nothing filled in get no strip.
- Booking detail view: passenger fields are now labelled with the form label they were collected under, instead of the humanised field id ("Wbtm Full Name").

### Verification

Against the real booking on the dev install, via the actual export handlers:

```
#151  WooCommerce  Shuvo Bhai  Eco Move  Paris -> Berlin  2026-07-31 09:00  A3  20.00 ... Processing  Outbound
ID 152             +8801728182955                                          Adult
Passenger Name: Nahid Reza - Passenger Email: shahnurlfe@gmail.com - passport number: 436346546546
```

Stress-tested on throwaway bookings with 8 long custom fields (Emergency Contact Name/Phone/Relationship, National ID, Next of Kin Address, Blood Group, Medical Notes, Insurance Policy): the PDF strip wraps to a second line and every column keeps its width — no layout break. The same run confirmed CSV/PDF parity (38 CSV columns, 11 passenger columns, all rows cell-aligned), that a deactivated field is excluded, that a field deleted from the form still exports its old answers, that legacy numeric-shape bookings match by label, and that a booking with no passenger data yields neither a strip nor a ragged CSV row.

### Notes / follow-ups (not in this PR)

- The PRO per-bus manifest PDF (`template/pdf/passenger_list_pdf.php`) does render custom fields, but has no UI entry point left — it is only reachable by passing `wbtm_bus_id` to `WBTM_Pro_Pdf::get_pdf_url()`. Worth re-exposing.
- CSV formula injection: passenger-form values are customer-supplied, and a value starting with `=`/`+`/`-`/`@` executes when opened in Excel. This already applies to existing columns (billing name, address), so it is untouched here rather than half-fixed.
