### PR TITLE
Fix rich-text settings silently discarding their content on save

### DIFF
--- a/admin/WBTM_Global_settings.php
+++ b/admin/WBTM_Global_settings.php
@@ -43,11 +43,16 @@ if ( ! defined( 'ABSPATH' ) ) { die; }
 					[],
 					file_exists( $wbtm_gs_css ) ? filemtime( $wbtm_gs_css ) : WBTM_VERSION
 				);
+				// Versioned by filemtime() like the stylesheet above, NOT by the static
+				// WBTM_VERSION: that constant only changes on release, so every edit to
+				// this file kept being served from the browser cache — a fix to the save
+				// handler simply never reached the admin until they cleared it by hand.
+				$wbtm_gs_js = WBTM_PLUGIN_DIR . '/assets/admin/js/wbtm-global-settings.js';
 				wp_enqueue_script(
 					'wbtm-global-settings-js',
 					WBTM_PLUGIN_URL . '/assets/admin/js/wbtm-global-settings.js',
 					['jquery'],
-					WBTM_VERSION,
+					file_exists( $wbtm_gs_js ) ? filemtime( $wbtm_gs_js ) : WBTM_VERSION,
 					true
 				);
 				wp_enqueue_style('wp-color-picker');

--- a/assets/admin/js/wbtm-global-settings.js
+++ b/assets/admin/js/wbtm-global-settings.js
@@ -100,6 +100,18 @@
 			var $forms = $('.bm-gs__tab-panel.bm-gs--active').find('form');
 			if (!$forms.length) { return; }
 
+			// Flush any TinyMCE (wysiwyg) field back into its <textarea> first.
+			// TinyMCE holds the edited content in an iframe and only writes it to the
+			// textarea when the form fires its native submit event — and NEITHER path
+			// below fires one: HTMLFormElement.prototype.submit() bypasses handlers by
+			// design, and FormData reads the DOM as it stands. Without this, a wysiwyg
+			// setting (Terms & Condition Text) posted its pre-edit value, so editing it
+			// in the Visual tab looked like saving did nothing. Editing in the Text tab
+			// happened to work, because that writes straight to the textarea.
+			if (window.tinymce && typeof window.tinymce.triggerSave === 'function') {
+				window.tinymce.triggerSave();
+			}
+
 			// Single-section tab: plain browser POST, no JS in the save path.
 			if ($forms.length === 1) {
 				HTMLFormElement.prototype.submit.call($forms[0]);

--- a/readme.txt
+++ b/readme.txt
@@ -452,3 +452,6 @@ Seat number rotation stopped
 * Fixed the Upper Deck and Lower Deck of the same cabin sharing a single seat price override — each deck now keeps its own per-seat prices, so an upper-deck seat can be priced independently of the lower-deck seat with the same number
 * Seat prices you have already saved are preserved and continue to apply to the Lower Deck exactly as before; only the Upper Deck needs its prices entered
 * The Booking Calendar no longer shows the internal seat reference (such as "cabin_0_dd_A1") — it now displays the seat number with the deck shown as a small "Upper Deck" tag, and the cabin name on its own line
+
+**Settings Fixes**
+* Fixed rich-text settings not saving — most visibly "Terms & Condition Text" under PDF settings. Anything typed in the editor's Visual tab was discarded on save; the Text tab happened to work. Applies to every rich-text setting on the Global Settings screen, including the email content fields


### PR DESCRIPTION
Reported on Global Settings → PDF: **"Terms & Condition Text" does not save.** It affects every rich-text setting on that screen — five of them, including the email content fields — and only when the content is typed in the editor's **Visual** tab. Typing in the **Text** tab worked, which is what made it look intermittent.

### Cause

TinyMCE keeps the edited content in its iframe and only writes it back to the underlying `<textarea>` when the form fires its **native submit event**. Neither save path fires one:

- single-section tab → `HTMLFormElement.prototype.submit.call(form)`, which bypasses handlers by design (it's used here to dodge WP's `id=submit` property-shadowing bug);
- merged tab → `new FormData(form)`, which reads the DOM as it stands.

So the textarea still held its pre-edit value, and that is what reached `options.php`. Nothing was wrong server-side: `sanitize_options()` passes a value through untouched when a field declares no callback.

### Fix

Flush the editors with `tinymce.triggerSave()` before either path runs — the canonical WP fix, guarded so it's a no-op if TinyMCE isn't on the page.

### Verification

The live install's own data made the diagnosis conclusive — in the `wbtm_pdf_settings` group, every field had saved except the one wysiwyg field:

```
[pdf_logo]     => .../dummy-image-3-4.png   saved
[pdf_address]  => Intex Nadira E/2, ...     saved
[pdf_phone]    => 01770001211               saved
[pdf_email]    => shahnuralam1027@...       saved
[pdf_tc_title] => tearm and conditicon      saved   <- plain text input
[pdf_tc_text]  =>                           EMPTY   <- the only wysiwyg field
```

### Note

`readme.txt` gains a "Settings Fixes" block at the end of the 5.9.0 section. #420 and #421 also append there, so expect a trivial end-of-file conflict depending on merge order.